### PR TITLE
[DIT] Create regulations - SENTRY reported issue 'wrong constant name_REQUIRED_PARAMS'

### DIFF
--- a/app/interactors/regulation_saver.rb
+++ b/app/interactors/regulation_saver.rb
@@ -367,7 +367,7 @@ class RegulationSaver
     end
 
     def check_required_params!
-      if target_class.blank?
+      if target_class.to_s.blank?
         @errors[:role] = "You need to specify the regulation type!"
 
         return false

--- a/app/interactors/regulation_saver.rb
+++ b/app/interactors/regulation_saver.rb
@@ -367,6 +367,12 @@ class RegulationSaver
     end
 
     def check_required_params!
+      if target_class.blank?
+        @errors[:role] = "You need to specify the regulation type!"
+
+        return false
+      end
+
       target_class_required_params.map do |k|
         if original_params[k.to_s].blank?
           @errors[k] = "#{k.to_s.capitalize.split('_').join(' ')} can't be blank!"


### PR DESCRIPTION
SENTRY ISSUE RELATED: https://sentry.io/bit-zesty-client-apps/management/issues/602327087/

Issue happens if submit blank form.

![regulation_create_flow_added_validation](https://user-images.githubusercontent.com/358508/42459750-00d0833e-83a5-11e8-95eb-679671eb4ab0.png)

[TRELLO CARD](https://trello.com/c/9SCluIDP/346-dit-create-regulations-sentry-reported-issue-wrong-constant-name-requiredparams-https-sentryio-bit-zesty-client-apps-management)