### PR TITLE
Bulk edit popup fixes

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 //= require vue
 //= require vue-resource
 //= require ./vendors/vue-virtual-scroller.min
+//= require ./components/utils
 //= require_tree ./vue_components
 //= require_tree .
 

--- a/app/assets/javascripts/components/bulk-edit-measures.js
+++ b/app/assets/javascripts/components/bulk-edit-measures.js
@@ -165,7 +165,7 @@ $(document).ready(function() {
             status: measure.status,
             visible: measure.visible,
             validity_start_date: measure.validity_start_date,
-            validity_end_date: measure.validity_end_date,
+            validity_end_date: measure.validity_end_date || "&ndash;",
             changes: measure.changes
           }
         });

--- a/app/assets/javascripts/components/bulk-edit-measures.js
+++ b/app/assets/javascripts/components/bulk-edit-measures.js
@@ -34,17 +34,14 @@ $(document).ready(function() {
         ],
         actions: [
           { value: 'toggle_unselected', label: 'Hide/Show unselected items' },
-          { value: 'make_copies', label: 'Make copies...' },
           { value: 'change_regulation', label: 'Change generating regulation' },
           { value: 'change_validity_period', label: 'Change validity period...' },
           { value: 'change_origin', label: 'Change origin...' },
           { value: 'change_commodity_codes', label: 'Change commodity codes...' },
           { value: 'change_additional_code', label: 'Change additional code...' },
-          { value: 'change_quota', label: 'Change quota...' },
           { value: 'change_duties', label: 'Change duties...' },
           { value: 'change_conditions', label: 'Change conditions...' },
           { value: 'change_footnotes', label: 'Change footnotes...' },
-          { value: 'change_status', label: 'Change status...' },
           { value: 'remove_from_group', label: 'Remove from group...' },
           { value: 'delete', label: 'Delete measures' },
         ],
@@ -57,13 +54,10 @@ $(document).ready(function() {
         changingAdditionalCode: false,
         changingCommodityCodes: false,
         changingOrigin: false,
-        makingCopies: false,
         changingRegulation: false,
         changingValidityPeriod: false,
-        changingQuota: false,
-        changingStatus: false,
         isLoading: true,
-        selectedAllMeasures: false,
+        selectedAllMeasures: true,
         pagination: {
           total_count: window.__pagination_metadata.total_count,
           page: window.__pagination_metadata.page,
@@ -154,7 +148,7 @@ $(document).ready(function() {
             measure_sid: measure.measure_sid,
             regulation: measure.regulation.formatted_id,
             measure_type_id: measure.measure_type.measure_type_id,
-            goods_nomenclature: measure.goods_nomenclature.goods_nomenclature_item_id,
+            goods_nomenclature: measure.goods_nomenclature ? measure.goods_nomenclature.goods_nomenclature_item_id : "-",
             additional_code: measure.additional_code || "-",
             geographical_area: origin,
             excluded_geographical_areas: formatted_exclusions,
@@ -203,9 +197,6 @@ $(document).ready(function() {
           case 'toggle_unselected':
             this.toggleUnselected();
             break;
-          case 'make_copies':
-            this.makingCopies = true;
-            break;
           case 'change_regulation':
             this.changingRegulation = true;
             break;
@@ -221,9 +212,6 @@ $(document).ready(function() {
           case 'change_additional_code':
             this.changingAdditionalCode = true;
             break;
-          case 'change_quota':
-            this.changingQuota = true;
-            break;
           case 'change_duties':
             this.changingDuties = true;
             break;
@@ -232,9 +220,6 @@ $(document).ready(function() {
             break;
           case 'change_footnotes':
             this.changingFootnotes = true;
-            break;
-          case 'change_status':
-            this.changingStatus = true;
             break;
           case 'remove_from_group':
             this.removingFromGroup = true;
@@ -253,11 +238,8 @@ $(document).ready(function() {
         this.changingAdditionalCode = false;
         this.changingCommodityCodes = false;
         this.changingOrigin = false;
-        this.makingCopies = false;
         this.changingRegulation = false;
         this.changingValidityPeriod = false;
-        this.changingQuota = false;
-        this.changingStatus = false;
       },
       loadMeasures: function(page, callback) {
         var self = this;

--- a/app/assets/javascripts/components/measure-condition-formatter.js
+++ b/app/assets/javascripts/components/measure-condition-formatter.js
@@ -7,7 +7,7 @@ window.MeasureConditionFormatter = {
 
     var res = [];
 
-    if (mc.component_sequence_number !== null) {
+    if (mc.component_sequence_number) {
       res = ["" + mc.measure_condition_code.condition_code + mc.component_sequence_number];
     } else {
       res = [ mc.condition_code ];
@@ -21,6 +21,10 @@ window.MeasureConditionFormatter = {
 
     if (action_code) {
       res.push(action_code);
+    }
+
+    if (certificate_type_code === undefined || certificate_code === undefined) {
+      console.log(mc, res);
     }
 
     if (res.length === 2) {

--- a/app/assets/javascripts/components/utils.js
+++ b/app/assets/javascripts/components/utils.js
@@ -1,0 +1,18 @@
+function ordinal(n) {
+  var nHundreds = n % 100;
+  var nDecimal = n % 10;
+
+  if ([11, 12, 13].indexOf(nHundreds) > -1) {
+    return n + "th"
+  }
+
+  if (nDecimal === 1) {
+    return n + "st";
+  } else if (nDecimal === 2) {
+    return n + "nd";
+  } else if (nDecimal === 3) {
+    return n + "rd";
+  }
+
+  return n + "th";
+}

--- a/app/assets/javascripts/vue_components/change-conditions-popup.js
+++ b/app/assets/javascripts/vue_components/change-conditions-popup.js
@@ -1,21 +1,22 @@
 Vue.component("change-conditions-popup", {
   template: "#change-conditions-popup-template",
-  props: ["measures", "onClose", "open"],
+  props: ["measures", "onClose", "open", "index"],
   data: function() {
     return {
-      measureComponents: [],
+      conditions: [],
       replacing: false,
-      errors: []
+      errors: [],
+      mode: null
     };
   },
   mounted: function() {
     var self = this;
     var equal = true;
     var n = this.measures.length;
-    var dtCount = this.measures[0].measure_components.length;
+    var count = this.measures[0].measure_conditions.length;
 
     for (var i = 1; i < n; i++) {
-      if (dtCount != this.measures[i].measure_components.length) {
+      if (count != this.measures[i].measure_conditions.length) {
         equal = false;
         break;
       }
@@ -23,22 +24,16 @@ Vue.component("change-conditions-popup", {
 
     // count is equal
     if (equal) {
-      for (var i = 0; i < dtCount; i++) {
-        var dutyExpressionId = this.measures[0].measure_components[0].duty_expression_id;
-        var dutyExpressionAmount = this.measures[0].measure_components[0].amount;
-        var dutyExpressionMonetaryUnit = this.measures[0].measure_components[0].monetary_unit_id;
-        var dutyExpressionMeasurementUnit = this.measures[0].measure_components[0].measurement_unit_id;
-        var dutyExpressionMeasurementUnitQualifier = this.measures[0].measure_components[0].measurement_unit_qualifier_id;
+      for (var i = 0; i < count; i++) {
+        var first = this.normalizeCondition(this.measures[0].measure_conditions[i]);
 
         for (var j = 1; j < n; j++) {
-          if (dutyExpressionId != this.measures[j].measure_components[i].duty_expression_id ||
-              dutyExpressionAmount != this.measures[j].measure_components[i].amount ||
-              dutyExpressionMonetaryUnit != this.measures[j].measure_components[i].monetary_unit_id ||
-              dutyExpressionMeasurementUnit != this.measures[j].measure_components[i].measurement_unit_id ||
-              dutyExpressionMeasurementUnitQualifier != this.measures[j].measure_components[i].measurement_unit_qualifier_id) {
-                equal = false;
-                break;
-              }
+          var current = this.normalizeCondition(this.measures[j].measure_conditions[i]);
+
+          if (!this.equivalent(first, current)) {
+            equal = false;
+            break;
+          }
         }
       }
     }
@@ -46,45 +41,85 @@ Vue.component("change-conditions-popup", {
     this.replacing = !equal;
 
     if (equal) {
-      this.measureComponents = this.measures[0].measure_components.map(function(component) {
-        return {
-          duty_expression_id: self.getDutyExpressionId(component),
-          amount: component.duty_amount,
-          measurement_unit_code: component.measurement_unit ? component.measurement_unit.measurement_unit_code : null,
-          measurement_unit_qualifier_code: component.measurement_unit_qualifier ? component.measurement_unit_qualifier.measurement_unit_qualifier_code : null,
-          duty_expression: component.duty_expression,
-          measurement_unit: component.measurement_unit,
-          measurement_unit_qualifier: component.measurement_unit_qualifier,
-          monetary_unit: component.monetary_unit,
-          monetary_unit_code: component.monetary_unit ? component.monetary_unit.monetary_unit_code : null
-        };
+      var normalizeFunc = this.normalizeCondition.bind(this);
+      this.conditions = this.measures[0].measure_conditions.map(function(condition) {
+        var newCondition = normalizeFunc(condition);
+
+        if (newCondition.measure_condition_components.length === 0) {
+          newCondition.measure_condition_components.push({
+            duty_expression_id: null,
+            amount: null,
+            measurement_unit_code: null,
+            measurement_unit_qualifier_code: null,
+            duty_expression: null,
+            measurement_unit: null,
+            measurement_unit_qualifier: null,
+            monetary_unit: null,
+            monetary_unit_code: null
+          });
+        }
+
+        return newCondition;
       });
+
+      if (this.measures[0].measure_conditions.length === 0) {
+        this.addCondition();
+      }
     } else {
-      this.addDutyExpression();
+      this.addCondition();
     }
   },
   computed: {
     multiple: function() {
       return this.measures.length > 1;
     },
-    canRemoveMeasureComponent: function() {
-      return this.measureComponents.length > 1;
+    canRemoveMeasureCondition: function() {
+      return this.conditions.length > 1;
     }
   },
   methods: {
+    normalizeComponent: function(component) {
+      return {
+        duty_expression_id: this.getDutyExpressionId(component),
+        amount: component.duty_amount,
+        measurement_unit_code: component.measurement_unit ? component.measurement_unit.measurement_unit_code : null,
+        measurement_unit_qualifier_code: component.measurement_unit_qualifier ? component.measurement_unit_qualifier.measurement_unit_qualifier_code : null,
+        duty_expression: component.duty_expression,
+        measurement_unit: component.measurement_unit,
+        measurement_unit_qualifier: component.measurement_unit_qualifier,
+        monetary_unit: component.monetary_unit,
+        monetary_unit_code: component.monetary_unit ? component.monetary_unit.monetary_unit_code : null
+      };
+    },
+    normalizeCondition: function(condition) {
+      return {
+        measure_condition_code: condition.measure_condition_code,
+        condition_code: condition.measure_condition_code ? condition.measure_condition_code.condition_code : null,
+        action_code: condition.measure_action ? condition.measure_action.action_code : null,
+        measure_action: condition.measure_action,
+        certificate_type_id: condition.certificate_type ? condition.certificate_type.certificate_type_id : null,
+        certificate_id: condition.certificate ? condition.certificate_id : null,
+        certificate_type: condition.certificate_type,
+        certificate: condition.certificate,
+        measure_condition_components: condition.measure_condition_components.map(this.normalizeComponent)
+      };
+    },
+    equivalent: function(c1, c2) {
+      var str_c1 = JSON.stringify(c1.measure_condition_components);
+      var str_c2 = JSON.stringify(c2.measure_condition_components);
+
+      if (c1.action_code != c2.action_code ||
+          c1.condition_code != c2.condition_code ||
+          c1.certificate_type_id != c2.certificate_type_id ||
+          c1.certificate_id != c2.certificate_id ||
+          str_c1 != str_c2) {
+            return false;
+      }
+
+      return true;
+    },
     validate: function() {
       var errors = [];
-      var amountRegex = new RegExp(/^([\d]+)[\.]?[\d]*$/g);
-
-      this.measureComponents.forEach(function(mc, index) {
-        if (!mc.duty_expression_id || mc.duty_expression_id == "37") {
-          return;
-        }
-
-        if (!mc.amount || !amountRegex.test(mc.amount)) {
-          errors.push("Amount field for " + ordinal(index + 1) + " duty expression is invalid");
-        }
-      });
 
       this.errors = errors;
 
@@ -105,29 +140,54 @@ Vue.component("change-conditions-popup", {
       return id + "A";
     },
     confirmChanges: function() {
-      var components = this.measureComponents;
+      var conditions = this.conditions;
+      var self = this;
 
       if (!this.validate()) {
         return;
       }
 
-      this.measures.forEach(function(measure) {
-        if (measure.changes.indexOf("duties") === -1) {
-          measure.changes.push("duties");
-        }
+      if (!this.replacing || (this.replacing && this.mode == "replace")) {
+        this.measures.forEach(function(measure) {
+          if (measure.changes.indexOf("conditions") === -1) {
+            measure.changes.push("conditions");
+          }
 
-        measure.measure_components.splice(0, 999);
+          measure.measure_conditions.splice(0, measure.measure_conditions.length);
 
-        components.forEach(function(component) {
-          measure.measure_components.push({
-            duty_amount: component.amount,
-            duty_expression: component.duty_expression,
-            measurement_unit: component.measurement_unit,
-            measurement_unit_qualifier: component.measurement_unit_qualifier,
-            monetary_unit: component.monetary_unit
+          conditions.forEach(function(condition) {
+            // this will take care of second radio button instructing
+            // users to leave blank to remove all conditions
+            if (!condition.condition_code) {
+              return;
+            }
+
+            measure.measure_conditions.push(condition);
           });
         });
-      });
+      } else {
+        // Existing conditions will be retained. Conditions specified here will not be added to any measures in which the exact same condition already exists.
+
+        this.measures.forEach(function(measure) {
+          if (measure.changes.indexOf("conditions") === -1) {
+            measure.changes.push("conditions");
+          }
+
+          conditions.forEach(function(condition) {
+            var found = false;
+
+            measure.measure_conditions.forEach(function(mc) {
+              if (self.equivalent(condition, mc)) {
+                found = true;
+              }
+            });
+
+            if (!found) {
+              measure.measure_conditions.push(condition);
+            }
+          })
+        });
+      }
 
       this.$emit("measures-updated");
       this.onClose();
@@ -135,21 +195,34 @@ Vue.component("change-conditions-popup", {
     triggerClose: function() {
       this.onClose();
     },
-    addDutyExpression: function() {
-      this.measureComponents.push({
-        duty_expression_id: null,
-        amount: null,
-        monetary_unit_code: null,
-        measurement_unit_code: null,
-        measurement_unit_qualifier_code: null,
-        duty_expression: null,
-        measurement_unit: null,
-        measurement_unit_qualifier: null,
-        monetary_unit: null
+    addCondition: function() {
+      this.conditions.push({
+        id: null,
+        condition_code: null,
+        action_code: null,
+        certificate_type_id: null,
+        certificate_id: null,
+        certificate_type: null,
+        certificate: null,
+        measure_action: null,
+        measure_condition: null,
+        measure_condition_components: [
+          {
+            duty_expression_id: null,
+            amount: null,
+            monetary_unit_code: null,
+            measurement_unit_code: null,
+            measurement_unit_qualifier_code: null,
+            duty_expression: null,
+            measurement_unit: null,
+            measurement_unit_qualifier: null,
+            monetary_unit: null
+          }
+        ]
       });
     },
-    removeMeasureComponent: function(measureComponent, index) {
-      this.measureComponents.splice(index, 1);
+    removeCondition: function(condition, indes) {
+      this.conditions.splice(index, 1);
     }
   }
 });

--- a/app/assets/javascripts/vue_components/change-conditions-popup.js
+++ b/app/assets/javascripts/vue_components/change-conditions-popup.js
@@ -1,5 +1,5 @@
-Vue.component("change-duties-popup", {
-  template: "#change-duties-popup-template",
+Vue.component("change-conditions-popup", {
+  template: "#change-conditions-popup-template",
   props: ["measures", "onClose", "open"],
   data: function() {
     return {
@@ -59,10 +59,6 @@ Vue.component("change-duties-popup", {
           monetary_unit_code: component.monetary_unit ? component.monetary_unit.monetary_unit_code : null
         };
       });
-
-      if (this.measures[0].measure_components.length === 0) {
-        this.addDutyExpression();
-      }
     } else {
       this.addDutyExpression();
     }

--- a/app/assets/javascripts/vue_components/change-duties-popup.js
+++ b/app/assets/javascripts/vue_components/change-duties-popup.js
@@ -73,8 +73,23 @@ Vue.component("change-duties-popup", {
   },
   methods: {
     validate: function() {
+      var errors = [];
+      var amountRegex = new RegExp(/^([\d]+)[\.]?[\d]*$/g);
 
-    }
+      this.measureComponents.forEach(function(mc, index) {
+        if (!mc.duty_expression_id || mc.duty_expression_id == "37") {
+          return;
+        }
+
+        if (!mc.amount || !amountRegex.test(mc.amount)) {
+          errors.push("Amount field for " + ordinal(index + 1) + " duty expression is invalid");
+        }
+      });
+
+      this.errors = errors;
+
+      return errors.length === 0;
+    },
     getDutyExpressionId: function(component) {
       var ids = ["01","02","04","19","20"];
       var id = component.duty_expression.duty_expression_id;

--- a/app/assets/javascripts/vue_components/change-duties-popup.js
+++ b/app/assets/javascripts/vue_components/change-duties-popup.js
@@ -4,7 +4,8 @@ Vue.component("change-duties-popup", {
   data: function() {
     return {
       measureComponents: [],
-      replacing: false
+      replacing: false,
+      errors: []
     };
   },
   mounted: function() {
@@ -71,6 +72,9 @@ Vue.component("change-duties-popup", {
     }
   },
   methods: {
+    validate: function() {
+
+    }
     getDutyExpressionId: function(component) {
       var ids = ["01","02","04","19","20"];
       var id = component.duty_expression.duty_expression_id;
@@ -87,6 +91,10 @@ Vue.component("change-duties-popup", {
     },
     confirmChanges: function() {
       var components = this.measureComponents;
+
+      if (!this.validate()) {
+        return;
+      }
 
       this.measures.forEach(function(measure) {
         if (measure.changes.indexOf("duties") === -1) {

--- a/app/assets/javascripts/vue_components/loading-indicator.js
+++ b/app/assets/javascripts/vue_components/loading-indicator.js
@@ -13,7 +13,7 @@ Vue.component("loading-indicator", {
       return ((done * 100) / total).toFixed(2);
     },
     start: function() {
-      return (this.metadata.page - 1) * this.metadata.per_page + 1;
+      return this.metadata.page * this.metadata.per_page + 1;
     },
     end: function() {
       return Math.min(this.start + this.metadata.per_page - 1, this.total);

--- a/app/assets/javascripts/vue_components/measure-components.js
+++ b/app/assets/javascripts/vue_components/measure-components.js
@@ -59,7 +59,7 @@ var componentCommonFunctionality = {
     expressionsFriendlyDuplicate: function(options) {
       return DutyExpressionsParser.parse(options);
     },
-    dutyExpressionSelected: function(item) {
+    onDutyExpressionSelected: function(item) {
       this[this.thing].duty_expression = item;
 
       if (!this.showMonetaryUnit) {
@@ -74,13 +74,13 @@ var componentCommonFunctionality = {
         this[this.thing].measurement_unit_qualifier = null;
       }
     },
-    monetaryUnitSelected: function(item) {
+    onMonetaryUnitSelected: function(item) {
       this[this.thing].monetary_unit = item;
     },
-    measurementUnitSelected: function(item) {
+    onMeasurementUnitSelected: function(item) {
       this[this.thing].measurement_unit = item;
     },
-    measurementUnitQualifierSelected: function(item) {
+    onMeasurementUnitQualifierSelected: function(item) {
       this[this.thing].measurement_unit_qualifier = item;
     }
   }

--- a/app/assets/javascripts/vue_components/measure-condition.js
+++ b/app/assets/javascripts/vue_components/measure-condition.js
@@ -1,6 +1,6 @@
 Vue.component('measure-condition', {
   template: "#condition-template",
-  props: ["condition"],
+  props: ["condition", "hideHelp"],
   computed: {
     showAction: function() {
       var codes = ["K", "P", "S", "W", "Y"];
@@ -99,6 +99,21 @@ Vue.component('measure-condition', {
       }
 
       this.condition.measure_condition_components.splice(idx, 1);
-    }
+    },
+    addCertificate: function() {
+
+    },
+    onConditionCodeSelected: function(obj) {
+      this.condition.measure_condition_code = obj;
+    },
+    onCertificateTypeSelected: function(obj) {
+      this.condition.certificate_type = obj;
+    },
+    onCertificateSelected: function(obj) {
+      this.condition.certificate = obj;
+    },
+    onActionSelected: function(obj) {
+      this.condition.measure_action = obj;
+    },
   }
 });

--- a/app/assets/javascripts/vue_components/measures-grid.js
+++ b/app/assets/javascripts/vue_components/measures-grid.js
@@ -110,22 +110,23 @@ Vue.component("measures-grid", {
     selectAll: function(val) {
       var self = this;
 
-      if (this.selectAllHasChanged) {
-        this.selectAllHasChanged(val);
-      }
-
       if (this.indirectSelectAll) {
         return;
       }
 
       if (this.onSelectAllChanged) {
         this.onSelectAllChanged(val);
-        return;
+
+        if(this.clientSorting !== true) {
+          return;
+        }
       }
 
       if (val) {
         this.data.map(function(row) {
-          self.onItemSelected(row.measure_sid);
+          if (self.selectedRows.indexOf(row.measure_sid) === -1) {
+            self.onItemSelected(row.measure_sid);
+          }
         });
       } else {
         this.data.map(function(row) {

--- a/app/assets/javascripts/vue_components/popup.js
+++ b/app/assets/javascripts/vue_components/popup.js
@@ -1,7 +1,7 @@
 window.___modal_count = 0;
 
 var template = [
-  '<div :id="\'modal-\' + id" aria-hidden="true" class="modal">',
+  '<div :id="\'modal-\' + id" aria-hidden="true" :class="[classes, \'modal\']">',
     '<div tabindex="-1" class="modal__overlay">',
       '<div role="dialog" class="modal__container" aria-modal="true" aria-labelledby="\'modal-\' + id + \'-title\'" >',
         '<header class="modal__header">',
@@ -20,7 +20,7 @@ var template = [
 
 Vue.component("pop-up", {
   template: template,
-  props: ["onClose", "open"],
+  props: ["onClose", "open", "classes"],
   data: function() {
     return {
       id: (++window.___modal_count)

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -86,7 +86,7 @@ label abbr {
   }
 }
 
-.condition {
+.measure-condition {
   padding: 15px 0 0;
 
   &:first-of-type {
@@ -101,9 +101,18 @@ label abbr {
     padding-bottom: 0 !important;
   }
 
-  & + .condition {
+  & + .measure-condition {
     margin-top: 15px;
     border-top: 1px solid #000;
+  }
+
+  .modal & {
+    padding: 0;
+
+    & + .measure-condition {
+      padding-top: 15px;
+      margin-top: 0;
+    }
   }
 }
 
@@ -125,6 +134,14 @@ label abbr {
   & + .measure-component {
     margin-top: 15px;
     border-top: 1px solid #000;
+  }
+
+  .modal & {
+    padding: 0;
+
+    & + .measure-component {
+      margin-top: 0;
+    }
   }
 }
 
@@ -194,8 +211,12 @@ label abbr {
     padding-bottom: 0;
   }
 
-  & + .condition {
-    border-top: 1px solid #000;
+  .modal & {
+    padding: 0;
+
+    & + .measure-condition-component {
+      margin-top: 0;
+    }
   }
 }
 
@@ -269,6 +290,20 @@ label abbr {
 .remove-link {
   color: $red;
   text-decoration: underline;
+}
+
+.form-group {
+  .multiple-choice {
+    label {
+      font-size: 1em !important;
+      max-width: 35em !important;
+
+      span.form-hint {
+        font-size: 1em !important;
+        margin: 0.5em 0 0;
+      }
+    }
+  }
 }
 
 .small-checkbox {

--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -99,3 +99,7 @@ html {
     margin-left: auto;
   }
 }
+
+.text-danger {
+  color: $red;
+}

--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -4,8 +4,6 @@
 }
 
 #wrapper {
-  max-width: none !important;
-  min-width: 1440px !important;
   padding: 0 15px;
   margin: 0 auto;
 }
@@ -27,13 +25,12 @@ html {
   background: #fff !important;
 }
 
-#global-header-bar, #global-cookie-message p, #footer .footer-wrapper {
-  max-width: none !important;
-  min-width: 1440px !important;
-}
-
-.header-wrapper {
-  max-width: none !important;
+#global-header-bar,
+#global-cookie-message p,
+#footer .footer-wrapper,
+.header-wrapper,
+#wrapper {
+  max-width: calc(100% - 60px) !important;
   min-width: 1440px !important;
 }
 

--- a/app/assets/stylesheets/components/modal.scss
+++ b/app/assets/stylesheets/components/modal.scss
@@ -30,6 +30,10 @@
   box-sizing: border-box;
   border: 2px solid $text-colour;
   box-shadow: 0 0 75px rgba(0, 0, 0, 0.3);
+
+  .conditions-popup & {
+    width: 1280px;
+  }
 }
 
 .modal__header {

--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -11,6 +11,7 @@ table {
     border-bottom: 1px solid $border-colour;
     height: 45px;
     overflow: hidden;
+    display: flex;
   }
 
   .table__column {

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -145,7 +145,7 @@ class MeasureCondition < Sequel::Model
       monetary_unit: monetary_unit.try(:to_json),
       measurement_unit_qualifier: measurement_unit_qualifier.try(:to_json),
       measure_condition_code: measure_condition_code.try(:to_json),
-      measure_condition_components: measure_condition_components.try(:to_json),
+      measure_condition_components: measure_condition_components.map(&:to_json),
       component_sequence_number: component_sequence_number
     }
   end

--- a/app/views/measures/bulks/edit.html.slim
+++ b/app/views/measures/bulks/edit.html.slim
@@ -35,7 +35,9 @@ form.bulk-edit-measures
 
   = render "measures/bulks/action_buttons"
 
-  = content_tag "change-duties-popup", nil, { "v-if" => "changingDuties", ":open" => "true", ":measures" => "selectedMeasureObjects", ":on-close" => "closeAllPopups" }
+  = content_tag "change-duties-popup", nil, { "v-if" => "changingDuties", ":open" => "true", ":measures" => "selectedMeasureObjects", ":on-close" => "closeAllPopups", "@measures-updated" => "measuresUpdated" }
+
+  = content_tag "change-conditions-popup", nil, { "v-if" => "changingConditions", ":open" => "true", ":measures" => "selectedMeasureObjects", ":on-close" => "closeAllPopups", "@measures-updated" => "measuresUpdated" }
 
   = content_tag "change-validity-period-popup", nil, { "v-if" => "changingValidityPeriod", ":open" => "true", ":measures" => "selectedMeasureObjects", ":on-close" => "closeAllPopups", "@measures-updated" => "measuresUpdated" }
 
@@ -54,6 +56,7 @@ form.bulk-edit-measures
 = render "shared/vue_templates/measures_grid"
 = render "shared/vue_templates/measure_origin"
 = render "shared/vue_templates/change_duties"
+= render "shared/vue_templates/change_conditions"
 = render "shared/vue_templates/change_regulation"
 = render "shared/vue_templates/change_commodity_codes"
 = render "shared/vue_templates/change_validity_period"

--- a/app/views/shared/vue_templates/_change_conditions.html.erb
+++ b/app/views/shared/vue_templates/_change_conditions.html.erb
@@ -1,0 +1,62 @@
+<script type="text/x-template" id="change-conditions-popup-template">
+  <pop-up :open="open" :on-close="triggerClose">
+    <template slot="title">
+      Change conditions
+    </template>
+
+    <div v-if="multiple">
+      <warning-message>
+        You are bulk-changing {{measures.length}} measures. Please check your inputs carefully!
+      </warning-message>
+    </div>
+
+    <div v-if="replacing">
+      <info-message>
+        The selection contains differing conditions.
+        <br />
+        These will be replaced with the conditions you configure here
+      </info-message>
+    </div>
+
+    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1" v-if="errors.length > 0">
+
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There are {{errors.length}} errors on the duty expressions entered
+      </h2>
+
+      <ul class="error-summary-list">
+        <li v-for="error in errors">{{error}}</li>
+      </ul>
+
+    </div>
+
+    <div class="measure-condition" v-for="(measureCondition, index) in conditions">
+      <measure-condition :condition="measureCondition" :index="index">
+        <div class="col-md-2">
+          <div class="form-group">
+            <a class="secondary-button text-danger" href="#" v-on:click.prevent="removeCondition(condition, index)" v-if="canRemoveMeasureCondition">
+              remove
+            </a>
+          </div>
+        </div>
+      </measure-condition>
+    </div>
+
+    <p>
+      <a href="#" v-on:click.prevent="addCondition">Add another condition</a>
+    </p>
+
+    <div v-if="replacing">
+
+    </div>
+
+    <div class="form-actions">
+      <button class="button" v-on:click.prevent="confirmChanges">
+        Update selected measures
+      </button>
+      <a href="#" class="secondary-button" v-on:click.prevent="onClose">
+        Cancel
+      </a>
+    </div>
+  </pop-up>
+</script>

--- a/app/views/shared/vue_templates/_change_conditions.html.erb
+++ b/app/views/shared/vue_templates/_change_conditions.html.erb
@@ -1,5 +1,5 @@
 <script type="text/x-template" id="change-conditions-popup-template">
-  <pop-up :open="open" :on-close="triggerClose">
+  <pop-up :open="open" :on-close="triggerClose" classes="conditions-popup">
     <template slot="title">
       Change conditions
     </template>
@@ -31,7 +31,7 @@
     </div>
 
     <div class="measure-condition" v-for="(measureCondition, index) in conditions">
-      <measure-condition :condition="measureCondition" :index="index">
+      <measure-condition :condition="measureCondition" :index="index" :hide-help="true">
         <div class="col-md-2">
           <div class="form-group">
             <a class="secondary-button text-danger" href="#" v-on:click.prevent="removeCondition(condition, index)" v-if="canRemoveMeasureCondition">
@@ -47,7 +47,33 @@
     </p>
 
     <div v-if="replacing">
+      <div class="form-group">
+        <div class="multiple-choice">
+          <input type='radio' id="conditions_add" class="radio-inline-group" v-model="mode" value="add" />
+          <label for="conditions_add">
+            Add to any existing conditions in the selection
 
+            <br>
+
+            <span class="form-hint">
+              Existing conditions will be retained. Conditions specified here will not be added to any measures in which the exact same condition already exists.
+            </span>
+          </label>
+        </div>
+
+        <div class="multiple-choice">
+          <input type='radio' id="conditions_replace" class="radio-inline-group" v-model="mode" value="replace" />
+          <label for="conditions_replace">
+            Replace any existing conditions in the selection
+
+            <br>
+
+            <span class="form-hint">
+              Select this option and leave the condition field above unselected to remove all existing conditions in the selection
+            </span>
+          </label>
+        </div>
+      </div>
     </div>
 
     <div class="form-actions">

--- a/app/views/shared/vue_templates/_change_duties.html.erb
+++ b/app/views/shared/vue_templates/_change_duties.html.erb
@@ -18,6 +18,18 @@
       </info-message>
     </div>
 
+    <div class="error-summary" role="alert" aria-labelledby="error-summary-heading-example-1" tabindex="-1" v-if="errors.length > 0">
+
+      <h2 class="heading-medium error-summary-heading" id="error-summary-heading-example-1">
+        There are {{errors.length}} errors on the duty expressions entered
+      </h2>
+
+      <ul class="error-summary-list">
+        <li v-for="error in errors">{{error}}</li>
+      </ul>
+
+    </div>
+
     <div class="duty-expression" v-for="(measureComponent, index) in measureComponents">
       <measure-component :measure-component="measureComponent" :index="index">
         <div class="col-md-2">

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -5,15 +5,15 @@ script type="text/x-template" id="condition-template"
         .form-group
           label.form-label
             | Condition
-            span.form-hint
+            span.form-hint v-if="hideHelp !== true"
               | You can optionally select conditions that will determine the customs treatment of the goods this measure applies to.
-          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select condition ―", "code-class-name" => "prefix--condition" }
+          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select condition ―", "code-class-name" => "prefix--condition", ":on-change" => "onConditionCodeSelected", ":allow-clear" => "true" }
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showMinimumPrice" do
         .form-group
           label.form-label
             | Minimum Price (€)
-            span.form-hint
+            span.form-hint v-if="hideHelp !== true"
               | Specify the price (in €) at or above which this condition will apply.
           input.form-control type="text" v-model="condition.amount"
 
@@ -21,7 +21,7 @@ script type="text/x-template" id="condition-template"
         .form-group
           label.form-label
             | Ratio
-            span.form-hint
+            span.form-hint v-if="hideHelp !== true"
               | Specify the ratio at or above which this condition will apply.
           input.form-control type="text" v-model="condition.amount"
 
@@ -29,7 +29,7 @@ script type="text/x-template" id="condition-template"
         .form-group
           label.form-label
             | Entry Price (€)
-            span.form-hint
+            span.form-hint v-if="hideHelp !== true"
               | Specify the price (in €) above which this condition will apply.
           input.form-control type="text" v-model="condition.amount"
 
@@ -43,35 +43,39 @@ script type="text/x-template" id="condition-template"
         .form-group
           label.form-label
             | Certificate type
-            span.form-hint
+            span.form-hint v-if="hideHelp !== true"
               | Select the type of certificate that will be required, or select 'no certificate presented' to define the action for that case.
-          = content_tag "custom-select", "", { url: "/certificate_types", "v-model" => "condition.certificate_type_code", "codeField" => "certificate_type_code", "valueField" => "certificate_type_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate type ―", "code-class-name" => "prefix--certificate-type" }
+          = content_tag "custom-select", "", { url: "/certificate_types", "v-model" => "condition.certificate_type_code", "codeField" => "certificate_type_code", "valueField" => "certificate_type_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate type ―", "code-class-name" => "prefix--certificate-type", ":on-change" => "onCertificateTypeSelected", ":allow-clear" => "true" }
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showCertificate" do
         .form-group
           label.form-label
             | Certificate
-            span.form-hint
+            span.form-hint v-if="hideHelp !== true"
               | Select the type of certificate that will be required, or select 'no certificate presented' to define the action for that case.
-          = content_tag "custom-select", "", { url: "/certificates", "v-model" => "condition.certificate_code", "codeField" => "certificate_code", "valueField" => "certificate_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate ―", "drilldown-name" => "certificate_type_code", ":drilldown-value" => "condition.certificate_type_code", ":drilldown-required" => "showCertificateType", "code-class-name" => "prefix--certificate" }
+          = content_tag "custom-select", "", { url: "/certificates", "v-model" => "condition.certificate_code", "codeField" => "certificate_code", "valueField" => "certificate_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate ―", "drilldown-name" => "certificate_type_code", ":drilldown-value" => "condition.certificate_type_code", ":drilldown-required" => "showCertificateType", "code-class-name" => "prefix--certificate", ":on-change" => "onCertificateSelected", ":allow-clear" => "true" }
 
       = content_tag :div, { class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showAction" } do
         .form-group
           label.form-label
             | Action
-            = content_tag :span, { class: "form-hint", "v-if" => "certificateActionHint" } do
+            = content_tag :span, { class: "form-hint", "v-if" => "hideHelp !== true && certificateActionHint" } do
               | Define the action to take when the specified certificate (or no certificate) is presented.
-            = content_tag :span, { class: "form-hint", "v-if" => "noCertificateActionHint" } do
+            = content_tag :span, { class: "form-hint", "v-if" => "hideHelp !== true && noCertificateActionHint" } do
               | Define the action to take if the condition is met.
-          = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action" }
+          = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action", ":on-change" => "onActionSelected", ":allow-clear" => "true" }
+
+
+      = content_tag :slot
     = content_tag :div, { class: "condition-components-wrapper", "v-if" => "showConditionComponents" } do
       .measure-condition-components
         div.measure-condition-component v-for="(measureConditionComponent, index) in condition.measure_condition_components"
-          = content_tag "measure-condition-component", "", { ":measure-condition-component" => "measureConditionComponent", ":index" => "index" }
-
-          div v-if="canRemoveComponent"
-            a.text-danger href="#" v-on:click.prevent="removeMeasureConditionComponent(measureConditionComponent)"
-              | Remove duty expression
+          = content_tag "measure-condition-component", { ":measure-condition-component" => "measureConditionComponent", ":index" => "index" } do
+            .col-md-3 v-if="canRemoveComponent"
+              label.form-label
+                | &nbsp;
+              a.text-danger href="#" v-on:click.prevent="removeMeasureConditionComponent(measureConditionComponent)"
+                | Remove
 
       div
         a href="#" v-on:click.prevent="addMeasureConditionComponent"

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -10,43 +10,43 @@ script type="text/x-template" id="measure-component-template"
       .form-group
         label.form-label v-if="index === 0"
           | Duty amount (% or €)
-        input.form-control v-model="measureComponent.amount"
+        input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountPercentage"
       .form-group
         label.form-label v-if="index === 0"
           | Duty amount (%)
-        input.form-control v-model="measureComponent.amount"
+        input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountNegativePercentage"
       .form-group
         label.form-label v-if="index === 0"
           | Duty amount (-%)
-        input.form-control v-model="measureComponent.amount"
+        input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountNumber"
       .form-group
         label.form-label v-if="index === 0"
           | Duty amount (€)
-        input.form-control v-model="measureComponent.amount"
+        input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountMinimum"
       .form-group
         label.form-label v-if="index === 0"
           | Duty amount (at least €)
-        input.form-control v-model="measureComponent.amount"
+        input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountMaximum"
       .form-group
         label.form-label
           | Duty amount (not more than €)
-        input.form-control v-model="measureComponent.amount"
+        input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyRefundAmount"
       .form-group
         label.form-label v-if="index === 0"
           | Refund amount (€)
-        input.form-control v-model="measureComponent.amount"
+        input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showMonetaryUnit"
       .form-group

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -4,7 +4,7 @@ script type="text/x-template" id="measure-component-template"
       .form-group
         label.form-label v-if="index === 0"
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "dutyExpressionSelected" }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected" }
 
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
@@ -52,17 +52,17 @@ script type="text/x-template" id="measure-component-template"
       .form-group
         label.form-label v-if="index === 0"
           | Monetary unit
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "monetaryUnitSelected" }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label v-if="index === 0"
           | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "measurementUnitSelected" }
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label v-if="index === 0"
           | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "measurementUnitQualifierSelected" }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected" }
     slot

--- a/app/views/shared/vue_templates/_measure_condition_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.slim
@@ -4,7 +4,7 @@ script type="text/x-template" id="measure-condition-component-template"
       .form-group
         label.form-label
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate" }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected", ":allow-clear" => "true" }
 
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
@@ -58,17 +58,18 @@ script type="text/x-template" id="measure-condition-component-template"
       .form-group
         label.form-label
           | Monetary unit
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit" }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected", ":allow-clear" => "true" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label
           | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit" }
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":allow-clear" => "true" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
         label.form-label
           | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier" }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":allow-clear" => "true" }
 
+    = content_tag :slot, nil


### PR DESCRIPTION
This PR accomplishes the following on the Bulk Edit flow:

- Implements amount field validation in duties popup
- Implements the Change Conditions popup
- Plus, fixes some small issues:
  - Removes unnecessary bulk actions (make copies, change quota and change status)
  - Fixes select all checkbox in bulk edit screen
  - Fixes loading indicator start/end numbers
  - Fixes editing measures without commodity code
  - Fixes empty end date
  - Fixes table cells collapsing when they have no content
  - Fixes measure condition component serialization in models


![screen shot 2018-07-13 at 10 38 49](https://user-images.githubusercontent.com/758001/42694696-a0271114-8689-11e8-8115-c12b43301acc.png)
![screen shot 2018-07-13 at 10 39 00](https://user-images.githubusercontent.com/758001/42694697-a049dc80-8689-11e8-8c74-31fa7f4d9592.png)
![screen shot 2018-07-13 at 10 39 11](https://user-images.githubusercontent.com/758001/42694698-a06e7ab8-8689-11e8-8bdf-81909a0ac571.png)
![screen shot 2018-07-13 at 10 43 53](https://user-images.githubusercontent.com/758001/42694721-b0f74bda-8689-11e8-979b-97f95b79c804.png)
![screen shot 2018-07-13 at 10 44 21](https://user-images.githubusercontent.com/758001/42694731-b7d402b8-8689-11e8-9130-8f8c13306cbb.png)

