### PR TITLE
Making duty expressions easier to select and fill

### DIFF
--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -13,6 +13,10 @@ function debounce(func, wait, immediate) {
   };
 };
 
+function clone(obj) {
+  return JSON.parse(JSON.stringify(obj));
+}
+
 $(document).ready(function() {
 
   var form = document.querySelector(".measure-form");
@@ -109,14 +113,6 @@ $(document).ready(function() {
       }
 
       this.fetchNomenclatureCode("/goods_nomenclatures", 10, "goods_nomenclature_code", "goods_nomenclature_code_description");
-
-      // $("#measure_form_measure_type_series_id").on("change", function() {
-      //   self.measure.measure_type_series_id = $("#measure_form_measure_type_series_id").val();
-      // });
-
-      // $("#measure_form_measure_type_id").on("change", function() {
-      //   self.measure.measure_type_id = $("#measure_form_measure_type_id").val();
-      // });
 
       $(".measure-form").on("submit", function(e) {
         e.preventDefault();
@@ -303,10 +299,7 @@ $(document).ready(function() {
           additional_code_type_id: this.measure.additional_code_type_id,
           goods_nomenclature_code_description: this.measure.goods_nomenclature_code_description,
           additional_code_description: this.measure.additional_code_description,
-
-          measure_components: this.measure.measure_components,
           footnotes: this.measure.footnotes,
-          conditions: this.measure.conditions,
 
           existing_quota: this.measure.existing_quota === "existing",
           quota_status: this.measure.quota_status,
@@ -314,6 +307,32 @@ $(document).ready(function() {
           quota_criticality_threshold: this.measure.quota_criticality_threshold,
           quota_description: this.measure.quota_description
         };
+
+        try {
+          payload.measure_components = this.measure.measure_components.map(function(component) {
+            var c = clone(component);
+            // to ignore A and B
+            c.duty_expression_id = c.duty_expression_id.substring(0, 2);
+
+            return c;
+          });
+
+          payload.conditions = this.measure.conditions.map(function(condition) {
+            var c = clone(condition);
+
+            c.measure_condition_components = c.measure_condition_components.map(function(component) {
+              var c = clone(component);
+              // to ignore A and B
+              c.duty_expression_id = c.duty_expression_id.substring(0, 2);
+
+              return c;
+            });
+
+            return c;
+          });
+        } catch (e) {
+
+        }
 
         if (this.origins.country.selected) {
           payload.geographical_area_id = this.origins.country.geographical_area_id;

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -17,7 +17,8 @@ Vue.component('custom-select', {
     "allowClear",
     "name",
     "codeClassName",
-    "abbreviationClassName"
+    "abbreviationClassName",
+    "optionsFilter"
   ],
   data: function() {
     return {
@@ -56,7 +57,11 @@ Vue.component('custom-select', {
     }
 
     if (this.options) {
-      options["options"] = this.options;
+      try {
+        options["options"] = this.optionsFilter(this.options);
+      } catch (e) {
+        options["options"] = this.options;
+      }
     }
 
     if (this.url && !this.minLength) {
@@ -105,7 +110,11 @@ Vue.component('custom-select', {
             callback();
           },
           success: function(res) {
-            callback(res);
+            try {
+              callback(vm.optionsFilter(res));
+            } catch (e) {
+              callback(res);
+            }
           }
         });
       }
@@ -173,7 +182,11 @@ Vue.component('custom-select', {
               callback();
             },
             success: function(res) {
-              callback(res);
+              try {
+                callback(vm.optionsFilter(res));
+              } catch (e) {
+                callback(res);
+              }
             }
           });
         });

--- a/app/assets/javascripts/vue_components/measure-components.js
+++ b/app/assets/javascripts/vue_components/measure-components.js
@@ -6,17 +6,17 @@ var componentCommonFunctionality = {
       return ids.indexOf(this[this.thing].duty_expression_id) > -1;
     },
     showDutyAmountPercentage: function() {
-      var ids = ["23"];
+      var ids = ["23", "01A", "04A", "19A", "20A"];
 
       return ids.indexOf(this[this.thing].duty_expression_id) > -1;
     },
     showDutyAmountNegativePercentage: function() {
-      var ids = ["36"];
+      var ids = ["36", "02A"];
 
       return ids.indexOf(this[this.thing].duty_expression_id) > -1;
     },
     showDutyAmountNumber: function() {
-      var ids = ["06", "07", "09", "11", "12", "13", "14", "21", "25", "27", "29", "31"];
+      var ids = ["01B", "04B", "19B", "20B", "06", "07", "09", "11", "12", "13", "14", "21", "25", "27", "29", "31"];
 
       return ids.indexOf(this[this.thing].duty_expression_id) > -1;
     },
@@ -27,6 +27,11 @@ var componentCommonFunctionality = {
     },
     showDutyAmountMaximum: function() {
       var ids = ["17", "35"];
+
+      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
+    },
+    showDutyAmountNegativeNumber: function() {
+      var ids = ["02B"];
 
       return ids.indexOf(this[this.thing].duty_expression_id) > -1;
     },
@@ -43,9 +48,85 @@ var componentCommonFunctionality = {
              this.showDutyRefundAmount;
     },
     showMeasurementUnit: function() {
-      var ids = ["23", "36", "37"];
+      var ids = ["23", "36", "37", "01A", "04A", "19A", "20A", "02A"];
 
       return this[this.thing].duty_expression_id && ids.indexOf(this[this.thing].duty_expression_id) === -1;
+    }
+  },
+  methods: {
+    expressionsFriendlyDuplicate: function(options) {
+      var newOptions = [];
+
+      options.forEach(function(option) {
+        option.duty_expression_code = option.duty_expression_id;
+        var newOption = null;
+
+        if (option.duty_expression_id === "01") {
+          option.duty_expression_id = "01A";
+          option.description = "% (ad valorem)";
+          option.abbreviation = "+ %";
+
+          newOption = {
+            duty_expression_code: option.duty_expression_code,
+            duty_expression_id: "01B",
+            description: "Specific duty rate",
+            abbreviation: "+ €"
+          };
+        } else if (option.duty_expression_id === "02") {
+          option.duty_expression_id = "02A";
+          option.description = "Minus %";
+          option.abbreviation = "- %";
+
+          newOption = {
+            duty_expression_code: option.duty_expression_code,
+            duty_expression_id: "02B",
+            description: "Minus amount",
+            abbreviation: "- €"
+          };
+        } else if (option.duty_expression_id === "04") {
+          option.duty_expression_id = "04A";
+          option.description = "Plus %";
+          option.abbreviation = "+ %";
+
+          newOption = {
+            duty_expression_code: option.duty_expression_code,
+            duty_expression_id: "04B",
+            description: "Plus amount",
+            abbreviation: "+ €"
+          };
+        } else if (option.duty_expression_id === "19") {
+          option.duty_expression_id = "19A";
+          option.description = "Plus %";
+          option.abbreviation = "+ %";
+
+          newOption = {
+            duty_expression_code: option.duty_expression_code,
+            duty_expression_id: "19B",
+            description: "Plus amount",
+            abbreviation: "+ €"
+          };
+        } else if (option.duty_expression_id === "20") {
+          option.duty_expression_id = "20A";
+          option.description = "Plus %";
+          option.abbreviation = "+ %";
+
+          newOption = {
+            duty_expression_code: option.duty_expression_code,
+            duty_expression_id: "20B",
+            description: "Plus amount",
+            abbreviation: "+ €"
+          };
+        }
+
+        newOptions.push(option);
+
+        if (newOption) {
+          newOptions.push(newOption);
+        }
+      });
+
+
+      return newOptions;
     }
   }
 };

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -16,6 +16,10 @@ input.date-picker {
   }
 }
 
+.measure-form [class*="col-"] {
+  justify-content: flex-end;
+}
+
 .help-block {
   color: $secondary-text-colour;
   margin: 0 0 0.3em;

--- a/app/assets/stylesheets/simple-grid.scss
+++ b/app/assets/stylesheets/simple-grid.scss
@@ -35,14 +35,14 @@ $maxcol: $site-width / 12;
 
 @each $col in $cols {
   .col-#{$col} {
-    width: $maxcol * $col;
-    max-width: calc(#{$single * $col} - 30px);
+    max-width: $maxcol * $col;
+    width: calc(#{$single * $col} - 30px);
     flex: 0 0 calc(#{$single * $col} - 30px);
   }
 
   .col-xs-#{$col} {
-    width: $maxcol * $col;
-    max-width: calc(#{$single * $col} - 30px);
+    max-width: $maxcol * $col;
+    width: calc(#{$single * $col} - 30px);
     flex: 0 0 calc(#{$single * $col} - 30px);
   }
 }
@@ -50,8 +50,8 @@ $maxcol: $site-width / 12;
 @media (min-width: 768px) {
   @each $col in $cols {
     .col-sm-#{$col} {
-      width: $maxcol * $col;
-      max-width: calc(#{$single * $col} - 30px);
+      max-width: $maxcol * $col;
+      width: calc(#{$single * $col} - 30px);
       flex: 0 0 calc(#{$single * $col} - 30px);
     }
   }
@@ -60,8 +60,8 @@ $maxcol: $site-width / 12;
 @media (min-width: 992px) {
   @each $col in $cols {
     .col-md-#{$col} {
-      width: $maxcol * $col;
-      max-width: calc(#{$single * $col} - 30px);
+      max-width: $maxcol * $col;
+      width: calc(#{$single * $col} - 30px);
       flex: 0 0 calc(#{$single * $col} - 30px);
     }
   }
@@ -70,8 +70,8 @@ $maxcol: $site-width / 12;
 @media (min-width: 1024px) {
   @each $col in $cols {
     .col-lg-#{$col} {
-      width: $maxcol * $col;
-      max-width: calc(#{$single * $col} - 30px);
+      max-width: $maxcol * $col;
+      width: calc(#{$single * $col} - 30px);
       flex: 0 0 calc(#{$single * $col} - 30px);
     }
   }
@@ -80,8 +80,8 @@ $maxcol: $site-width / 12;
 @media (min-width: 1600px) {
   @each $col in $cols {
     .col-xl-#{$col} {
-      width: $maxcol * $col;
-      max-width: calc(#{$single * $col} - 30px);
+      max-width: $maxcol * $col;
+      width: calc(#{$single * $col} - 30px);
       flex: 0 0 calc(#{$single * $col} - 30px);
     }
   }

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -1,10 +1,10 @@
 script type="text/x-template" id="measure-component-template"
   .row
-    .col-md-3
+    .col-md-4
       .form-group
         label.form-label
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_id", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression" }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate" }
 
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group

--- a/app/views/shared/vue_templates/_measure_condition_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.slim
@@ -1,10 +1,10 @@
 script type="text/x-template" id="measure-condition-component-template"
   .row
-    .col-md-3
+    .col-md-4
       .form-group
         label.form-label
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_id", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression" }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate" }
 
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
@@ -28,6 +28,12 @@ script type="text/x-template" id="measure-condition-component-template"
       .form-group
         label.form-label
           | Duty amount (€)
+        input.form-control v-model="measureConditionComponent.amount"
+
+    .col-md-3 v-if="showDutyAmountNegativeNumber"
+      .form-group
+        label.form-label
+          | Duty amount (-€)
         input.form-control v-model="measureConditionComponent.amount"
 
     .col-md-3 v-if="showDutyAmountMinimum"


### PR DESCRIPTION
Separating "% or amount" duty expressions logically on the frontend so
users can select more appropriate options, and have the UI change
accordingly.

Affected expressions: 01, 02, 04, 19, 20

![screen shot 2018-05-01 at 14 24 22](https://user-images.githubusercontent.com/758001/39485303-be4ea00e-4d4e-11e8-8d4f-000e14838d0e.png)
