### PR TITLE
Measure saver bug fix + Additional Code Type updates

### DIFF
--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -228,6 +228,8 @@ $(document).ready(function() {
             end_date: end_date
           };
 
+          if (vm.drilldownRequired === "true" && !vm.drilldownValue) return callback();
+
           if (vm.drilldownName && vm.drilldownValue) {
             data[vm.drilldownName] = vm.drilldownValue;
           }
@@ -258,6 +260,17 @@ $(document).ready(function() {
 
         $(".measure-form").on("dates:changed", this.handleDateSentitivity);
       }
+
+
+      vm.$watch("drilldownValue", function(newVal, oldVal) {
+        $(vm.$el)[0].selectize.clear();
+
+        if (newVal == oldVal) {
+          return;
+        }
+
+        vm.handleDateSentitivity({}, vm.start_date, vm.end_date);
+      })
     },
     watch: {
       value: function (value) {
@@ -267,13 +280,6 @@ $(document).ready(function() {
         $(this.$el)[0].selectize.clearOptions();
         $(this.$el)[0].selectize.addOption(options);
         $(this.$el)[0].selectize.refreshOptions(false);
-      },
-      drilldownValue: function(newVal, oldVal) {
-        if (newVal == oldVal) {
-          return;
-        }
-
-        this.handleDateSentitivity({}, this.start_date, this.end_date);
       }
     },
     destroyed: function () {

--- a/app/controllers/additional_codes/additional_code_types_controller.rb
+++ b/app/controllers/additional_codes/additional_code_types_controller.rb
@@ -1,8 +1,22 @@
 module AdditionalCodes
   class AdditionalCodeTypesController < ::BaseController
 
+    expose(:measure_type) do
+      MeasureType.actual
+                 .where(measure_type_id: params[:measure_type_id])
+                 .first
+    end
+
     def collection
-      AdditionalCodeType.q_search(params[:q])
+      scope = measure_type.additional_code_types
+
+      if params[:q].present?
+        scope = scope.select do |ac_type|
+          ac_type.additional_code_type_id.starts_with?(params[:q].strip)
+        end
+      end
+
+      scope
     end
   end
 end

--- a/app/interactors/measure_saver.rb
+++ b/app/interactors/measure_saver.rb
@@ -18,6 +18,7 @@ class MeasureParamsNormalizer
     measure_type_id
     regulation_id
     geographical_area_id
+    additional_code
   )
 
   attr_accessor :normalized_params
@@ -105,6 +106,8 @@ class MeasureParamsNormalizer
           goods_nomenclature_item_id: goods_nomenclature_item_id,
           goods_nomenclature_sid: commodity.goods_nomenclature_sid
         }
+      else
+        {}
       end
     end
 end

--- a/app/interactors/measure_saver.rb
+++ b/app/interactors/measure_saver.rb
@@ -98,17 +98,15 @@ class MeasureParamsNormalizer
     end
 
     def method_goods_nomenclature_item_values(goods_nomenclature_item_id)
-      commodity = Commodity.actual
-                           .where(goods_nomenclature_item_id: goods_nomenclature_item_id).first
+      goods_nomenclature = GoodsNomenclature.actual
+                                            .where(goods_nomenclature_item_id: goods_nomenclature_item_id)
+                                            .first
+                                            .try(:sti_instance)
 
-      if commodity.present?
-        {
-          goods_nomenclature_item_id: goods_nomenclature_item_id,
-          goods_nomenclature_sid: commodity.goods_nomenclature_sid
-        }
-      else
-        {}
-      end
+      {
+        goods_nomenclature_item_id: goods_nomenclature_item_id,
+        goods_nomenclature_sid: goods_nomenclature.goods_nomenclature_sid
+      }
     end
 end
 
@@ -150,7 +148,6 @@ class MeasureSaver
 
   def valid?
     check_required_params!
-    check_goods_nomenclature!
     return false if @errors.present?
 
     @measure = Measure.new(measure_params)
@@ -203,16 +200,6 @@ class MeasureSaver
         if original_params[k.to_s].blank?
           @errors[v.to_sym] = "#{k.to_s.capitalize.split('_').join(' ')} can't be blank!"
         end
-      end
-    end
-
-    def check_goods_nomenclature!
-      goods_nomenclature_code = original_params[:goods_nomenclature_code].to_s.strip
-
-      if goods_nomenclature_code.present? &&
-         normalized_params[:goods_nomenclature_sid].blank?
-
-        @errors[:goods_nomenclature_code] = "There are no goods nomenclature for code: '#{goods_nomenclature_code}'!"
       end
     end
 

--- a/app/interactors/measure_saver.rb
+++ b/app/interactors/measure_saver.rb
@@ -100,10 +100,12 @@ class MeasureParamsNormalizer
       commodity = Commodity.actual
                            .where(goods_nomenclature_item_id: goods_nomenclature_item_id).first
 
-      {
-        goods_nomenclature_item_id: goods_nomenclature_item_id,
-        goods_nomenclature_sid: commodity.goods_nomenclature_sid
-      }
+      if commodity.present?
+        {
+          goods_nomenclature_item_id: goods_nomenclature_item_id,
+          goods_nomenclature_sid: commodity.goods_nomenclature_sid
+        }
+      end
     end
 end
 
@@ -145,6 +147,7 @@ class MeasureSaver
 
   def valid?
     check_required_params!
+    check_goods_nomenclature!
     return false if @errors.present?
 
     @measure = Measure.new(measure_params)
@@ -197,6 +200,16 @@ class MeasureSaver
         if original_params[k.to_s].blank?
           @errors[v.to_sym] = "#{k.to_s.capitalize.split('_').join(' ')} can't be blank!"
         end
+      end
+    end
+
+    def check_goods_nomenclature!
+      goods_nomenclature_code = original_params[:goods_nomenclature_code].to_s.strip
+
+      if goods_nomenclature_code.present? &&
+         normalized_params[:goods_nomenclature_sid].blank?
+
+        @errors[:goods_nomenclature_code] = "There are no goods nomenclature for code: '#{goods_nomenclature_code}'!"
       end
     end
 

--- a/app/models/additional_code_type.rb
+++ b/app/models/additional_code_type.rb
@@ -32,14 +32,6 @@ class AdditionalCodeType < Sequel::Model
     4 => "Export refund for processed agricultural goods"
   }
 
-  dataset_module do
-    def q_search(keyword)
-      where {
-        Sequel.ilike(:additional_code_type_id, "#{keyword}%")
-      }
-    end
-  end
-
   def meursing?
     application_code.in?("3")
   end

--- a/app/models/measure_type.rb
+++ b/app/models/measure_type.rb
@@ -22,6 +22,9 @@ class MeasureType < Sequel::Model
 
   many_to_one :measure_type_series
 
+  many_to_many :additional_code_types, join_table: :additional_code_type_measure_types,
+                                       class_name: 'AdditionalCodeType'
+
   delegate :description, to: :measure_type_description
 
   dataset_module do

--- a/app/views/measures/measures/form_parts/_goods_nomenclature.html.slim
+++ b/app/views/measures/measures/form_parts/_goods_nomenclature.html.slim
@@ -19,7 +19,7 @@ fieldset
 
       span.form-hint.after-field v-else=""
         | Code description will appear here once you enter at least ten digits above.
-  .form-group
+  .form-group v-if="measure.measure_type_id"
     label.form-label
       | Additional code
       span.form-hint
@@ -29,11 +29,11 @@ fieldset
         .form-group
           label.form-label
             | Additional code type
-          = content_tag "custom-select", "", { url: "/additional_code_types", "label-field" => "description", "value-field" => "additional_code_type_id", "code-field" => "additional_code_type_id", placeholder: "― select additional code type ―", "v-model" => "measure.additional_code_type_id", "drilldown-name" => "measure_type_id", ":drilldown-value" => "measure.measure_type_id", "drilldown-required" => false, "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/additional_code_types", "label-field" => "description", "value-field" => "additional_code_type_id", "code-field" => "additional_code_type_id", placeholder: "― select additional code type ―", "v-model" => "measure.additional_code_type_id", "drilldown-name" => "measure_type_id", "v-bind:drilldown-value.sync" => "measure.measure_type_id", "drilldown-required" => true, "date-sensitive" => true }
 
       .col-md-5 v-if="measure.additional_code_type_id"
         .form-group
           label.form-label
             | Additional code
 
-          = content_tag "custom-select", "", { url: "/additional_codes", "label-field" => "description", "value-field" => "additional_code", "code-field" => "additional_code", placeholder: "― start typing ―", "min-length" => 1, "v-model" => "measure.additional_code", "drilldown-name" => "additional_code_type_id", ":drilldown-value" => "measure.additional_code_type_id", "drilldown-required" => true, "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/additional_codes", "label-field" => "description", "value-field" => "additional_code", "code-field" => "additional_code", placeholder: "― start typing ―", "min-length" => 1, "v-model" => "measure.additional_code", "drilldown-name" => "additional_code_type_id", "v-bind:drilldown-value.sync" => "measure.additional_code_type_id", "drilldown-required" => true, "date-sensitive" => true }


### PR DESCRIPTION
**THIS PR COVERS:**

1)  'Additional code types' select should be pre-populated with additional code types related to specified measure type (via AdditionalCodeTypeMeasureType db record)

[TRELLO CARD](https://trello.com/c/WKRFV0rg/169-measure-form-additional-code-types-select-should-be-pre-populated-with-additional-code-types-related-to-specified-measure-type-v)

2) Measure saver: fixed issue with assigning of Heading for Measure. Previously used code was working with Commodities only (and was ignoring Headings)

[SENTRY ISSUE](https://sentry.io/bit-zesty-client-apps/management/issues/526975545/)