### PR TITLE
[CREATE MEASURES V2 - BACKEND] Improve mechanism of caching geographical areas collection

### DIFF
--- a/app/forms/measure_form.rb
+++ b/app/forms/measure_form.rb
@@ -70,7 +70,7 @@ class MeasureForm
   end
 
   def geographical_areas_json
-    @ga_json ||= Rails.cache.fetch(:measures_form_geographical_areas_json, expires_in: 8.hours) do
+    @ga_json ||= Rails.cache.fetch(:measures_form_geographical_areas_json, expires_in: 24.hours) do
       list = {}
 
       GeographicalArea.actual.all.each do |group|
@@ -101,7 +101,7 @@ class MeasureForm
   end
 
   def all_geographical_areas
-    @all_ga ||= Rails.cache.fetch(:measures_form_geographical_areas, expires_in: 8.hours) do
+    @all_ga ||= Rails.cache.fetch(:measures_form_geographical_areas, expires_in: 24.hours) do
       GeographicalArea.actual
                       .all
                       .map { |area| { geographical_area_id: area.geographical_area_id, description: area.description } }
@@ -109,7 +109,7 @@ class MeasureForm
   end
 
   def all_geographical_countries
-    @all_gc ||= Rails.cache.fetch(:measures_form_geographical_countries, expires_in: 8.hours) do
+    @all_gc ||= Rails.cache.fetch(:measures_form_geographical_countries, expires_in: 24.hours) do
       GeographicalArea.actual
                       .countries
                       .all
@@ -118,7 +118,7 @@ class MeasureForm
   end
 
   def geographical_groups_except_erga_omnes
-    @ggeeo ||= Rails.cache.fetch(:measures_form_geographical_groups_except_erga_omnes, expires_in: 8.hours) do
+    @ggeeo ||= Rails.cache.fetch(:measures_form_geographical_groups_except_erga_omnes, expires_in: 24.hours) do
       GeographicalArea.actual.groups
                       .except_erga_omnes
                       .all
@@ -127,7 +127,7 @@ class MeasureForm
   end
 
   def geographical_area_erga_omnes
-    @gaeo ||= Rails.cache.fetch(:measures_form_geographical_area_erga_omnes, expires_in: 8.hours) do
+    @gaeo ||= Rails.cache.fetch(:measures_form_geographical_area_erga_omnes, expires_in: 24.hours) do
       GeographicalArea.erga_omnes_group.to_hash.slice(:geographical_area_id, :description)
     end
   end

--- a/app/workers/refresh_cache_worker.rb
+++ b/app/workers/refresh_cache_worker.rb
@@ -1,0 +1,9 @@
+class RefreshCacheWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: 5
+
+  def perform
+    ::Measures::RefreshCache.run
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,5 +20,9 @@
   # Online converter: https://crontab.guru/#0_22_*_*_*
   #
   UpdatesSynchronizerWorker:
-    cron: "0 22 * * *" # 10 PM every days
-    description: "UpdatesSynchronizerWorker will run at every 0th minute past the 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 18, 19, 20, 21, 22 and 23rd hour."
+    cron: "0 22 * * *" # 10 PM every day
+    description: "UpdatesSynchronizerWorker will run at 10 PM every day"
+
+  RefreshCacheWorker:
+    cron: "0 5 * * *" # 5 AM every day
+    description: "RefreshCacheWorker will run at 5 AM every day"

--- a/lib/tasks/measures/refresh_cache.rb
+++ b/lib/tasks/measures/refresh_cache.rb
@@ -1,0 +1,45 @@
+module Measures
+  class RefreshCache
+
+    KEYS_TO_CLEAR = [
+      :measures_form_geographical_areas_json,
+      :measures_form_geographical_areas,
+      :measures_form_geographical_countries,
+      :measures_form_geographical_groups_except_erga_omnes,
+      :measures_form_geographical_area_erga_omnes
+    ]
+
+    class << self
+      def run
+        notify_via_sentry!("started")
+
+        clear_keys!
+        recache_keys!
+
+        notify_via_sentry!("completed")
+      end
+
+      def clear_keys!
+        KEYS_TO_CLEAR.map do |cache_key|
+          Rails.cache.delete(cache_key)
+        end
+      end
+
+      def recache_keys!
+        form = MeasureForm.new(Measure.last)
+
+        form.geographical_areas_json
+        form.all_geographical_areas
+        form.all_geographical_countries
+        form.geographical_groups_except_erga_omnes
+        form.geographical_area_erga_omnes
+      end
+
+      def notify_via_sentry!(message)
+        ::Raven.capture_exception(
+          "[RefreshCacheWorker] #{message}!"
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Improve mechanism of caching geographical areas collection for 'Which origin will the measures apply to?' block.
Currently sometimes it raising 'Rack::Timeout' issues on server when user opening 'Create measures' section

Related sentry issue https://sentry.io/bit-zesty-client-apps/management/issues/611373879/

[TRELLO CARD](https://trello.com/c/IN154EvH/204-dit-create-measures-iteration)