### PR TITLE
[DB Rollbacks] Ability to clear data from an operational date

### DIFF
--- a/app/controllers/db/rollbacks_controller.rb
+++ b/app/controllers/db/rollbacks_controller.rb
@@ -19,7 +19,7 @@ module Db
         ::Db::RollbackWorker.perform_async(record.id) unless Rails.env.test?
 
         redirect_to db_rollbacks_path,
-                    notice: "Rollback was successfully scheduled for #{record.clear_date.strftime("%e %b %Y")}. Please wait!"
+                    notice: "Rollback was successfully scheduled for #{record.clear_date.to_formatted_s(:uk)}. Please wait!"
       else
         redirect_to db_rollbacks_path,
                     notice: "Something wrong!"

--- a/app/controllers/db/rollbacks_controller.rb
+++ b/app/controllers/db/rollbacks_controller.rb
@@ -1,0 +1,35 @@
+module Db
+  class RollbacksController < ApplicationController
+
+    expose(:rollbacks) do
+      Db::RollbackDecorator.decorate_collection(
+        Db::Rollback.reverse_order(:clear_date)
+                        .page(params[:page])
+      )
+    end
+
+    def create
+      record = ::Db::Rollback.new(
+        clear_date: clear_date,
+        issue_date: Time.zone.now,
+        state: "P"
+      )
+
+      if record.save
+        ::Db::RollbackWorker.perform_async(record.id) unless Rails.env.test?
+
+        redirect_to db_rollbacks_path,
+                    notice: "Rollback was successfully scheduled for #{record.clear_date.strftime("%e %b %Y")}. Please wait!"
+      else
+        redirect_to db_rollbacks_path,
+                    notice: "Something wrong!"
+      end
+    end
+
+    private
+
+      def clear_date
+        params[:clear_date].try(:to_date) || Date.today
+      end
+  end
+end

--- a/app/decorators/application_decorator.rb
+++ b/app/decorators/application_decorator.rb
@@ -3,7 +3,7 @@ class ApplicationDecorator < Draper::Decorator
   delegate_all
 
   def to_readable_date(field_name)
-    object.public_send(field_name).strftime("%e %b %Y")
+    object.public_send(field_name).to_formatted_s(:uk)
   end
 
   def to_readable_date_time(field_name)

--- a/app/decorators/db/rollback_decorator.rb
+++ b/app/decorators/db/rollback_decorator.rb
@@ -1,0 +1,8 @@
+module Db
+  class RollbackDecorator < JobBaseDecorator
+
+    def clear_date
+      to_readable_date_time(:clear_date)
+    end
+  end
+end

--- a/app/decorators/job_base_decorator.rb
+++ b/app/decorators/job_base_decorator.rb
@@ -1,0 +1,19 @@
+class JobBaseDecorator < ApplicationDecorator
+
+  def status
+    case object.state
+    when "P"
+      "Pending"
+    when "G"
+      "Generation in progress"
+    when "C"
+      "Completed"
+    when "F"
+      "Failed"
+    end
+  end
+
+  def issue_date
+    to_readable_date_time(:issue_date)
+  end
+end

--- a/app/decorators/xml_export/file_decorator.rb
+++ b/app/decorators/xml_export/file_decorator.rb
@@ -1,22 +1,5 @@
 module XmlExport
-  class FileDecorator < ApplicationDecorator
-
-    def status
-      case object.state
-      when "P"
-        "Pending"
-      when "G"
-        "Generation in progress"
-      when "C"
-        "Completed"
-      when "F"
-        "Failed"
-      end
-    end
-
-    def issue_date
-      to_readable_date_time(:issue_date)
-    end
+  class FileDecorator < JobBaseDecorator
 
     def date_of_export
       to_readable_date(:relevant_date)

