### PR TITLE
[BULK EDIT of MEASURES] add ID of comformance rule applied in validation details popup

### DIFF
--- a/app/value_objects/measures/validation_helper.rb
+++ b/app/value_objects/measures/validation_helper.rb
@@ -18,7 +18,9 @@ module Measures
 
         if measure.conformance_errors.present?
           measure.conformance_errors.map do |error_code, error_details_list|
-            @errors[get_error_area(error_code)] = error_details_list
+            @errors[get_error_area(error_code)] = error_details_list.map do |error_message|
+              "#{error_code}: #{error_message}"
+            end.uniq
           end
         end
       end


### PR DESCRIPTION
[TRELLO CARD](https://trello.com/c/aFkYx1Gf/343-dit-bulk-edit-of-measures-add-the-rule-id-number-in-the-conformance-error-eg-me1-in-a-validation-popup)

![example](https://user-images.githubusercontent.com/358508/42340864-e35f44f6-8099-11e8-90eb-3d83d07b9d17.png)
