### PR TITLE
[SECURITY UPDATES] updated 'sinatra' gem to '2.0.2'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 ruby "~> 2.5.0"
 
 gem "rails", "5.1.5"
+gem "sinatra", "~> 2.0.2"
 
 # DB
 gem "pg", "0.18.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -809,7 +809,7 @@ GEM
     rabl (0.13.1)
       activesupport (>= 2.3.14)
     rack (2.0.4)
-    rack-protection (2.0.1)
+    rack-protection (2.0.2)
       rack
     rack-test (1.0.0)
       rack (>= 1.0, < 3)
@@ -935,10 +935,10 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (2.0.1)
+    sinatra (2.0.2)
       mustermann (~> 1.0)
       rack (~> 2.0)
-      rack-protection (= 2.0.1)
+      rack-protection (= 2.0.2)
       tilt (~> 2.0)
     slim (3.0.9)
       temple (>= 0.7.6, < 0.9)
@@ -1055,6 +1055,7 @@ DEPENDENCIES
   simple_form (~> 3.5)
   simplecov (~> 0.14.1)
   simplecov-rcov!
+  sinatra (~> 2.0.2)
   slim-rails
   tilt
   uglifier (~> 2.7)


### PR DESCRIPTION
Snyk detected possible vulnerability in 'sinatra' gem less than '2.0.2'

[SNYK REPORTED ISSUE DETAILS](https://snyk.io/vuln/SNYK-RUBY-SINATRA-22027?utm_source=slack)

[TRELLO CARD](https://trello.com/c/s0cA5djh/218-update-gems-for-security-across-app-tariff-apps)