--- a/app/models/db/rollback.rb
+++ b/app/models/db/rollback.rb
@@ -1,0 +1,10 @@
+module Db
+  class Rollback < Sequel::Model(:db_rollbacks)
+
+    class << self
+      def max_per_page
+        15
+      end
+    end
+  end
+end

--- a/app/models/db/rollback_process.rb
+++ b/app/models/db/rollback_process.rb
@@ -1,0 +1,36 @@
+module Db
+  class RollbackProcess
+
+    attr_accessor :record,
+                  :data
+
+    def initialize(record)
+      @record = record
+    end
+
+    def run
+      fetch_relevant_data
+      delete_target_db_records!
+      mark_job_as_completed!
+    end
+
+    private
+
+      def fetch_relevant_data
+        @data = ::XmlGeneration::Search.new(
+          record.clear_date
+        ).send(:data)
+      end
+
+      def delete_target_db_records!
+        data.map do |item|
+          item.manual_add = true
+          item.delete
+        end
+      end
+
+      def mark_job_as_completed!
+        record.update(state: "C")
+      end
+  end
+end

--- a/app/models/xml_generation/search.rb
+++ b/app/models/xml_generation/search.rb
@@ -54,6 +54,8 @@ module XmlGeneration
       MeasureConditionCodeDescription,
       MeasureCondition,
       MeasureConditionComponent,
+      MeasurePartialTemporaryStop,
+      MeasureExcludedGeographicalArea,
 
       AdditionalCodeType,
       AdditionalCodeTypeDescription,
@@ -101,6 +103,7 @@ module XmlGeneration
       FootnoteAssociationGoodsNomenclature,
       FootnoteAssociationMeasure,
       FootnoteAssociationMeursingHeading,
+      FootnoteAssociationErn,
 
       ExportRefundNomenclature,
       ExportRefundNomenclatureDescription,

--- a/app/views/db/rollbacks/_form.html.slim
+++ b/app/views/db/rollbacks/_form.html.slim
@@ -1,0 +1,10 @@
+.search-form
+  = simple_form_for :rollback, url: db_rollbacks_path, html: {method: :post} do |f|
+
+    .row
+      .col-sm-2
+        = f.input :date, as: :string, label: 'Select date',  input_html: { name: :clear_date, class: 'form-control', 'data-behaviour' => 'datepicker' }
+
+    .form-actions
+      = f.button :submit, 'Schedule Rollback', class: 'button', data: { 'disable-with' => 'Scheduling' }
+      = link_to 'Refresh Page', db_rollbacks_path, class: 'secondary-button'

--- a/app/views/db/rollbacks/_table.html.slim
+++ b/app/views/db/rollbacks/_table.html.slim
@@ -1,0 +1,19 @@
+table.table
+  colgroup
+    col width="180"
+    col width="130"
+    col width="*"
+  thead
+    tr
+      th.span2 Clear date
+      th.span2 Scheduled at
+      th.span2 Status
+  tbody
+    - rollbacks.map do |export_item|
+      tr
+        td
+          = export_item.clear_date
+        td
+          = export_item.issue_date
+        td
+          = export_item.status

--- a/app/views/db/rollbacks/index.html.slim
+++ b/app/views/db/rollbacks/index.html.slim
@@ -1,0 +1,18 @@
+.breadcrumbs
+  ol
+    li
+      = link_to "Tariff Management", root_url
+
+    li aria-current="page"
+      | Rollbacks
+
+h2.heading-large Rollbacks
+
+p Clear all data from the db from an operational date
+
+= render "form"
+
+- if rollbacks.present?
+  = render "table"
+- else
+  p Nothing found!

--- a/app/views/home/index.html.slim
+++ b/app/views/home/index.html.slim
@@ -29,3 +29,9 @@
         = link_to "XML generation", xml_generation_exports_path
       p.font-xsmall
         | Generate TARIC3 XML files
+
+    .w30.mt1
+      h3.heading-small style="margin:0px"
+        = link_to "Rollbacks", db_rollbacks_path
+      p.font-xsmall
+        | Clear all data from the db from an operational date

