### PR TITLE
Adding abbreviations to dropdown selects

### DIFF
--- a/app/assets/javascripts/components/custom-select.js
+++ b/app/assets/javascripts/components/custom-select.js
@@ -15,7 +15,9 @@ Vue.component('custom-select', {
     "drilldownRequired",
     "onChange",
     "allowClear",
-    "name"
+    "name",
+    "codeClassName",
+    "abbreviationClassName"
   ],
   data: function() {
     return {
@@ -35,7 +37,7 @@ Vue.component('custom-select', {
       valueField: this.valueField,
       labelField: this.labelField,
       allowClear: this.allowClear || false,
-      searchField: [this.valueField, this.codeField, this.labelField]
+      searchField: [this.valueField, this.codeField, "abbreviation", this.labelField]
     };
 
     if (this.onChange) {
@@ -107,14 +109,28 @@ Vue.component('custom-select', {
     }
 
     var codeField = this.codeField;
+    var codeClassName = this.codeClassName || "";
+    var abbreviationClassName = this.abbreviationClassName || "";
 
     if (codeField) {
       options["render"] = {
         option: function(data) {
-          return "<span class='selection" + (data.disabled ? ' selection--strikethrough' : '') + "'><span class='option-prefix option-prefix--series'>" + data[codeField] + "</span> " + data[options.labelField] + "</span>";
+          var abbreviationSpan = "";
+
+          if (abbreviationClassName) {
+            abbreviationSpan = "<span class='abbreviation " + abbreviationClassName + "'>" + (data.abbreviation || "&nbsp;") + "</span>";
+          }
+
+          return "<span class='selection'><span class='option-prefix " + codeClassName + "'>" + data[codeField] + "</span>" + abbreviationSpan + "<span>" + data[options.labelField] + "</span></span>";
         },
         item: function(data) {
-          return "<div class='item'>" + data[codeField] + " - " + data[options.labelField] + "</div>";
+          var abbreviation = "";
+
+          if (abbreviationClassName && data.abbreviation) {
+            abbreviation = data.abbreviation + " - ";
+          }
+
+          return "<div class='item'>" + data[codeField] + " - " + abbreviation + data[options.labelField] + "</div>";
         }
       };
     }

--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -894,7 +894,7 @@ $(document).ready(function() {
     allowClear: true,
     render: {
       option: function(data) {
-        return "<span class='selection" + (data.disabled ? ' selection--strikethrough' : '') + "'><span class='option-prefix option-prefix--series'>" + data.measure_type_series_id + "</span> " + data.description + "</span>";
+        return "<span class='selection'><span class='option-prefix option-prefix--series'>" + data.measure_type_series_id + "</span> " + data.description + "</span>";
       },
       item: function(data) {
         return "<div class='item'>" + data.measure_type_series_id + " - " + data.description + "</div>";
@@ -911,7 +911,7 @@ $(document).ready(function() {
     allowClear: true,
     render: {
       option: function(data) {
-        return "<span class='selection" + (data.disabled ? ' selection--strikethrough' : '') + "'><span class='option-prefix option-prefix--type'>" + data.measure_type_id + "</span> " + data.description + "</span>";
+        return "<span class='selection'><span class='option-prefix option-prefix--type'>" + data.measure_type_id + "</span> " + data.description + "</span>";
       },
       item: function(data) {
         return "<div class='item'>" + data.measure_type_id + " - " + data.description + "</div>";

--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -1,12 +1,11 @@
 .selection {
-  display: block;
+  display: flex;
   padding: 0.5em 0.2em !important;
-  position: relative !important;
-}
 
-.selection--strikethrough {
-  text-decoration: line-through;
-
+  span {
+    flex: 0 1 auto;
+    align-self: stretch;
+  }
 }
 
 .selectize-input .item {
@@ -16,29 +15,148 @@
   text-overflow: ellipsis !important;
 }
 
+.abbreviation {
+  display: inline-block;
+  margin-right: 0.5em;
+}
+
 .option-prefix {
   display: inline-block;
-  min-width: 2.3em;
   margin-right: 0.5em;
   padding-left: 0.5em;
+}
 
-  .selection--strikethrough & {
-    position: relative;
-
-    &:after {
-      content: " ";
-      position: absolute;
-      top: calc(50% + 1px);
-      left: 0;
-      width: 100%;
-      height: 1px;
-      background: currentColor;
-    }
-  }
+.option-prefix--series {
+  flex-basis: 1.7em;
+  min-width: 1.7em;
+  width: 1.7em;
 }
 
 .option-prefix--type {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
+}
 
+.prefix--country {
+  flex-basis: 2.3em;
+  min-width: 2.3em;
+  width: 2.3em;
+}
+
+.prefix--region {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
+}
+
+.prefix--monetary-unit {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
+}
+
+.prefix--measurement-unit {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
+  flex-shrink: 0;
+}
+
+.prefix--measurement-unit-qualifier {
+  flex-basis: 1.7em;
+  min-width: 1.7em;
+  width: 1.7em;
+}
+
+.prefix--condition {
+  flex-basis: 1.7em;
+  min-width: 1.7em;
+  width: 1.7em;
+}
+
+.prefix--measure-action {
+  flex-basis: 2.1em;
+  min-width: 2.1em;
+  width: 2.1em;
+}
+
+.prefix--certificate-type {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
+}
+
+.prefix--certificate {
+  flex-basis: 2.8em;
+  min-width: 2.8em;
+  width: 2.8em;
+}
+
+.prefix--quota-status {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
+}
+
+.prefix--quota-order-number {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
+}
+
+.prefix--additional-code-type {
+  flex-basis: 1.7em;
+  min-width: 1.7em;
+  width: 1.7em;
+}
+
+.prefix--additional-code {
+  flex-basis: 2.8em;
+  min-width: 2.8em;
+  width: 2.8em;
+}
+
+.prefix--duty-expression {
+  flex-basis: 2.1em;
+  min-width: 2.1em;
+  width: 2.1em;
+}
+
+.abbreviation--measurement-unit {
+  flex-basis: 6.5em;
+  min-width: 6.5em;
+  width: 6.5em;
+}
+
+.abbreviation--duty-expression {
+  flex-basis: 4.5em;
+  min-width: 4.5em;
+  width: 4.5em;
+}
+
+.prefix--footnote-type{
+  flex-basis: 2.3em;
+  min-width: 2.3em;
+  width: 2.3em;
+}
+
+.prefix--l1 {
+  flex-basis: 1.7em;
+  min-width: 1.7em;
+  width: 1.7em;
+}
+
+.prefix--regulation {
+  flex-basis: 5.5em;
+  min-width: 5.5em;
+  width: 5.5em;
+}
+
+.prefix--regulation-group {
+  flex-basis: 3em;
+  min-width: 3em;
+  width: 3em;
 }
 
 .origin-select {

--- a/app/views/measures/measures/form_parts/_goods_nomenclature.html.slim
+++ b/app/views/measures/measures/form_parts/_goods_nomenclature.html.slim
@@ -28,10 +28,10 @@ fieldset
       .col-md-5
           label.form-label
             | Additional code type
-          = content_tag "custom-select", "", { url: "/additional_code_types", "label-field" => "description", "value-field" => "additional_code_type_id", "code-field" => "additional_code_type_id", placeholder: "― select additional code type ―", "v-model" => "measure.additional_code_type_id", "drilldown-name" => "measure_type_id", "v-bind:drilldown-value.sync" => "measure.measure_type_id", "drilldown-required" => true, "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/additional_code_types", "label-field" => "description", "value-field" => "additional_code_type_id", "code-field" => "additional_code_type_id", placeholder: "― select additional code type ―", "v-model" => "measure.additional_code_type_id", "drilldown-name" => "measure_type_id", "v-bind:drilldown-value.sync" => "measure.measure_type_id", "drilldown-required" => true, "date-sensitive" => true, "code-class-name" => "prefix--additional-code-type" }
 
       .col-md-5 v-if="measure.additional_code_type_id"
         label.form-label
           | Additional code
 
-          = content_tag "custom-select", "", { url: "/additional_codes", "label-field" => "description", "value-field" => "additional_code", "code-field" => "additional_code", placeholder: "― start typing ―", "min-length" => 1, "v-model" => "measure.additional_code", "drilldown-name" => "additional_code_type_id", "v-bind:drilldown-value.sync" => "measure.additional_code_type_id", "drilldown-required" => true, "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/additional_codes", "label-field" => "description", "value-field" => "additional_code", "code-field" => "additional_code", placeholder: "― start typing ―", "min-length" => 1, "v-model" => "measure.additional_code", "drilldown-name" => "additional_code_type_id", "v-bind:drilldown-value.sync" => "measure.additional_code_type_id", "drilldown-required" => true, "date-sensitive" => true, "code-class-name" => "prefix--additional-code" }

--- a/app/views/measures/measures/form_parts/_quota.html.slim
+++ b/app/views/measures/measures/form_parts/_quota.html.slim
@@ -29,7 +29,7 @@ fieldset v-if="showQuota"
 
       .row
         .col-md-5
-          = content_tag "custom-select", "", { ":options" => "quota_statuses", "label-field" => "label", "value-field" => "value", placeholder: "― select initial status ―", "v-model" => "measure.quota_status" }
+          = content_tag "custom-select", "", { ":options" => "quota_statuses", "label-field" => "label", "value-field" => "value", placeholder: "― select initial status ―", "v-model" => "measure.quota_status", "code-class-name" => "prefix--quota-status" }
 
     .form-group
       label.form-label
@@ -74,4 +74,4 @@ fieldset v-if="showQuota"
           | Start typing in the field to see available quotas. If the quota you need is not in the list, change the option above to create a new one instead.
       .row
         .col-3
-          = content_tag "custom-select", "", { url: "/quota_order_numbers", "label-field" => "quota_order_number_id", "value-field" => "quota_order_number_id", placeholder: "― start typing ―", "min-length" => 1, "v-model" => "measure.quota_ordernumber", "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/quota_order_numbers", "label-field" => "quota_order_number_id", "value-field" => "quota_order_number_id", placeholder: "― start typing ―", "min-length" => 1, "v-model" => "measure.quota_ordernumber", "date-sensitive" => true, "code-class-name" => "prefix--quota-order-number" }

--- a/app/views/measures/measures/form_parts/_reference_price.html.slim
+++ b/app/views/measures/measures/form_parts/_reference_price.html.slim
@@ -12,10 +12,10 @@ fieldset v-if="showReferencePrice"
       .form-group
         label.form-label
           | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measurement_unit_code", "placeholder" => "― select the duty expression to use ―" }
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit" }
 
     .col-md-4
       .form-group
         label.form-label
           | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―" }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--measurement-unit-qualifier" }

--- a/app/views/measures/measures/form_parts/_standart_import_value.html.slim
+++ b/app/views/measures/measures/form_parts/_standart_import_value.html.slim
@@ -12,10 +12,10 @@ fieldset v-if="showStandardImportValue"
       .form-group
         label.form-label
           | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measurement_unit_code", "placeholder" => "― select the duty expression to use ―" }
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit" }
 
     .col-md-4
       .form-group
         label.form-label
           | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―" }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--measurement-unit-qualifier" }

--- a/app/views/measures/measures/form_parts/_unit_price.html.slim
+++ b/app/views/measures/measures/form_parts/_unit_price.html.slim
@@ -12,10 +12,10 @@ fieldset v-if="showUnitPrice"
       .form-group
         label.form-label
           | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measurement_unit_code", "placeholder" => "― select measurement unit ―" }
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measurement_unit_code", "placeholder" => "― select measurement unit ―", "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit" }
 
     .col-md-4
       .form-group
         label.form-label
           | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measurement_unit_qualifier_code", "placeholder" => "― select measurement unit qualifier ―" }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measurement_unit_qualifier_code", "placeholder" => "― select measurement unit qualifier ―", "code-class-name" => "prefix--measurement-unit-qualifier" }

--- a/app/views/regulations/_form.html.slim
+++ b/app/views/regulations/_form.html.slim
@@ -7,7 +7,7 @@
       | Specify the regulation type
     .row
       .col-md-6
-        = content_tag "custom-select", { "allow-clear" => true, "code-field" => "value", "label-field" => "text", "value-field" => "value", "v-model" => "regulation.role" } do
+        = content_tag "custom-select", { "allow-clear" => true, "code-field" => "value", "label-field" => "text", "value-field" => "value", "v-model" => "regulation.role", "code-class-name" => "prefix--l1" } do
           = f.input :role, as: :select, collection: RegulationForm.regulation_roles, value_method: :first, label_method: :last, label: false, include_blank: true, prompt: "- select regulation type -"
 
     div v-if="dependentOnBaseRegulation"
@@ -16,7 +16,7 @@
       .row
         .col-md-6
           = f.input :base_regulation_role, as: :hidden, input_html: { "v-model" => "regulation.base_regulation_role" }
-          = content_tag "custom-select", "", { url: "/regulation_form_api/base_regulations", "allow-clear" => true, "code-field" => "regulation_id", "label-field" => "description", "value-field" => "regulation_id", "v-model" => "regulation.base_regulation_id", placeholder: "- select base regulation -", ":on-change" => "onBaseRegulationChange", "name" => "regulation_form[base_regulation_id]" }
+          = content_tag "custom-select", "", { url: "/regulation_form_api/base_regulations", "allow-clear" => true, "code-field" => "regulation_id", "label-field" => "description", "value-field" => "regulation_id", "v-model" => "regulation.base_regulation_id", placeholder: "- select base regulation -", ":on-change" => "onBaseRegulationChange", "name" => "regulation_form[base_regulation_id]", "code-class-name" => "prefix--regulation" }
 
     div v-if="canHaveRelatedAntidumpingLink"
       h4.heading-small
@@ -24,13 +24,13 @@
       .row
         .col-md-6
           = f.input :antidumping_regulation_role, as: :hidden, input_html: { "v-model" => "regulation.antidumping_regulation_role" }
-          = content_tag "custom-select", "", { url: "/regulation_form_api/base_regulations", "allow-clear" => true, "code-field" => "regulation_id", "label-field" => "description", "value-field" => "regulation_id", "v-model" => "regulation.related_antidumping_regulation_id", placeholder: "- select related antidumping regulation -", ":on-change" => "onRelatedAntidumpingRegulationChange", "name" => "regulation_form[related_antidumping_regulation_id]", ":drilldown-value" => "antidumpingRoles", "drilldown-name" => "roles" }
+          = content_tag "custom-select", "", { url: "/regulation_form_api/base_regulations", "allow-clear" => true, "code-field" => "regulation_id", "label-field" => "description", "value-field" => "regulation_id", "v-model" => "regulation.related_antidumping_regulation_id", placeholder: "- select related antidumping regulation -", ":on-change" => "onRelatedAntidumpingRegulationChange", "name" => "regulation_form[related_antidumping_regulation_id]", ":drilldown-value" => "antidumpingRoles", "drilldown-name" => "roles", "code-class-name" => "prefix--regulation" }
 
     h4.heading-small
       | Specify the community code
     .row
       .col-md-4
-        = content_tag "custom-select", { "allow-clear" => true, "code-field" => "value", "label-field" => "text", "value-field" => "value", "v-model" => "regulation.community_code" } do
+        = content_tag "custom-select", { "allow-clear" => true, "code-field" => "value", "label-field" => "text", "value-field" => "value", "v-model" => "regulation.community_code", "code-class-name" => "prefix--l1" } do
           = f.input :community_code, as: :select, collection: RegulationForm.community_codes, value_method: :first, label_method: :last, label: false, include_blank: true, prompt: "- select community code -"
 
     h4.heading-small
@@ -39,7 +39,7 @@
     .row
       .col-md-3
         = content_tag "custom-select", { "allow-clear" => true, "code-field" => "value", "label-field" => "text", "value-field" => "value", "v-model" => "regulation.prefix" } do
-          = f.input :prefix, as: :select, collection: RegulationForm.prefixes, value_method: :first, label_method: :last, label: "Prefix", include_blank: true, prompt: "- select prefix -"
+          = f.input :prefix, as: :select, collection: RegulationForm.prefixes, value_method: :first, label_method: :last, label: "Prefix", include_blank: true, prompt: "- select prefix -", "code-class-name" => "prefix--l1"
       .col-md-3
         = f.input :publication_year, label: "Publication year", input_html: { placeholder: "YY", "v-model" => "regulation.publication_year" }
       .col-md-3
@@ -49,7 +49,7 @@
 
     .row
       .col-md-4
-        = content_tag "custom-select", { "code-field" => "value", "label-field" => "text", "value-field" => "value", "v-model" => "regulation.replacement_indicator" } do
+        = content_tag "custom-select", { "code-field" => "value", "label-field" => "text", "value-field" => "value", "v-model" => "regulation.replacement_indicator", "code-class-name" => "prefix--l1" } do
           = f.input :replacement_indicator, as: :select, collection: RegulationForm::REPLACEMENT_INDICATORS, value_method: :first, label_method: :last, label: "Replacement indicator", include_blank: true, prompt: "- select replacement indicator -"
 
 
@@ -92,7 +92,7 @@
       .col-md-6
         .form-group v-bind:class="{ 'form-group-error': regulation.errors.regulation_group_id }"
           span.error-message v-if="regulation.errors.regulation_group_id" v-html="regulation.errors.regulation_group_id[0]"
-          = content_tag "custom-select", "", { url: "/regulation_form_api/regulation_groups", "label-field" => "description", "code-field" => "regulation_group_id", "value-field" => "regulation_group_id",  "v-model" => "regulation.regulation_group_id", "name" => "regulation_form[regulation_group_id]", placeholder: "- select regulation group -", "allow-clear" => true }
+          = content_tag "custom-select", "", { url: "/regulation_form_api/regulation_groups", "label-field" => "description", "code-field" => "regulation_group_id", "value-field" => "regulation_group_id",  "v-model" => "regulation.regulation_group_id", "name" => "regulation_form[regulation_group_id]", placeholder: "- select regulation group -", "allow-clear" => true, "code-class-name" => "prefix--regulation-group" }
 
 
     h4.heading-small

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -7,7 +7,7 @@ script type="text/x-template" id="condition-template"
             | Condition
             span.form-hint
               | You can optionally select conditions that will determine the customs treatment of the goods this measure applies to.
-          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select condition ―" }
+          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select condition ―", "code-class-name" => "prefix--condition" }
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showMinimumPrice" do
         .form-group
@@ -45,7 +45,7 @@ script type="text/x-template" id="condition-template"
             | Certificate type
             span.form-hint
               | Select the type of certificate that will be required, or select 'no certificate presented' to define the action for that case.
-          = content_tag "custom-select", "", { url: "/certificate_types", "v-model" => "condition.certificate_type_code", "codeField" => "certificate_type_code", "valueField" => "certificate_type_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate type ―" }
+          = content_tag "custom-select", "", { url: "/certificate_types", "v-model" => "condition.certificate_type_code", "codeField" => "certificate_type_code", "valueField" => "certificate_type_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate type ―", "code-class-name" => "prefix--certificate-type" }
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showCertificate" do
         .form-group
@@ -53,7 +53,7 @@ script type="text/x-template" id="condition-template"
             | Certificate
             span.form-hint
               | Select the type of certificate that will be required, or select 'no certificate presented' to define the action for that case.
-          = content_tag "custom-select", "", { url: "/certificates", "v-model" => "condition.certificate_code", "codeField" => "certificate_code", "valueField" => "certificate_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate ―", "drilldown-name" => "certificate_type_code", ":drilldown-value" => "condition.certificate_type_code", ":drilldown-required" => "showCertificateType" }
+          = content_tag "custom-select", "", { url: "/certificates", "v-model" => "condition.certificate_code", "codeField" => "certificate_code", "valueField" => "certificate_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate ―", "drilldown-name" => "certificate_type_code", ":drilldown-value" => "condition.certificate_type_code", ":drilldown-required" => "showCertificateType", "code-class-name" => "prefix--certificate" }
 
       = content_tag :div, { class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showAction" } do
         .form-group
@@ -63,7 +63,7 @@ script type="text/x-template" id="condition-template"
               | Define the action to take when the specified certificate (or no certificate) is presented.
             = content_tag :span, { class: "form-hint", "v-if" => "noCertificateActionHint" } do
               | Define the action to take if the condition is met.
-          = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action" }
     = content_tag :div, { class: "condition-components-wrapper", "v-if" => "showConditionComponents" } do
       .measure-condition-components
         div.measure-condition-component v-for="(measureConditionComponent, index) in condition.measure_condition_components"

--- a/app/views/shared/vue_templates/_footnote.html.slim
+++ b/app/views/shared/vue_templates/_footnote.html.slim
@@ -5,7 +5,7 @@ script type="text/x-template" id="footnote-template"
         | Footnote type
       .row
         .col-md-5
-          = content_tag "custom-select", "", { url: "/footnote_types", "label-field" => "description", "value-field" => "footnote_type_id", "code-field" => "footnote_type_id", "v-model" => "footnote.footnote_type_id", "placeholder" => "― select the footnote type to use ―", "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/footnote_types", "label-field" => "description", "value-field" => "footnote_type_id", "code-field" => "footnote_type_id", "v-model" => "footnote.footnote_type_id", "placeholder" => "― select the footnote type to use ―", "date-sensitive" => true, "code-class-name" => "prefix--footnote-type" }
     div v-if="footnote.footnote_type_id"
       .row
         .col-md-8

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -4,7 +4,7 @@ script type="text/x-template" id="measure-component-template"
       .form-group
         label.form-label
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_id", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_id", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression" }
 
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
@@ -52,17 +52,17 @@ script type="text/x-template" id="measure-component-template"
       .form-group
         label.form-label
           | Monetary unit
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label
           | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true }
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label
           | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier" }
 

--- a/app/views/shared/vue_templates/_measure_condition_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.slim
@@ -4,7 +4,7 @@ script type="text/x-template" id="measure-condition-component-template"
       .form-group
         label.form-label
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_id", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―" }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_id", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression" }
 
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
@@ -52,17 +52,17 @@ script type="text/x-template" id="measure-condition-component-template"
       .form-group
         label.form-label
           | Monetary unit
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label
           | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true }
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label
           | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier" }
 

--- a/app/views/shared/vue_templates/_measure_origin.html.slim
+++ b/app/views/shared/vue_templates/_measure_origin.html.slim
@@ -3,7 +3,7 @@ script type="text/x-template" id="measure-origin-template"
     .multiple-choice
       input type='radio' :id="radioID" class="radio-inline-group" name="geographical_area_type" :checked="origin.selected"
       label v-if="notErgaOmnes"
-        = content_tag "custom-select", "", { ":options" => "optionsForSelect", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", ":placeholder": "placeholder", "v-model" => "origin.geographical_area_id", class: "origin-select" }
+        = content_tag "custom-select", "", { ":options" => "optionsForSelect", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", ":placeholder": "placeholder", "v-model" => "origin.geographical_area_id", class: "origin-select", "code-class-name" => "prefix--region" }
       label :for="radioID" v-else=""
         | ERGA OMNES (all origins)
 
@@ -14,7 +14,7 @@ script type="text/x-template" id="measure-origin-template"
       .exclusions-target
         .exclusion v-for="exclusion in origin.exclusions"
           .exclusion-select
-            = content_tag "custom-select", "", { ":options" => "exclusion.options", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", "placeholder": "― start typing ―", "min-length" => 1, "v-model" => "exclusion.geographical_area_id", class: "origin-select" }
+            = content_tag "custom-select", "", { ":options" => "exclusion.options", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", "placeholder": "― start typing ―", "min-length" => 1, "v-model" => "exclusion.geographical_area_id", class: "origin-select", "code-class-name" => "prefix--country" }
           .exclusion-actions v-if="origin.exclusions.length > 1"
             a.remove-link v-on:click.prevent="removeExclusion(exclusion)"
                | Remove

--- a/app/views/shared/vue_templates/_quota_period.html.slim
+++ b/app/views/shared/vue_templates/_quota_period.html.slim
@@ -1,7 +1,7 @@
 script type="text/x-template" id="quota-period-template"
   div
     .row
-      .col-md-5
+      .col-md-3
         .form-group v-if="isFirst"
           label.form-label
             | Quota period
@@ -136,15 +136,15 @@ script type="text/x-template" id="quota-period-template"
         .form-group
           label.form-label
             | Monetary unit
-          = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "quotaPeriod.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true }
-      .col-md-3
+          = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "quotaPeriod.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit" }
+      .col-md-4
         .form-group
           label.form-label
             | Measurement unit
-          = content_tag "custom-select", "", { url: "/measurement_units", "labelField" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "quotaPeriod.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/measurement_units", "labelField" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "quotaPeriod.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit" }
       .col-md-4
         .form-group
           label.form-label
             | Measurement unit qualifier
-          = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "labelField" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "quotaPeriod.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true }
+          = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "labelField" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "quotaPeriod.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier" }
 


### PR DESCRIPTION
Measurement units and duty expression codes have abbreviations which are
more commonly used in place of the description or code, so makes sense
to use them.

Also took the time to properly align all dropdown codes with their
descriptions so not too much nor too little spacing was between them.

**ps: I know this is stuff related mostly to measure form, but since regulations-form branch has the most up-to-date code, made sense to me to PR against it**

![screen shot 2018-04-23 at 14 34 54](https://user-images.githubusercontent.com/758001/39143346-12ad4174-4704-11e8-9427-a796a9a46367.png)
![screen shot 2018-04-23 at 14 35 11](https://user-images.githubusercontent.com/758001/39143347-12d4fc32-4704-11e8-8b36-66188210d812.png)
