### PR TITLE
Switch from £ to € in the views, the default currency is euro

### DIFF
--- a/app/views/measures/measures/form_parts/_reference_price.html.slim
+++ b/app/views/measures/measures/form_parts/_reference_price.html.slim
@@ -6,7 +6,7 @@ fieldset v-if="showReferencePrice"
     .col-md-4
       .form-group
         label.form-label
-          | Amount (£)
+          | Amount (€)
         input.form-control
     .col-md-4
       .form-group

--- a/app/views/measures/measures/form_parts/_standart_import_value.html.slim
+++ b/app/views/measures/measures/form_parts/_standart_import_value.html.slim
@@ -6,7 +6,7 @@ fieldset v-if="showStandardImportValue"
     .col-md-4
       .form-group
         label.form-label
-          | Amount (£)
+          | Amount (€)
         input.form-control
     .col-md-4
       .form-group

--- a/app/views/measures/measures/form_parts/_unit_price.html.slim
+++ b/app/views/measures/measures/form_parts/_unit_price.html.slim
@@ -6,7 +6,7 @@ fieldset v-if="showUnitPrice"
     .col-md-4
       .form-group
         label.form-label
-          | Amount (£)
+          | Amount (€)
         input.form-control
     .col-md-4
       .form-group

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -12,9 +12,9 @@ script type="text/x-template" id="condition-template"
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showMinimumPrice" do
         .form-group
           label.form-label
-            | Minimum Price (£)
+            | Minimum Price (€)
             span.form-hint
-              | Specify the price (in £) at or above which this condition will apply.
+              | Specify the price (in €) at or above which this condition will apply.
           input.form-control type="text" v-model="condition.amount"
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showRatio" do
@@ -28,9 +28,9 @@ script type="text/x-template" id="condition-template"
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showEntryPrice" do
         .form-group
           label.form-label
-            | Entry Price (£)
+            | Entry Price (€)
             span.form-hint
-              | Specify the price (in £) above which this condition will apply.
+              | Specify the price (in €) above which this condition will apply.
           input.form-control type="text" v-model="condition.amount"
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showAmount" do

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -9,7 +9,7 @@ script type="text/x-template" id="measure-component-template"
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
         label.form-label
-          | Duty amount (% or £)
+          | Duty amount (% or €)
         input.form-control v-model="measureComponent.amount"
 
     .col-md-3 v-if="showDutyAmountPercentage"
@@ -27,25 +27,25 @@ script type="text/x-template" id="measure-component-template"
     .col-md-3 v-if="showDutyAmountNumber"
       .form-group
         label.form-label
-          | Duty amount (£)
+          | Duty amount (€)
         input.form-control v-model="measureComponent.amount"
 
     .col-md-3 v-if="showDutyAmountMinimum"
       .form-group
         label.form-label
-          | Duty amount (at least £)
+          | Duty amount (at least €)
         input.form-control v-model="measureComponent.amount"
 
     .col-md-3 v-if="showDutyAmountMaximum"
       .form-group
         label.form-label
-          | Duty amount (not more than £)
+          | Duty amount (not more than €)
         input.form-control v-model="measureComponent.amount"
 
     .col-md-3 v-if="showDutyRefundAmount"
       .form-group
         label.form-label
-          | Refund amount (£)
+          | Refund amount (€)
         input.form-control v-model="measureComponent.amount"
 
     .col-md-3 v-if="showMeasurementUnit"

--- a/app/views/shared/vue_templates/_measure_condition_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.slim
@@ -9,7 +9,7 @@ script type="text/x-template" id="measure-condition-component-template"
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
         label.form-label
-          | Duty amount (% or £)
+          | Duty amount (% or €)
         input.form-control v-model="measureConditionComponent.amount"
 
     .col-md-3 v-if="showDutyAmountPercentage"
@@ -27,25 +27,25 @@ script type="text/x-template" id="measure-condition-component-template"
     .col-md-3 v-if="showDutyAmountNumber"
       .form-group
         label.form-label
-          | Duty amount (£)
+          | Duty amount (€)
         input.form-control v-model="measureConditionComponent.amount"
 
     .col-md-3 v-if="showDutyAmountMinimum"
       .form-group
         label.form-label
-          | Duty amount (at least £)
+          | Duty amount (at least €)
         input.form-control v-model="measureConditionComponent.amount"
 
     .col-md-3 v-if="showDutyAmountMaximum"
       .form-group
         label.form-label
-          | Duty amount (not more than £)
+          | Duty amount (not more than €)
         input.form-control v-model="measureConditionComponent.amount"
 
     .col-md-3 v-if="showDutyRefundAmount"
       .form-group
         label.form-label
-          | Refund amount (£)
+          | Refund amount (€)
         input.form-control v-model="measureConditionComponent.amount"
 
     .col-md-3 v-if="showMeasurementUnit"


### PR DESCRIPTION
We have a GBP to euro exchange rate which we can use to display £ but
cannot save data in GBP or the amounts will be a mix of Euro and GBP.