--- a/app/workers/db/rollback_worker.rb
+++ b/app/workers/db/rollback_worker.rb
@@ -1,0 +1,12 @@
+module Db
+  class RollbackWorker
+    include Sidekiq::Worker
+
+    sidekiq_options queue: :xml_generation, retry: false
+
+    def perform(record_id)
+      record = ::Db::Rollback.filter(id: record_id).first
+      ::Db::RollbackProcess.new(record).run
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,9 @@ Rails.application.routes.draw do
   namespace :xml_generation do
     resources :exports, only: [:index, :show, :create]
   end
+  namespace :db do
+    resources :rollbacks, only: [:index, :create]
+  end
 
   resources :goods_nomenclatures, only: [:index]
   resources :regulations, only: [:index]

--- a/db/migrate/20180410100532_create_db_rollbacks.rb
+++ b/db/migrate/20180410100532_create_db_rollbacks.rb
@@ -1,0 +1,12 @@
+Sequel.migration do
+  change do
+    create_table :db_rollbacks do
+      primary_key :id
+      String :state, size: 1
+      DateTime :issue_date
+      Date :clear_date
+      Time :updated_at
+      Time :created_at
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1232,6 +1232,39 @@ CREATE TABLE data_migrations (
 
 
 --
+-- Name: db_rollbacks; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE db_rollbacks (
+    id integer NOT NULL,
+    state character varying(1),
+    issue_date timestamp without time zone,
+    clear_date date,
+    updated_at timestamp without time zone,
+    created_at timestamp without time zone
+);
+
+
+--
+-- Name: db_rollbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE db_rollbacks_id_seq
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: db_rollbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE db_rollbacks_id_seq OWNED BY db_rollbacks.id;
+
+
+--
 -- Name: duty_expression_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -6513,6 +6546,13 @@ ALTER TABLE ONLY complete_abrogation_regulations_oplog ALTER COLUMN oid SET DEFA
 
 
 --
+-- Name: id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY db_rollbacks ALTER COLUMN id SET DEFAULT nextval('db_rollbacks_id_seq'::regclass);
+
+
+--
 -- Name: oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -7320,6 +7360,14 @@ ALTER TABLE ONLY complete_abrogation_regulations_oplog
 
 ALTER TABLE ONLY data_migrations
     ADD CONSTRAINT data_migrations_pkey PRIMARY KEY (filename);
+
+
+--
+-- Name: db_rollbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY db_rollbacks
+    ADD CONSTRAINT db_rollbacks_pkey PRIMARY KEY (id);
 
 
 --
@@ -10131,4 +10179,5 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180402091320_remove_type
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180402142849_add_record_to_node_messages.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180402154232_change_record_id_to_record_filter_ops_in_node_messages.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180406152439_remove_xml_nodes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180410100532_create_db_rollbacks.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180212145253_create_initial_schema.rb');

--- a/lib/sequel/plugins/oplog.rb
+++ b/lib/sequel/plugins/oplog.rb
@@ -74,6 +74,8 @@ module Sequel
         end
 
         def _destroy_delete
+          return super if manual_add
+
           self.operation = :destroy
 
           operation_klass.insert(self.values.except(:oid))
@@ -111,10 +113,6 @@ module Sequel
 
         def insert
           raise NotImplementedError.new("You should be inserting model instances.")
-        end
-
-        def delete
-          raise NotImplementedError.new("You should be *destroying* model instances.")
         end
       end
     end


### PR DESCRIPTION
**THIS PR COVERS:**

1) DB Rollbacks: implemented ability to clear all data from the db from an operational date

[TRELLO CARD](https://trello.com/c/mjslkrQF/149-delete-data-from-an-operational-date)

2) XML Exporter: fixed issue with missing db records in XML:

- MeasurePartialTemporaryStop
- MeasureExcludedGeographicalArea
- FootnoteAssociationErn