### PR TITLE
Bulk Edit - Additional Code update JSON object key options to more usefull

### DIFF
--- a/app/assets/javascripts/components/bulk-edit-measures.js
+++ b/app/assets/javascripts/components/bulk-edit-measures.js
@@ -46,7 +46,7 @@ $(document).ready(function() {
           { value: 'change_footnotes', label: 'Change footnotes...' },
           { value: 'change_status', label: 'Change status...' },
           { value: 'remove_from_group', label: 'Remove from group...' },
-          { value: 'delete', label: 'Delete...' },
+          { value: 'delete', label: 'Delete measures' },
         ],
         measures: [],
         changingDuties: false,

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -488,7 +488,7 @@ class Measure < Sequel::Model
   end
 
   def sent_to_cds?
-    status.blank? || status.to_s.in?(::Workbasket::SENT_TO_CDS_STATES)
+    status.blank? || status.to_s.in?(::Workbaskets::Workbasket::SENT_TO_CDS_STATES)
   end
 
   def additional_code_title

--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -494,7 +494,7 @@ class Measure < Sequel::Model
   def additional_code_title
     return "" if additional_code_id.blank?
 
-    "#{additional_code_type_id} #{additional_code_id}"
+    "#{additional_code_type_id}#{additional_code_id}"
   end
 
   def record_code
@@ -549,7 +549,7 @@ class Measure < Sequel::Model
       validity_start_date: validity_start_date.try(:strftime, "%d %b %Y"),
       validity_end_date: validity_end_date.try(:strftime, "%d %b %Y") || "-",
       goods_nomenclature: goods_nomenclature.try(:to_json),
-      additional_code: additional_code.try(:to_json),
+      additional_code: additional_code_title,
       geographical_area: geographical_area.try(:to_json),
       excluded_geographical_areas: excluded_geographical_areas.map(&:to_json),
       measure_components: measure_components.map(&:to_json),


### PR DESCRIPTION
Currently it looks like:

```
"additional_code"=>{"type_id"=>"2", "description"=>"Imported by land, inland waterway or sea or imported by air.", "additional_code"=>"550"}
```

We do not need such more values, we need just code here:
```
"additional_code"=>"[CODE HERE]"
```

EG:
```
"additional_code"=>"2550"
```

[TRELLO CARD](https://trello.com/c/u1DAWOlM/344-dit-bulk-edit-additional-code-update-json-object-key-options-to-more-usefull)