### PR TITLE
Rewriting measure origins

### DIFF
--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -129,3 +129,28 @@ input.datepicker {
 .add-another-wrapper {
   margin-bottom: 0;
 }
+
+.exclusion {
+  & + .exclusion {
+    margin-top: 20px;
+  }
+}
+
+.exclusion-select {
+  display: inline-block;
+}
+
+.exclusion-actions {
+  display: inline-block;
+  margin-left: 20px;
+
+  a {
+    position: relative;
+    top: -18px;
+  }
+}
+
+.remove-link {
+  color: $red;
+  text-decoration: underline;
+}

--- a/app/forms/measure_form.rb
+++ b/app/forms/measure_form.rb
@@ -104,6 +104,7 @@ class MeasureForm
     @all_ga ||= Rails.cache.fetch(:measures_form_geographical_areas, expires_in: 8.hours) do
       GeographicalArea.actual
                       .all
+                      .map { |area| { geographical_area_id: area.geographical_area_id, description: area.description } }
     end
   end
 
@@ -112,6 +113,7 @@ class MeasureForm
       GeographicalArea.actual
                       .countries
                       .all
+                      .map { |area| { geographical_area_id: area.geographical_area_id, description: area.description } }
     end
   end
 
@@ -120,12 +122,13 @@ class MeasureForm
       GeographicalArea.actual.groups
                       .except_erga_omnes
                       .all
+                      .map { |area| { geographical_area_id: area.geographical_area_id, description: area.description } }
     end
   end
 
   def geographical_area_erga_omnes
     @gaeo ||= Rails.cache.fetch(:measures_form_geographical_area_erga_omnes, expires_in: 8.hours) do
-      GeographicalArea.erga_omnes_group
+      GeographicalArea.erga_omnes_group.to_hash.slice(:geographical_area_id, :description)
     end
   end
 

--- a/app/forms/measure_form.rb
+++ b/app/forms/measure_form.rb
@@ -73,7 +73,7 @@ class MeasureForm
     @ga_json ||= Rails.cache.fetch(:measures_form_geographical_areas_json, expires_in: 8.hours) do
       list = {}
 
-      all_geographical_areas.each do |group|
+      GeographicalArea.actual.all.each do |group|
         list[group.geographical_area_id] = group.contained_geographical_areas.map do |child|
           {
             geographical_area_id: child.geographical_area_id,

--- a/app/views/measures/measures/_form.html.slim
+++ b/app/views/measures/measures/_form.html.slim
@@ -7,6 +7,7 @@
 = render "shared/vue_templates/date_select"
 = render "shared/vue_templates/measure_component"
 = render "shared/vue_templates/measure_condition_component"
+= render "shared/vue_templates/measure_origin"
 = render "shared/vue_templates/footnote"
 
 = simple_form_for form, url: measures_path, html: { class: "measure-form", data: { measure: form.measure.to_json, measure_condition_attributes: form.measure.measure_conditions.to_json } } do |f|

--- a/app/views/measures/measures/_js_variables.html.erb
+++ b/app/views/measures/measures/_js_variables.html.erb
@@ -2,4 +2,7 @@
   window.measure_types_json = <%= safe_json(form.measure_types_json) %>;
   window.measure_types_series_json = <%= safe_json(form.measure_types_series_json) %>;
   window.geographical_areas_json = <%= safe_json(form.geographical_areas_json) %>;
+  window.all_geographical_countries = <%= safe_json(form.all_geographical_countries) %>;
+  window.geographical_groups_except_erga_omnes = <%= safe_json(form.geographical_groups_except_erga_omnes) %>;
+  window.geographical_area_erga_omnes = <%= safe_json(form.geographical_area_erga_omnes) %>;
 </script>

--- a/app/views/measures/measures/form_parts/_geographical_area.html.slim
+++ b/app/views/measures/measures/form_parts/_geographical_area.html.slim
@@ -9,52 +9,6 @@ fieldset
     |.
 
   .controls.origins-region
-    = f.hidden_field :geographical_area_id, value: form.geographical_area_id, "v-model" => "measure.geographical_area_id"
-    = f.collection_select(:excluded_geographical_areas, form.all_geographical_areas, :geographical_area_id, :description, { include_blank: true, multiple: true }, {class: "js-hidden", multiple: true, "v-model" => "measure.excluded_geographical_areas" })
-
-    .multiple-choice
-      = f.radio_button :geographical_area_type, :country, value: form.geographical_area_type, class: "radio-inline-group"
-      label
-        = f.collection_select(:geographical_area_proxy, form.all_geographical_countries, :geographical_area_id, :description, { include_blank: true, prompt: "― select a country or region ―" }, {class: "origin-select", "data-placeholder" => "― select a country or region ―"})
-
-    .panel.panel-border-narrow.js-hidden#exclusions-for-country-region
-      label.form-label
-        | If you want to exclude countries from this measure, enter them here:
-
-      .exclusions-target
-
-      p.add-another-wrapper
-        a href="#" class="js-add-country-exclusion"
-          | Add another exclusion
-
-
-    .multiple-choice
-      = f.radio_button :geographical_area_type, :group, value: form.geographical_area_type, class: "radio-inline-group"
-      label
-        = f.collection_select(:geographical_area_proxy, form.geographical_groups_except_erga_omnes, :geographical_area_id, :description, { include_blank: true, prompt: "― select a group of countries ―" }, { class: "origin-select", "data-placeholder" => "― select a group of countries ―" })
-
-    .panel.panel-border-narrow.js-hidden#exclusions-for-groups
-      label.form-label
-        | If you want to exclude countries from this measure, enter them here:
-
-      .exclusions-target
-
-      p.add-another-wrapper
-        a href="#" class="js-add-country-exclusion"
-          | Add another exclusion
-
-
-    .multiple-choice
-      = f.radio_button :geographical_area_type, :erga_omnes, value: form.geographical_area_type, class: "radio-inline-group", id: "erga-omnes-radio"
-      label for="erga-omnes-radio"
-        | ERGA OMNES (all origins)
-
-    .panel.panel-border-narrow.js-hidden#exclusions-for-erga-omnes
-      label.form-label
-        | If you want to exclude countries from this measure, enter them here:
-
-      .exclusions-target
-
-      p.add-another-wrapper
-        a href="#" class="js-add-country-exclusion"
-          | Add another exclusion
+    = content_tag "measure-origin", "", { kind: "country", placeholder: "― select a country or region ―", ":origin" => "origins.country" }
+    = content_tag "measure-origin", "", { kind: "group", placeholder: "― select a group of countries ―", ":origin" => "origins.group" }
+    = content_tag "measure-origin", "", { kind: "erga_omnes", placeholder: "― select a country or region ―", ":origin" => "origins.erga_omnes" }

--- a/app/views/shared/vue_templates/_measure_origin.html.slim
+++ b/app/views/shared/vue_templates/_measure_origin.html.slim
@@ -1,0 +1,24 @@
+script type="text/x-template" id="measure-origin-template"
+  .measure-origin
+    .multiple-choice
+      input type='radio' :id="radioID" class="radio-inline-group" name="geographical_area_type" :checked="origin.selected"
+      label v-if="notErgaOmnes"
+        = content_tag "custom-select", "", { ":options" => "optionsForSelect", "label-field" => "description", "value-field" => "geographical_area_id", ":placeholder": "placeholder", "v-model" => "origin.geographical_area_id", class: "origin-select" }
+      label :for="radioID" v-else=""
+        | ERGA OMNES (all origins)
+
+    .panel.panel-border-narrow v-if="showExclusions"
+      label.form-label
+        | If you want to exclude countries from this measure, enter them here:
+
+      .exclusions-target
+        .exclusion v-for="exclusion in origin.exclusions"
+          .exclusion-select
+            = content_tag "custom-select", "", { ":options" => "exclusion.options", "label-field" => "description", "value-field" => "geographical_area_id", "placeholder": "― start typing ―", "min-length" => 1, "v-model" => "exclusion.geographical_area_id", class: "origin-select" }
+          .exclusion-actions v-if="origin.exclusions.length > 1"
+            a.remove-link v-on:click.prevent="removeExclusion(exclusion)"
+               | Remove
+
+      p.add-another-wrapper
+        a href="#" v-on:click.prevent="addExclusion"
+          | Add another exclusion


### PR DESCRIPTION
Rewriting the whole origin section to be able to fix issue of VueJS re-rendering the form, losing the origin section customisations.

#### Note: whenever this gets deployed, need to make sure the Rails cache is cleared, due to the changed data being cached and also the js_variables partial cache.