### PR TITLE
[CREATE MEASURES V2 + XML Export V2] Improvements and bugfixes

### DIFF
--- a/app/assets/javascripts/components/create-measures/save-actions.js.coffee
+++ b/app/assets/javascripts/components/create-measures/save-actions.js.coffee
@@ -58,7 +58,6 @@ window.CreateMeasuresSaveActions =
       ), 1000
     else
       if resp.next_step.length > 0 && window.create_measures_mode == 'continue'
-        CreateMeasuresSaveActions.showSuccessMessage()
         CreateMeasuresSaveActions.setSpinnerText("Redirecting to next step")
 
         setTimeout (->

--- a/app/assets/javascripts/components/create-measures/validation_errors_handler.js.coffee
+++ b/app/assets/javascripts/components/create-measures/validation_errors_handler.js.coffee
@@ -7,7 +7,7 @@ window.CreateMeasuresValidationErrorsHandler =
     if response.responseJSON.step == "main"
       CreateMeasuresValidationErrorsHandler.setFormErrors(response, measure_form)
     else
-      CreateMeasuresValidationErrorsHandler.renderErrorsBlock(response)
+      CreateMeasuresValidationErrorsHandler.renderErrorsBlock(response, measure_form)
 
     CreateMeasuresSaveActions.unlockButtonsAndHideSpinner()
 
@@ -32,10 +32,22 @@ window.CreateMeasuresValidationErrorsHandler =
 
     return false
 
-  renderErrorsBlock: (response) ->
+  renderErrorsBlock: (response, measure_form) ->
     CreateMeasuresValidationErrorsHandler.showCustomErrorsBlock()
 
-    $.each response.responseJSON.errors, (group_key, errors_collection) ->
+    grouped_errors = response.responseJSON.errors
+    general_errors = grouped_errors['general']
+
+    if general_errors isnt undefined
+      $.each general_errors, (key, value) ->
+        group_block = $(".js-create-measures-custom-errors[data-errors-container='measure']")
+        group_block.removeClass('hidden')
+        list_block = group_block.find("ul")
+        list_block.append("<li><div class='create-measures-error-block with_left_margin'>" + value + "</div></li>")
+
+    delete grouped_errors['general']
+
+    $.each grouped_errors, (group_key, errors_collection) ->
       group_block = $(".js-create-measures-custom-errors[data-errors-container='" + group_key + "']")
       group_block.removeClass('hidden')
       list_block = group_block.find("ul")

--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -156,6 +156,8 @@ $(document).ready(function() {
           var data_ops = {
             step: window.current_step,
             mode: window.create_measures_mode,
+            start_date: window.create_measures_start_date,
+            end_date: window.create_measures_end_date,
             settings: payload
           };
         }

--- a/app/assets/javascripts/vue_components/footnote.js
+++ b/app/assets/javascripts/vue_components/footnote.js
@@ -31,7 +31,9 @@ Vue.component("foot-note", {
         url: "/footnotes",
         data: {
           footnote_type_id: type_id,
-          description: description
+          description: description,
+          start_date: window.measure_start_date,
+          end_date: window.measure_end_date
         },
         success: function(data) {
           self.suggestions = data;

--- a/app/controllers/workbaskets/create_measures_controller.rb
+++ b/app/controllers/workbaskets/create_measures_controller.rb
@@ -3,7 +3,8 @@ module Workbaskets
 
     before_action :require_to_be_workbasket_owner!,
                   :require_step_declaration_in_params!,
-                  :check_if_action_is_permitted!, only: [ :edit, :update ]
+                  :check_if_action_is_permitted!,
+                  :status_check!, only: [ :edit, :update ]
 
     expose(:current_step) { params[:step] }
 
@@ -118,6 +119,14 @@ module Workbaskets
             workbasket.id,
             step: previous_step
           )
+
+          return false
+        end
+      end
+
+      def status_check!
+        unless workbasket.in_progress?
+          redirect_to create_measure_url(workbasket.id)
 
           return false
         end

--- a/app/controllers/xml_generation/base_controller.rb
+++ b/app/controllers/xml_generation/base_controller.rb
@@ -1,4 +1,0 @@
-module XmlGeneration
-  class BaseController < ApplicationController
-  end
-end

--- a/app/controllers/xml_generation/exports_controller.rb
+++ b/app/controllers/xml_generation/exports_controller.rb
@@ -18,25 +18,5 @@ module XmlGeneration
     expose(:redirect_url) do
       xml_generation_exports_path
     end
-
-    def create
-      record = klass.new(
-        date_filters: date_filters,
-        issue_date: Time.zone.now,
-        state: "P"
-      )
-
-      if record.save
-        #worker_klass.perform_async(record.id) unless Rails.env.test?
-
-        ::XmlGeneration::TaricExport.new(record).run
-
-        redirect_to redirect_url,
-                    notice: "#{record_name} was successfully scheduled. Please wait!"
-      else
-        redirect_to redirect_url,
-                    notice: "Something wrong!"
-      end
-    end
   end
 end

--- a/app/controllers/xml_generation/exports_controller.rb
+++ b/app/controllers/xml_generation/exports_controller.rb
@@ -1,5 +1,5 @@
 module XmlGeneration
-  class ExportsController < ::XmlGeneration::BaseController
+  class ExportsController < ApplicationController
 
     include ::BaseJobMixin
 
@@ -17,6 +17,26 @@ module XmlGeneration
 
     expose(:redirect_url) do
       xml_generation_exports_path
+    end
+
+    def create
+      record = klass.new(
+        date_filters: date_filters,
+        issue_date: Time.zone.now,
+        state: "P"
+      )
+
+      if record.save
+        #worker_klass.perform_async(record.id) unless Rails.env.test?
+
+        ::XmlGeneration::TaricExport.new(record).run
+
+        redirect_to redirect_url,
+                    notice: "#{record_name} was successfully scheduled. Please wait!"
+      else
+        redirect_to redirect_url,
+                    notice: "Something wrong!"
+      end
     end
   end
 end

--- a/app/helpers/xml_generation/base_helper.rb
+++ b/app/helpers/xml_generation/base_helper.rb
@@ -5,7 +5,15 @@ module XmlGeneration
     end
 
     def xml_data_item(xml_node, data)
-      xml_node.text!(data.to_s || '')
+      xml_node.text!(data.to_s)
+    end
+
+    def xml_data_item_v2(xml_node, namespace, data)
+      if data.present?
+        xml_node.tag!("oub:#{namespace}") do xml_node
+          xml_data_item(xml_node, data)
+        end
+      end
     end
   end
 end

--- a/app/interactors/measure_saver.rb
+++ b/app/interactors/measure_saver.rb
@@ -82,7 +82,7 @@ class MeasureSaver
         measure, MeasureValidator, @errors
       )
 
-      measure = normalizer.measure
+      measure = normalizer.record
       @errors = normalizer.errors
     end
 

--- a/app/interactors/workbaskets/create_measures/settings_saver.rb
+++ b/app/interactors/workbaskets/create_measures/settings_saver.rb
@@ -21,6 +21,13 @@ module Workbaskets
         footnotes
       )
 
+      ASSOCIATIONS_LIST = %w(
+        measure_components
+        conditions
+        footnotes
+        excluded_geographical_areas
+      )
+
       attr_accessor :current_step,
                     :save_mode,
                     :settings,
@@ -176,7 +183,7 @@ module Workbaskets
           m_errors = measure_errors(measure)
           errors_collection[:measure] = m_errors if m_errors.present?
 
-          ::CreateMeasures::StepPointer::DUTIES_CONDITIONS_FOOTNOTES_STEP_SETTINGS.map do |name|
+          ASSOCIATIONS_LIST.map do |name|
             if public_send(name).present?
               association_errors = send("#{name}_errors", measure)
               errors_collection[name] = association_errors if association_errors.present?
@@ -210,7 +217,7 @@ module Workbaskets
           ).errors
         end
 
-        ::CreateMeasures::StepPointer::DUTIES_CONDITIONS_FOOTNOTES_STEP_SETTINGS.map do |name|
+        ASSOCIATIONS_LIST.map do |name|
           define_method("#{name}_errors") do |measure|
             klass_name = name.split("_").map(&:capitalize).join('')
 

--- a/app/interactors/workbaskets/create_measures/settings_saver.rb
+++ b/app/interactors/workbaskets/create_measures/settings_saver.rb
@@ -19,6 +19,7 @@ module Workbaskets
         measure_components
         conditions
         footnotes
+        excluded_geographical_areas
       )
 
       ASSOCIATIONS_LIST = %w(

--- a/app/interactors/workbaskets/create_measures/settings_saver.rb
+++ b/app/interactors/workbaskets/create_measures/settings_saver.rb
@@ -8,6 +8,8 @@ module Workbaskets
       )
 
       ATTRS_PARSER_METHODS = %w(
+        start_date
+        end_date
         workbasket_name
         operation_date
         commodity_codes
@@ -104,7 +106,7 @@ module Workbaskets
           general_errors = {}
 
           REQUIRED_PARAMS.map do |k|
-            if settings_params[k.to_s].blank?
+            if public_send(k).blank?
               general_errors[k.to_sym] = "#{k.to_s.capitalize.split('_').join(' ')} can't be blank!"
             end
           end
@@ -135,13 +137,15 @@ module Workbaskets
           #   @errors[:commodity_codes] = errors_translator(:commodity_codes_invalid)
           # end
 
-          if step_pointer.main_step?
-            general_errors.map do |k, v|
-              @errors[k] = v
-            end
+          if general_errors.present?
+            if step_pointer.main_step?
+              general_errors.map do |k, v|
+                @errors[k] = v
+              end
 
-          else
-            @errors[:general] = general_errors
+            else
+              @errors[:general] = general_errors
+            end
           end
         end
 

--- a/app/models/concerns/workbasket_helpers/association.rb
+++ b/app/models/concerns/workbasket_helpers/association.rb
@@ -15,6 +15,7 @@ module WorkbasketHelpers
     end
 
     def move_status_to!(new_status)
+      self.manual_add = true
       self.status = new_status
       save
     end

--- a/app/models/measure_excluded_geographical_area.rb
+++ b/app/models/measure_excluded_geographical_area.rb
@@ -1,6 +1,7 @@
 class MeasureExcludedGeographicalArea < Sequel::Model
 
   include ::XmlGeneration::BaseHelper
+  include ::WorkbasketHelpers::Association
 
   plugin :oplog, primary_key: [:measure_sid, :geographical_area_sid]
   plugin :conformance_validator

--- a/app/models/workbaskets/create_measures_settings.rb
+++ b/app/models/workbaskets/create_measures_settings.rb
@@ -82,5 +82,13 @@ module Workbaskets
       Measure.where(measure_sid: measure_sids)
              .order(:measure_sid)
     end
+
+    def start_date
+      settings['start_date']
+    end
+
+    def end_date
+      settings['end_date']
+    end
   end
 end

--- a/app/models/workbaskets/create_measures_settings.rb
+++ b/app/models/workbaskets/create_measures_settings.rb
@@ -70,7 +70,6 @@ module Workbaskets
     def set_searchable_data_for_created_measures!
       measures.map do |measure|
         measure.set_searchable_data!
-        measure.save
       end
     end
 

--- a/app/models/workbaskets/create_measures_settings.rb
+++ b/app/models/workbaskets/create_measures_settings.rb
@@ -10,6 +10,7 @@ module Workbaskets
       MeasureComponent
       MeasureCondition
       MeasureConditionComponent
+      MeasureExcludedGeographicalArea
     )
 
     plugin :timestamps

--- a/app/models/workbaskets/create_measures_settings.rb
+++ b/app/models/workbaskets/create_measures_settings.rb
@@ -69,6 +69,7 @@ module Workbaskets
 
     def set_searchable_data_for_created_measures!
       measures.map do |measure|
+        measure.manual_add = true
         measure.set_searchable_data!
       end
     end

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -139,12 +139,33 @@ module Workbaskets
 
     def debug_collection
       settings.collection
-              .map do |el|
-
-        puts "-"
+              .map.with_index do |el, index|
         puts ""
-        puts "#{el.class.name} | #{el.class.name == 'MeasureComponent' ? el.formatted_duty_expression : ''} | #{el.workbasket_id} | #{el.workbasket_sequence_number}"
-        puts "#{el.status}"
+        puts " [#{index}] Class: #{el.class.name}"
+        puts "             Workbasket ID: #{el.workbasket_id}"
+        puts "             Sequence number: #{el.workbasket_sequence_number}"
+        puts "             Status: #{el.status}"
+
+        custom_note = case el.class.name
+        when "Measure"
+          el.measure_sid
+        when "MeasureComponent"
+          el.formatted_duty_expression
+        when "MeasureCondition"
+          el.short_abbreviation
+        when "MeasureConditionComponent"
+          el.formatted_duty_expression
+        when "Footnote"
+          "#{el.footnote_type_id} - #{el.footnote_id}"
+        when "FootnoteDescription"
+          "#{el.description}"
+        when "FootnoteDescriptionPeriod"
+          "#{el.footnote_description_period_sid}"
+        when "FootnoteAssociationMeasure"
+          "footnote_type_id: #{el.footnote_type_id}, footnote_id: #{el.footnote_id}, measure_sid: #{el.measure_sid}"
+        end
+
+        puts "             #{custom_note}"
         puts ""
         puts "-"
       end

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -112,6 +112,19 @@ module Workbaskets
       end
     end
 
+    def debug_collection
+      settings.collection
+              .map do |el|
+
+        puts "-"
+        puts ""
+        puts "#{el.class.name} | #{el.class.name == 'MeasureComponent' ? el.formatted_duty_expression : ''} | #{el.workbasket_id} | #{el.workbasket_sequence_number}"
+        puts "#{el.status}"
+        puts ""
+        puts "-"
+      end
+    end
+
     class << self
       def buld_new_workbasket!(type, current_user)
         workbasket = Workbaskets::Workbasket.new(

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -69,7 +69,7 @@ module Workbaskets
       def xml_export_collection(start_date, end_date)
         by_date_range(
           start_date, end_date
-        ).in_status(:submitted_for_cross_check)
+        ).in_status("submitted_for_cross_check")
          .order(:operation_date)
       end
 

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -65,6 +65,31 @@ module Workbaskets
       inclusion_of :type, in: TYPES.map(&:to_s)
     end
 
+    dataset_module do
+      def xml_export_collection(start_date, end_date)
+        by_date_range(
+          start_date, end_date
+        ).in_status(:submitted_for_cross_check)
+         .order(:operation_date)
+      end
+
+      def by_date_range(start_date, end_date)
+        if end_date.present?
+          where(
+            "operation_date >= ? AND operation_date <= ?", start_date, end_date
+          )
+        else
+          where(
+            "operation_date = ?", start_date
+          )
+        end
+      end
+
+      def in_status(status_name)
+        where(status: status_name)
+      end
+    end
+
     begin :callbacks
       def after_create
         build_related_settings_table!

--- a/app/models/xml_generation/node_envelope.rb
+++ b/app/models/xml_generation/node_envelope.rb
@@ -4,18 +4,14 @@ module XmlGeneration
 
     attr_accessor :transactions
 
-    def initialize(records)
-      @transactions = records.map do |transaction_block|
-        ::XmlGeneration::NodeTransaction.new(transaction_block)
+    def initialize(workbaskets)
+      @transactions = workbaskets.map do |workbasket|
+        ::XmlGeneration::NodeTransaction.new(workbasket)
       end
     end
 
     def node_id
-      # TODO
-      #
-      # Emulation:
-      #
-      Time.now.to_i - 1519999000
+      Time.now.to_i
     end
   end
 end

--- a/app/models/xml_generation/node_message.rb
+++ b/app/models/xml_generation/node_message.rb
@@ -149,7 +149,7 @@ module XmlGeneration
     end
 
     def node_id
-      rand(2..999)
+      record.workbasket_sequence_number
     end
 
     def record_code
@@ -161,8 +161,11 @@ module XmlGeneration
     end
 
     def record_sequence_number
-      # TODO
-      rand(100..999)
+      #
+      # TODO: Need to make sure if node_id and
+      #       record_sequence_number are same thing
+      #
+      node_id
     end
 
     def update_type

--- a/app/models/xml_generation/node_transaction.rb
+++ b/app/models/xml_generation/node_transaction.rb
@@ -1,9 +1,11 @@
 module XmlGeneration
   class NodeTransaction
 
-    attr_accessor :messages
+    attr_accessor :workbasket,
+                  :messages
 
     def initialize(workbasket)
+      @workbasket = workbasket
       @messages = workbasket.settings
                             .collection
                             .map do |record|

--- a/app/models/xml_generation/node_transaction.rb
+++ b/app/models/xml_generation/node_transaction.rb
@@ -3,18 +3,16 @@ module XmlGeneration
 
     attr_accessor :messages
 
-    def initialize(records)
-      @messages = Array.wrap(records).map do |record|
+    def initialize(workbasket)
+      @messages = workbasket.settings
+                            .collection
+                            .map do |record|
         ::XmlGeneration::NodeMessage.new(record)
       end
     end
 
     def node_id
-      # TODO
-      #
-      # Emulation:
-      #
-      Time.now.to_i - 1515111000
+      workbasket.id
     end
   end
 end

--- a/app/models/xml_generation/search.rb
+++ b/app/models/xml_generation/search.rb
@@ -131,6 +131,12 @@ module XmlGeneration
     private
 
       def data
+        ::Workbaskets::Workbasket.by_date_range(
+          start_date, end_date
+        ).in_status(:submitted_for_cross_check)
+         .order(:operation_date)
+         .map do |workbasket|
+
         SEQUENCE_OF_DATA_FETCH.map do |record_class|
           if end_date.present?
             record_class.where(
@@ -143,5 +149,19 @@ module XmlGeneration
           end.all
         end.flatten
       end
+
+      # def data
+      #   SEQUENCE_OF_DATA_FETCH.map do |record_class|
+      #     if end_date.present?
+      #       record_class.where(
+      #         "operation_date >= ? AND operation_date <= ?", start_date, end_date
+      #       )
+      #     else
+      #       record_class.where(
+      #         "operation_date = ?", start_date
+      #       )
+      #     end.all
+      #   end.flatten
+      # end
   end
 end

--- a/app/models/xml_generation/search.rb
+++ b/app/models/xml_generation/search.rb
@@ -1,121 +1,6 @@
 module XmlGeneration
   class Search
 
-    SEQUENCE_OF_DATA_FETCH = [
-      GeographicalArea,
-      GeographicalAreaDescription,
-      GeographicalAreaDescriptionPeriod,
-      GeographicalAreaMembership,
-
-      MonetaryUnit,
-      MonetaryUnitDescription,
-      MonetaryExchangePeriod,
-      MonetaryExchangeRate,
-
-      MeasurementUnitQualifier,
-      MeasurementUnitQualifierDescription,
-      MeasurementUnit,
-      MeasurementUnitDescription,
-      Measurement,
-
-      QuotaOrderNumber,
-      QuotaOrderNumberOrigin,
-      QuotaOrderNumberOriginExclusion,
-      QuotaDefinition,
-      QuotaAssociation,
-      QuotaReopeningEvent,
-      QuotaUnsuspensionEvent,
-      QuotaUnblockingEvent,
-      QuotaBalanceEvent,
-      QuotaCriticalEvent,
-      QuotaExhaustionEvent,
-      QuotaSuspensionPeriod,
-      QuotaBlockingPeriod,
-
-      GoodsNomenclatureGroup,
-      GoodsNomenclatureGroupDescription,
-      GoodsNomenclature,
-      GoodsNomenclatureDescription,
-      GoodsNomenclatureDescriptionPeriod,
-      GoodsNomenclatureIndent,
-      GoodsNomenclatureOrigin,
-      GoodsNomenclatureSuccessor,
-      NomenclatureGroupMembership,
-
-      MeasureTypeSeries,
-      MeasureTypeSeriesDescription,
-      MeasureType,
-      MeasureTypeDescription,
-      MeasureAction,
-      MeasureActionDescription,
-      Measure,
-      MeasureComponent,
-      MeasureConditionCode,
-      MeasureConditionCodeDescription,
-      MeasureCondition,
-      MeasureConditionComponent,
-      MeasurePartialTemporaryStop,
-      MeasureExcludedGeographicalArea,
-
-      AdditionalCodeType,
-      AdditionalCodeTypeDescription,
-      AdditionalCodeTypeMeasureType,
-      AdditionalCode,
-      AdditionalCodeDescription,
-      AdditionalCodeDescriptionPeriod,
-
-      MeursingAdditionalCode,
-      MeursingTablePlan,
-      MeursingTableCellComponent,
-      MeursingHeading,
-      MeursingHeadingText,
-      MeursingSubheading,
-
-      DutyExpression,
-      DutyExpressionDescription,
-
-      CertificateType,
-      CertificateTypeDescription,
-      Certificate,
-      CertificateDescription,
-      CertificateDescriptionPeriod,
-
-      RegulationRoleType,
-      RegulationRoleTypeDescription,
-      RegulationReplacement,
-      RegulationGroup,
-      RegulationGroupDescription,
-      BaseRegulation,
-      ModificationRegulation,
-      CompleteAbrogationRegulation,
-      ExplicitAbrogationRegulation,
-      FullTemporaryStopRegulation,
-      FtsRegulationAction,
-      ProrogationRegulation,
-      ProrogationRegulationAction,
-
-      FootnoteType,
-      FootnoteTypeDescription,
-      Footnote,
-      FootnoteDescription,
-      FootnoteDescriptionPeriod,
-      FootnoteAssociationAdditionalCode,
-      FootnoteAssociationGoodsNomenclature,
-      FootnoteAssociationMeasure,
-      FootnoteAssociationMeursingHeading,
-      FootnoteAssociationErn,
-
-      ExportRefundNomenclature,
-      ExportRefundNomenclatureDescription,
-      ExportRefundNomenclatureDescriptionPeriod,
-      ExportRefundNomenclatureIndent,
-
-      Language,
-      LanguageDescription,
-      TransmissionComment,
-      PublicationSigle
-    ]
-
     attr_accessor :start_date,
                   :end_date
 
@@ -131,37 +16,9 @@ module XmlGeneration
     private
 
       def data
-        ::Workbaskets::Workbasket.by_date_range(
+        ::Workbaskets::Workbasket.xml_export_collection(
           start_date, end_date
-        ).in_status(:submitted_for_cross_check)
-         .order(:operation_date)
-         .map do |workbasket|
-
-        SEQUENCE_OF_DATA_FETCH.map do |record_class|
-          if end_date.present?
-            record_class.where(
-              "operation_date >= ? AND operation_date <= ?", start_date, end_date
-            )
-          else
-            record_class.where(
-              "operation_date = ?", start_date
-            )
-          end.all
-        end.flatten
+        )
       end
-
-      # def data
-      #   SEQUENCE_OF_DATA_FETCH.map do |record_class|
-      #     if end_date.present?
-      #       record_class.where(
-      #         "operation_date >= ? AND operation_date <= ?", start_date, end_date
-      #       )
-      #     else
-      #       record_class.where(
-      #         "operation_date = ?", start_date
-      #       )
-      #     end.all
-      #   end.flatten
-      # end
   end
 end

--- a/app/validators/measure_excluded_geographical_area_validator.rb
+++ b/app/validators/measure_excluded_geographical_area_validator.rb
@@ -1,0 +1,10 @@
+class MeasureExcludedGeographicalAreaValidator < TradeTariffBackend::Validator
+
+  #
+  # TODO: We need to make sure and confirm code of this comformance rule
+  #
+  validation :MEGAV1, 'Excluded geographical area code can not be blank.', on: [:create, :update] do
+    validates :presence, of: :excluded_geographical_area
+  end
+end
+

--- a/app/value_objects/create_measures/attributes_parser.rb
+++ b/app/value_objects/create_measures/attributes_parser.rb
@@ -2,6 +2,8 @@ module CreateMeasures
   class AttributesParser
 
     SIMPLE_OPS = %w(
+      start_date
+      end_date
       operation_date
       workbasket_name
       commodity_codes

--- a/app/value_objects/create_measures/attributes_parser.rb
+++ b/app/value_objects/create_measures/attributes_parser.rb
@@ -89,7 +89,7 @@ module CreateMeasures
     end
 
     def candidates
-      codes_analyzer.collection
+      codes_analyzer.try(:collection)
     end
 
     begin :decoration_methods
@@ -167,8 +167,8 @@ module CreateMeasures
         if ops[:start_date].present?
           @codes_analyzer = ::CreateMeasures::CodesAnalyzer.new(
             start_date: ops[:start_date].to_date,
-            commodity_codes: commodity_codes,
-            additional_codes: additional_codes,
+            commodity_codes: commodity_codes || [],
+            additional_codes: additional_codes || [],
             commodity_codes_exclusions: commodity_codes_exclusions
           )
         end

--- a/app/value_objects/create_measures/attributes_parser.rb
+++ b/app/value_objects/create_measures/attributes_parser.rb
@@ -56,30 +56,20 @@ module CreateMeasures
     end
 
     def measure_components
-      if ops[:measure_components].present?
-        ops[:measure_components].select do |k, option|
-          option[:duty_expression_id].present?
-        end
-      else
-        []
-      end
+      prepare_collection(:measure_components, :duty_expression_id)
     end
 
     def conditions
-      if ops[:conditions].present?
-        ops[:conditions].select do |k, option|
-          option[:condition_code].present?
-        end
-      else
-        []
-      end
+      prepare_collection(:conditions, :condition_code)
     end
 
     def footnotes
-      if ops[:footnotes].present?
-        ops[:footnotes].select do |k, option|
-          option[:footnote_type_id].present?
-        end
+      prepare_collection(:footnotes, :footnote_type_id)
+    end
+
+    def excluded_geographical_areas
+      if ops[:excluded_geographical_areas].present?
+        ops[:excluded_geographical_areas].uniq
       else
         []
       end
@@ -179,6 +169,16 @@ module CreateMeasures
       def date_to_format(date)
         date.try(:to_date)
             .try(:strftime, "%d %B %Y")
+      end
+
+      def prepare_collection(namespace, key_option)
+        if ops[namespace].present?
+          ops[namespace].select do |k, option|
+            option[key_option].present?
+          end
+        else
+          []
+        end
       end
   end
 end

--- a/app/value_objects/create_measures/step_pointer.rb
+++ b/app/value_objects/create_measures/step_pointer.rb
@@ -13,6 +13,7 @@ module CreateMeasures
       start_date
       end_date
       measure_type_id
+      workbasket_name
       operation_date
       commodity_codes
       commodity_codes_exclusions

--- a/app/value_objects/create_measures/validation_helpers/association_base.rb
+++ b/app/value_objects/create_measures/validation_helpers/association_base.rb
@@ -15,9 +15,6 @@ module CreateMeasures
 
           errors
         end
-      end
-
-      private
 
         def prepare_collection(collection)
           return collection if collection.is_a?(Hash)
@@ -32,6 +29,9 @@ module CreateMeasures
 
           res
         end
+      end
+
+      private
 
         def persist_record!(record)
           assigner = ::CreateMeasures::ValidationHelpers::SystemOpsAssigner.new(

--- a/app/value_objects/create_measures/validation_helpers/association_base.rb
+++ b/app/value_objects/create_measures/validation_helpers/association_base.rb
@@ -6,7 +6,7 @@ module CreateMeasures
         def errors_in_collection(measure, system_ops, collection)
           errors = {}
 
-          collection.map do |k, item_ops|
+          prepare_collection(collection).map do |k, item_ops|
             ops = item_ops.merge(position: k)
 
             record = new(measure, system_ops, ops)
@@ -18,6 +18,20 @@ module CreateMeasures
       end
 
       private
+
+        def prepare_collection(collection)
+          return collection if collection.is_a?(Hash)
+
+          res = {}
+          collection.uniq.each_with_index do |excluded_geographical_area, index|
+            res[index] = {
+              position: index,
+              excluded_geographical_area: excluded_geographical_area
+            }
+          end
+
+          res
+        end
 
         def persist_record!(record)
           assigner = ::CreateMeasures::ValidationHelpers::SystemOpsAssigner.new(

--- a/app/value_objects/create_measures/validation_helpers/conditions.rb
+++ b/app/value_objects/create_measures/validation_helpers/conditions.rb
@@ -1,6 +1,6 @@
 module CreateMeasures
   module ValidationHelpers
-    class Conditions < ::CreateMeasures::ValidationHelpers::AssociationBase
+    class Conditions < ::CreateMeasures::ValidationHelpers::MultipleAssociation
 
       attr_accessor :measure,
                     :system_ops,
@@ -18,17 +18,6 @@ module CreateMeasures
         @errors = {}
       end
 
-      def valid?
-        generate_records!
-        validate_records!
-
-        if @errors.blank? && !measure.new?
-          persist!
-        end
-
-        @errors.blank?
-      end
-
       def persist!
         records.map do |record|
           persist_record!(record)
@@ -40,6 +29,12 @@ module CreateMeasures
         def generate_records!
           generate_condition!
           generate_condition_components!
+        end
+
+        def validate_records!
+          records.map do |record|
+            validate!(record)
+          end
         end
 
         def records
@@ -77,23 +72,6 @@ module CreateMeasures
             mc_component.duty_expression_id = v[:duty_expression_id]
 
             mc_component
-          end
-        end
-
-        def validate_records!
-          records.map do |record|
-            validate!(record)
-          end
-        end
-
-        def validate!(record)
-          if validator(record.class.name).present?
-            ::Measures::ConformanceErrorsParser.new(
-              record, validator(record.class.name), {}
-            ).errors
-             .map do |k, v|
-              @errors[k] = v
-            end
           end
         end
 

--- a/app/value_objects/create_measures/validation_helpers/conditions.rb
+++ b/app/value_objects/create_measures/validation_helpers/conditions.rb
@@ -73,9 +73,10 @@ module CreateMeasures
             mc_component = MeasureConditionComponent.new(
               unit_ops(v)
             )
-
             mc_component.measure_condition_sid = condition.measure_condition_sid
             mc_component.duty_expression_id = v[:duty_expression_id]
+
+            mc_component
           end
         end
 

--- a/app/value_objects/create_measures/validation_helpers/excluded_geographical_areas.rb
+++ b/app/value_objects/create_measures/validation_helpers/excluded_geographical_areas.rb
@@ -1,0 +1,22 @@
+module CreateMeasures
+  module ValidationHelpers
+    class ExcludedGeographicalAreas < ::CreateMeasures::ValidationHelpers::SingleAssociation
+
+      private
+
+        def generate_record!
+          area = GeographicalArea.actual.where(
+            geographical_area_id: record_ops[:excluded_geographical_area]
+          ).first
+
+          @record = MeasureExcludedGeographicalArea.new(
+            excluded_geographical_area: record_ops[:excluded_geographical_area]
+          )
+          record.measure_sid = measure.measure_sid
+          record.geographical_area_sid = area.geographical_area_sid
+
+          set_primary_key(record)
+        end
+    end
+  end
+end

--- a/app/value_objects/create_measures/validation_helpers/footnotes.rb
+++ b/app/value_objects/create_measures/validation_helpers/footnotes.rb
@@ -1,6 +1,6 @@
 module CreateMeasures
   module ValidationHelpers
-    class Footnotes < ::CreateMeasures::ValidationHelpers::AssociationBase
+    class Footnotes < ::CreateMeasures::ValidationHelpers::MultipleAssociation
 
       attr_accessor :measure,
                     :system_ops,
@@ -23,17 +23,6 @@ module CreateMeasures
         @extra_increment_value = footnote_ops[:position]
 
         @errors = {}
-      end
-
-      def valid?
-        generate_records!
-        validate_records!
-
-        if @errors.blank? && !measure.new?
-          persist!
-        end
-
-        @errors.blank?
       end
 
       def persist!
@@ -126,17 +115,6 @@ module CreateMeasures
           footnote_description.footnote_id = footnote.footnote_id
           footnote_description.footnote_type_id = footnote_type_id
           footnote_description.footnote_description_period_sid = period_sid
-        end
-
-        def validate!(record)
-          if validator(record.class.name).present?
-            ::Measures::ConformanceErrorsParser.new(
-              record, validator(record.class.name), {}
-            ).errors
-             .map do |k, v|
-              @errors[k] = v
-            end
-          end
         end
 
         def validator(klass_name)

--- a/app/value_objects/create_measures/validation_helpers/footnotes.rb
+++ b/app/value_objects/create_measures/validation_helpers/footnotes.rb
@@ -38,8 +38,8 @@ module CreateMeasures
 
       def persist!
         unless footnote_reuse.present?
-          persist_record!(footnote)
           persist_record!(footnote_description_period)
+          persist_record!(footnote)
           persist_record!(footnote_description)
         end
 

--- a/app/value_objects/create_measures/validation_helpers/measure_components.rb
+++ b/app/value_objects/create_measures/validation_helpers/measure_components.rb
@@ -1,57 +1,17 @@
 module CreateMeasures
   module ValidationHelpers
-    class MeasureComponents < ::CreateMeasures::ValidationHelpers::AssociationBase
-
-      attr_accessor :measure,
-                    :system_ops,
-                    :duty_expression,
-                    :duty_expression_ops,
-                    :extra_increment_value,
-                    :errors
-
-      def initialize(measure, system_ops, duty_expression_ops={})
-        @measure = measure
-        @system_ops = system_ops
-        @duty_expression_ops = duty_expression_ops
-        @extra_increment_value = duty_expression_ops[:position]
-
-        @errors = {}
-      end
-
-      def valid?
-        generate_record!
-        validate!
-
-        if @errors.blank? && !measure.new?
-          persist!
-        end
-
-        @errors.blank?
-      end
-
-      def persist!
-        persist_record!(duty_expression)
-      end
+    class MeasureComponents < ::CreateMeasures::ValidationHelpers::SingleAssociation
 
       private
 
         def generate_record!
-          @duty_expression = MeasureComponent.new(
-            unit_ops(duty_expression_ops)
+          @record = MeasureComponent.new(
+            unit_ops(record_ops)
           )
-          duty_expression.measure_sid = measure.measure_sid
-          duty_expression.duty_expression_id = duty_expression_ops[:duty_expression_id]
+          record.measure_sid = measure.measure_sid
+          record.duty_expression_id = record_ops[:duty_expression_id]
 
-          set_primary_key(duty_expression)
-        end
-
-        def validate!
-          ::Measures::ConformanceErrorsParser.new(
-            duty_expression, MeasureComponentValidator, {}
-          ).errors
-           .map do |k, v|
-            @errors[k] = v
-          end
+          set_primary_key(record)
         end
     end
   end

--- a/app/value_objects/create_measures/validation_helpers/multiple_association.rb
+++ b/app/value_objects/create_measures/validation_helpers/multiple_association.rb
@@ -1,0 +1,30 @@
+module CreateMeasures
+  module ValidationHelpers
+    class MultipleAssociation < ::CreateMeasures::ValidationHelpers::AssociationBase
+
+      def valid?
+        generate_records!
+        validate_records!
+
+        if @errors.blank? && !measure.new?
+          persist!
+        end
+
+        @errors.blank?
+      end
+
+      private
+
+        def validate!(record)
+          if validator(record.class.name).present?
+            ::Measures::ConformanceErrorsParser.new(
+              record, validator(record.class.name), {}
+            ).errors
+             .map do |k, v|
+              @errors[k] = v
+            end
+          end
+        end
+    end
+  end
+end

--- a/app/value_objects/create_measures/validation_helpers/single_association.rb
+++ b/app/value_objects/create_measures/validation_helpers/single_association.rb
@@ -1,0 +1,52 @@
+module CreateMeasures
+  module ValidationHelpers
+    class SingleAssociation < ::CreateMeasures::ValidationHelpers::AssociationBase
+
+      attr_accessor :measure,
+                    :system_ops,
+                    :record,
+                    :record_ops,
+                    :extra_increment_value,
+                    :errors
+
+      def initialize(measure, system_ops, record_ops={})
+        @measure = measure
+        @system_ops = system_ops
+        @record_ops = record_ops
+        @extra_increment_value = record_ops[:position]
+
+        @errors = {}
+      end
+
+      def valid?
+        generate_record!
+        validate!
+
+        if @errors.blank? && !measure.new?
+          persist!
+        end
+
+        @errors.blank?
+      end
+
+      def persist!
+        persist_record!(record)
+      end
+
+      private
+
+        def validate!
+          ::Measures::ConformanceErrorsParser.new(
+            record, validator, {}
+          ).errors
+           .map do |k, v|
+            @errors[k] = v
+          end
+        end
+
+        def validator
+          "#{record.class.name}Validator".constantize
+        end
+    end
+  end
+end

--- a/app/views/workbaskets/create_measures/edit.html.slim
+++ b/app/views/workbaskets/create_measures/edit.html.slim
@@ -23,5 +23,9 @@ script
   == "window.current_step = '#{current_step}';"
   == "window.all_settings = #{workbasket_settings.settings.to_json};"
 
+  - unless step_pointer.main_step?
+    == "window.create_measures_start_date = '#{workbasket_settings.start_date}';"
+    == "window.create_measures_end_date = '#{workbasket_settings.end_date}';"
+
   - unless step_pointer.review_and_submit_step?
     == "window.current_step_settings = #{workbasket_settings.step_settings(current_step).to_json};"

--- a/app/views/workbaskets/create_measures/edit.html.slim
+++ b/app/views/workbaskets/create_measures/edit.html.slim
@@ -24,8 +24,8 @@ script
   == "window.all_settings = #{workbasket_settings.settings.to_json};"
 
   - unless step_pointer.main_step?
-    == "window.create_measures_start_date = '#{workbasket_settings.start_date}';"
-    == "window.create_measures_end_date = '#{workbasket_settings.end_date}';"
+    == "window.measure_start_date = '#{workbasket_settings.start_date}';"
+    == "window.measure_end_date = '#{workbasket_settings.end_date}';"
 
   - unless step_pointer.review_and_submit_step?
     == "window.current_step_settings = #{workbasket_settings.step_settings(current_step).to_json};"

--- a/app/views/xml_generation/templates/additional_codes/additional_code.builder
+++ b/app/views/xml_generation/templates/additional_codes/additional_code.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:additional.code") do |additional_code|
-  additional_code.tag!("oub:additional.code.sid") do additional_code
-    xml_data_item(additional_code, self.additional_code_sid)
-  end
-
-  additional_code.tag!("oub:additional.code.type.id") do additional_code
-    xml_data_item(additional_code, self.additional_code_type_id)
-  end
-
-  additional_code.tag!("oub:additional.code") do additional_code
-    xml_data_item(additional_code, self.additional_code)
-  end
-
-  additional_code.tag!("oub:validity.start.date") do additional_code
-    xml_data_item(additional_code, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  additional_code.tag!("oub:validity.end.date") do additional_code
-    xml_data_item(additional_code, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(additional_code, "additional.code.sid", self.additional_code_sid)
+  xml_data_item_v2(additional_code, "additional.code.type.id", self.additional_code_type_id)
+  xml_data_item_v2(additional_code, "additional.code", self.additional_code)
+  xml_data_item_v2(additional_code, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(additional_code, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/additional_codes/additional_code_description.builder
+++ b/app/views/xml_generation/templates/additional_codes/additional_code_description.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:additional.code.description") do |additional_code_description|
-  additional_code_description.tag!("oub:additional.code.description.period.sid") do additional_code_description
-    xml_data_item(additional_code_description, self.additional_code_description_period_sid)
-  end
-
-  additional_code_description.tag!("oub:language.id") do additional_code_description
-    xml_data_item(additional_code_description, self.language_id)
-  end
-
-  additional_code_description.tag!("oub:additional.code.sid") do additional_code_description
-    xml_data_item(additional_code_description, self.additional_code_sid)
-  end
-
-  additional_code_description.tag!("oub:additional.code.type.id") do additional_code_description
-    xml_data_item(additional_code_description, self.additional_code_type_id)
-  end
-
-  additional_code_description.tag!("oub:additional.code") do additional_code_description
-    xml_data_item(additional_code_description, self.additional_code)
-  end
-
-  additional_code_description.tag!("oub:description") do additional_code_description
-    xml_data_item(additional_code_description, self.description)
-  end
+  xml_data_item_v2(additional_code_description, "additional.code.description.period.sid", self.additional_code_description_period_sid)
+  xml_data_item_v2(additional_code_description, "language.id", self.language_id)
+  xml_data_item_v2(additional_code_description, "additional.code.sid", self.additional_code_sid)
+  xml_data_item_v2(additional_code_description, "additional.code.type.id", self.additional_code_type_id)
+  xml_data_item_v2(additional_code_description, "additional.code", self.additional_code)
+  xml_data_item_v2(additional_code_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/additional_codes/additional_code_description_period.builder
+++ b/app/views/xml_generation/templates/additional_codes/additional_code_description_period.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:additional.code.description.period") do |additional_code_description_period|
-  additional_code_description_period.tag!("oub:additional.code.description.period.sid") do additional_code_description_period
-    xml_data_item(additional_code_description_period, self.additional_code_description_period_sid)
-  end
-
-  additional_code_description_period.tag!("oub:additional.code.sid") do additional_code_description_period
-    xml_data_item(additional_code_description_period, self.additional_code_sid)
-  end
-
-  additional_code_description_period.tag!("oub:additional.code.type.id") do additional_code_description_period
-    xml_data_item(additional_code_description_period, self.additional_code_type_id)
-  end
-
-  additional_code_description_period.tag!("oub:additional.code") do additional_code_description_period
-    xml_data_item(additional_code_description_period, self.additional_code)
-  end
-
-  additional_code_description_period.tag!("oub:validity.start.date") do additional_code_description_period
-    xml_data_item(additional_code_description_period, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  additional_code_description_period.tag!("oub:validity.end.date") do additional_code_description_period
-    xml_data_item(additional_code_description_period, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(additional_code_description_period, "additional.code.description.period.sid", self.additional_code_description_period_sid)
+  xml_data_item_v2(additional_code_description_period, "additional.code.sid", self.additional_code_sid)
+  xml_data_item_v2(additional_code_description_period, "additional.code.type.id", self.additional_code_type_id)
+  xml_data_item_v2(additional_code_description_period, "additional.code", self.additional_code)
+  xml_data_item_v2(additional_code_description_period, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(additional_code_description_period, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/additional_codes/additional_code_type.builder
+++ b/app/views/xml_generation/templates/additional_codes/additional_code_type.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:additional.code.type") do |additional_code_type|
-  additional_code_type.tag!("oub:additional.code.type.id") do additional_code_type
-    xml_data_item(additional_code_type, self.additional_code_type_id)
-  end
-
-  additional_code_type.tag!("oub:application.code") do additional_code_type
-    xml_data_item(additional_code_type, self.application_code)
-  end
-
-  additional_code_type.tag!("oub:meursing.table.plan.id") do additional_code_type
-    xml_data_item(additional_code_type, self.meursing_table_plan_id)
-  end
-
-  additional_code_type.tag!("oub:validity.start.date") do additional_code_type
-    xml_data_item(additional_code_type, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  additional_code_type.tag!("oub:validity.end.date") do additional_code_type
-    xml_data_item(additional_code_type, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(additional_code_type, "additional.code.type.id", self.additional_code_type_id)
+  xml_data_item_v2(additional_code_type, "application.code", self.application_code)
+  xml_data_item_v2(additional_code_type, "meursing.table.plan.id", self.meursing_table_plan_id)
+  xml_data_item_v2(additional_code_type, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(additional_code_type, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/additional_codes/additional_code_type_description.builder
+++ b/app/views/xml_generation/templates/additional_codes/additional_code_type_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:additional.code.type.description") do |additional_code_type_description|
-  additional_code_type_description.tag!("oub:additional.code.type.id") do additional_code_type_description
-    xml_data_item(additional_code_type_description, self.additional_code_type_id)
-  end
-
-  additional_code_type_description.tag!("oub:language.id") do additional_code_type_description
-    xml_data_item(additional_code_type_description, self.language_id)
-  end
-
-  additional_code_type_description.tag!("oub:description") do additional_code_type_description
-    xml_data_item(additional_code_type_description, self.description)
-  end
+  xml_data_item_v2(additional_code_type_description, "additional.code.type.id", self.additional_code_type_id)
+  xml_data_item_v2(additional_code_type_description, "language.id", self.language_id)
+  xml_data_item_v2(additional_code_type_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/additional_codes/additional_code_type_measure_type.builder
+++ b/app/views/xml_generation/templates/additional_codes/additional_code_type_measure_type.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:additional.code.type.measure.type") do |additional_code_type_measure_type|
-  additional_code_type_measure_type.tag!("oub:measure.type.id") do additional_code_type_measure_type
-    xml_data_item(additional_code_type_measure_type, self.measure_type_id)
-  end
-
-  additional_code_type_measure_type.tag!("oub:additional.code.type.id") do additional_code_type_measure_type
-    xml_data_item(additional_code_type_measure_type, self.additional_code_type_id)
-  end
-
-  additional_code_type_measure_type.tag!("oub:validity.start.date") do additional_code_type_measure_type
-    xml_data_item(additional_code_type_measure_type, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  additional_code_type_measure_type.tag!("oub:validity.end.date") do additional_code_type_measure_type
-    xml_data_item(additional_code_type_measure_type, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(additional_code_type_measure_type, "measure.type.id", self.measure_type_id)
+  xml_data_item_v2(additional_code_type_measure_type, "additional.code.type.id", self.additional_code_type_id)
+  xml_data_item_v2(additional_code_type_measure_type, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(additional_code_type_measure_type, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/certificates/certificate.builder
+++ b/app/views/xml_generation/templates/certificates/certificate.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:certificate") do |certificate|
-  certificate.tag!("oub:certificate.type.code") do certificate
-    xml_data_item(certificate, self.certificate_type_code)
-  end
-
-  certificate.tag!("oub:certificate.code") do certificate
-    xml_data_item(certificate, self.certificate_code)
-  end
-
-  certificate.tag!("oub:national.abbrev") do certificate
-    xml_data_item(certificate, self.national_abbrev)
-  end
-
-  certificate.tag!("oub:validity.start.date") do certificate
-    xml_data_item(certificate, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  certificate.tag!("oub:validity.end.date") do certificate
-    xml_data_item(certificate, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(certificate, "certificate.type.code", self.certificate_type_code)
+  xml_data_item_v2(certificate, "certificate.code", self.certificate_code)
+  xml_data_item_v2(certificate, "national.abbrev", self.national_abbrev)
+  xml_data_item_v2(certificate, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(certificate, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/certificates/certificate_description.builder
+++ b/app/views/xml_generation/templates/certificates/certificate_description.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:certificate.description") do |certificate_description|
-  certificate_description.tag!("oub:certificate.description.period.sid") do certificate_description
-    xml_data_item(certificate_description, self.certificate_description_period_sid)
-  end
-
-  certificate_description.tag!("oub:certificate.type.code") do certificate_description
-    xml_data_item(certificate_description, self.certificate_type_code)
-  end
-
-  certificate_description.tag!("oub:certificate.code") do certificate_description
-    xml_data_item(certificate_description, self.certificate_code)
-  end
-
-  certificate_description.tag!("oub:language.id") do certificate_description
-    xml_data_item(certificate_description, self.language_id)
-  end
-
-  certificate_description.tag!("oub:description") do certificate_description
-    xml_data_item(certificate_description, self.description)
-  end
+  xml_data_item_v2(certificate_description, "certificate.description.period.sid", self.certificate_description_period_sid)
+  xml_data_item_v2(certificate_description, "certificate.type.code", self.certificate_type_code)
+  xml_data_item_v2(certificate_description, "certificate.code", self.certificate_code)
+  xml_data_item_v2(certificate_description, "language.id", self.language_id)
+  xml_data_item_v2(certificate_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/certificates/certificate_description_period.builder
+++ b/app/views/xml_generation/templates/certificates/certificate_description_period.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:certificate.description.period") do |certificate_description_period|
-  certificate_description_period.tag!("oub:certificate.description.period.sid") do certificate_description_period
-    xml_data_item(certificate_description_period, self.certificate_description_period_sid)
-  end
-
-  certificate_description_period.tag!("oub:certificate.type.code") do certificate_description_period
-    xml_data_item(certificate_description_period, self.certificate_type_code)
-  end
-
-  certificate_description_period.tag!("oub:certificate.code") do certificate_description_period
-    xml_data_item(certificate_description_period, self.certificate_code)
-  end
-
-  certificate_description_period.tag!("oub:validity.start.date") do certificate_description_period
-    xml_data_item(certificate_description_period, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  certificate_description_period.tag!("oub:validity.end.date") do certificate_description_period
-    xml_data_item(certificate_description_period, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(certificate_description_period, "certificate.description.period.sid", self.certificate_description_period_sid)
+  xml_data_item_v2(certificate_description_period, "certificate.type.code", self.certificate_type_code)
+  xml_data_item_v2(certificate_description_period, "certificate.code", self.certificate_code)
+  xml_data_item_v2(certificate_description_period, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(certificate_description_period, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/certificates/certificate_type.builder
+++ b/app/views/xml_generation/templates/certificates/certificate_type.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:certificate.type") do |certificate_type|
-  certificate_type.tag!("oub:certificate.type.code") do certificate_type
-    xml_data_item(certificate_type, self.certificate_type_code)
-  end
-
-  certificate_type.tag!("oub:validity.start.date") do certificate_type
-    xml_data_item(certificate_type, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  certificate_type.tag!("oub:validity.end.date") do certificate_type
-    xml_data_item(certificate_type, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(certificate_type, "certificate.type.code", self.certificate_type_code)
+  xml_data_item_v2(certificate_type, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(certificate_type, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/certificates/certificate_type_description.builder
+++ b/app/views/xml_generation/templates/certificates/certificate_type_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:certificate.type.description") do |certificate_type_description|
-  certificate_type_description.tag!("oub:certificate.type.code") do certificate_type_description
-    xml_data_item(certificate_type_description, self.certificate_type_code)
-  end
-
-  certificate_type_description.tag!("oub:language.id") do certificate_type_description
-    xml_data_item(certificate_type_description, self.language_id)
-  end
-
-  certificate_type_description.tag!("oub:description") do certificate_type_description
-    xml_data_item(certificate_type_description, self.description)
-  end
+  xml_data_item_v2(certificate_type_description, "certificate.type.code", self.certificate_type_code)
+  xml_data_item_v2(certificate_type_description, "language.id", self.language_id)
+  xml_data_item_v2(certificate_type_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/duty_expressions/duty_expression.builder
+++ b/app/views/xml_generation/templates/duty_expressions/duty_expression.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:duty.expression") do |duty_expression|
-  duty_expression.tag!("oub:duty.expression.id") do duty_expression
-    xml_data_item(duty_expression, self.duty_expression_id)
-  end
-
-  duty_expression.tag!("oub:validity.start.date") do duty_expression
-    xml_data_item(duty_expression, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  duty_expression.tag!("oub:validity.end.date") do duty_expression
-    xml_data_item(duty_expression, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  duty_expression.tag!("oub:duty.amount.applicability.code") do duty_expression
-    xml_data_item(duty_expression, self.duty_amount_applicability_code)
-  end
-
-  duty_expression.tag!("oub:measurement.unit.applicability.code") do duty_expression
-    xml_data_item(duty_expression, self.measurement_unit_applicability_code)
-  end
-
-  duty_expression.tag!("oub:monetary.unit.applicability.code") do duty_expression
-    xml_data_item(duty_expression, self.monetary_unit_applicability_code)
-  end
+  xml_data_item_v2(duty_expression, "duty.expression.id", self.duty_expression_id)
+  xml_data_item_v2(duty_expression, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(duty_expression, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(duty_expression, "duty.amount.applicability.code", self.duty_amount_applicability_code)
+  xml_data_item_v2(duty_expression, "measurement.unit.applicability.code", self.measurement_unit_applicability_code)
+  xml_data_item_v2(duty_expression, "monetary.unit.applicability.code", self.monetary_unit_applicability_code)
 end

--- a/app/views/xml_generation/templates/duty_expressions/duty_expression_description.builder
+++ b/app/views/xml_generation/templates/duty_expressions/duty_expression_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:duty.expression.description") do |duty_expression_description|
-  duty_expression_description.tag!("oub:duty.expression.id") do duty_expression_description
-    xml_data_item(duty_expression_description, self.duty_expression_id)
-  end
-
-  duty_expression_description.tag!("oub:language.id") do duty_expression_description
-    xml_data_item(duty_expression_description, self.language_id)
-  end
-
-  duty_expression_description.tag!("oub:description") do duty_expression_description
-    xml_data_item(duty_expression_description, self.description)
-  end
+  xml_data_item_v2(duty_expression_description, "duty.expression.id", self.duty_expression_id)
+  xml_data_item_v2(duty_expression_description, "language.id", self.language_id)
+  xml_data_item_v2(duty_expression_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature.builder
+++ b/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature.builder
@@ -1,33 +1,10 @@
 xml.tag!("oub:export.refund.nomenclature") do |export_refund_nomenclature|
-  export_refund_nomenclature.tag!("oub:export.refund.nomenclature.sid") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.export_refund_nomenclature_sid)
-  end
-
-  export_refund_nomenclature.tag!("oub:goods.nomenclature.item.id") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.goods_nomenclature_item_id)
-  end
-
-  export_refund_nomenclature.tag!("oub:additional.code.type") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.additional_code_type)
-  end
-
-  export_refund_nomenclature.tag!("oub:export.refund.code") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.export_refund_code)
-  end
-
-  export_refund_nomenclature.tag!("oub:productline.suffix") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.productline_suffix)
-  end
-
-  export_refund_nomenclature.tag!("oub:goods.nomenclature.sid") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.goods_nomenclature_sid)
-  end
-
-  export_refund_nomenclature.tag!("oub:validity.start.date") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  export_refund_nomenclature.tag!("oub:validity.end.date") do export_refund_nomenclature
-    xml_data_item(export_refund_nomenclature, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(export_refund_nomenclature, "export.refund.nomenclature.sid", self.export_refund_nomenclature_sid)
+  xml_data_item_v2(export_refund_nomenclature, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(export_refund_nomenclature, "additional.code.type", self.additional_code_type)
+  xml_data_item_v2(export_refund_nomenclature, "export.refund.code", self.export_refund_code)
+  xml_data_item_v2(export_refund_nomenclature, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(export_refund_nomenclature, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(export_refund_nomenclature, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(export_refund_nomenclature, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature_description.builder
+++ b/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature_description.builder
@@ -1,33 +1,10 @@
 xml.tag!("oub:export.refund.nomenclature.description") do |export_refund_nomenclature_description|
-  export_refund_nomenclature_description.tag!("oub:export.refund.nomenclature.description.period.sid") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.export_refund_nomenclature_description_period_sid)
-  end
-
-  export_refund_nomenclature_description.tag!("oub:language.id") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.language_id)
-  end
-
-  export_refund_nomenclature_description.tag!("oub:export.refund.nomenclature.sid") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.export_refund_nomenclature_sid)
-  end
-
-  export_refund_nomenclature_description.tag!("oub:goods.nomenclature.item.id") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.goods_nomenclature_item_id)
-  end
-
-  export_refund_nomenclature_description.tag!("oub:additional.code.type") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.additional_code_type)
-  end
-
-  export_refund_nomenclature_description.tag!("oub:export.refund.code") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.export_refund_code)
-  end
-
-  export_refund_nomenclature_description.tag!("oub:productline.suffix") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.productline_suffix)
-  end
-
-  export_refund_nomenclature_description.tag!("oub:description") do export_refund_nomenclature_description
-    xml_data_item(export_refund_nomenclature_description, self.description)
-  end
+  xml_data_item_v2(export_refund_nomenclature_description, "export.refund.nomenclature.description.period.sid", self.export_refund_nomenclature_description_period_sid)
+  xml_data_item_v2(export_refund_nomenclature_description, "language.id", self.language_id)
+  xml_data_item_v2(export_refund_nomenclature_description, "export.refund.nomenclature.sid", self.export_refund_nomenclature_sid)
+  xml_data_item_v2(export_refund_nomenclature_description, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(export_refund_nomenclature_description, "additional.code.type", self.additional_code_type)
+  xml_data_item_v2(export_refund_nomenclature_description, "export.refund.code", self.export_refund_code)
+  xml_data_item_v2(export_refund_nomenclature_description, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(export_refund_nomenclature_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature_description_period.builder
+++ b/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature_description_period.builder
@@ -1,33 +1,10 @@
 xml.tag!("oub:export.refund.nomenclature.description.period") do |export_refund_nomenclature_description_period|
-  export_refund_nomenclature_description_period.tag!("oub:export.refund.nomenclature.description.period.sid") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.export_refund_nomenclature_description_period_sid)
-  end
-
-  export_refund_nomenclature_description_period.tag!("oub:export.refund.nomenclature.sid") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.export_refund_nomenclature_sid)
-  end
-
-  export_refund_nomenclature_description_period.tag!("oub:goods.nomenclature.item.id") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.goods_nomenclature_item_id)
-  end
-
-  export_refund_nomenclature_description_period.tag!("oub:additional.code.type") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.additional_code_type)
-  end
-
-  export_refund_nomenclature_description_period.tag!("oub:export.refund.code") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.export_refund_code)
-  end
-
-  export_refund_nomenclature_description_period.tag!("oub:productline.suffix") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.productline_suffix)
-  end
-
-  export_refund_nomenclature_description_period.tag!("oub:validity.start.date") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  export_refund_nomenclature_description_period.tag!("oub:validity.end.date") do export_refund_nomenclature_description_period
-    xml_data_item(export_refund_nomenclature_description_period, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(export_refund_nomenclature_description_period, "export.refund.nomenclature.description.period.sid", self.export_refund_nomenclature_description_period_sid)
+  xml_data_item_v2(export_refund_nomenclature_description_period, "export.refund.nomenclature.sid", self.export_refund_nomenclature_sid)
+  xml_data_item_v2(export_refund_nomenclature_description_period, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(export_refund_nomenclature_description_period, "additional.code.type", self.additional_code_type)
+  xml_data_item_v2(export_refund_nomenclature_description_period, "export.refund.code", self.export_refund_code)
+  xml_data_item_v2(export_refund_nomenclature_description_period, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(export_refund_nomenclature_description_period, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(export_refund_nomenclature_description_period, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature_indent.builder
+++ b/app/views/xml_generation/templates/export_refund_nomenclatures/export_refund_nomenclature_indent.builder
@@ -1,37 +1,11 @@
 xml.tag!("oub:export.refund.nomenclature.indents") do |export_refund_nomenclature_indents|
-  export_refund_nomenclature_indents.tag!("oub:export.refund.nomenclature.indents.sid") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.export_refund_nomenclature_indents_sid)
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:export.refund.nomenclature.sid") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.export_refund_nomenclature_sid)
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:number.export.refund.nomenclature.indents") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.number_export_refund_nomenclature_indents)
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:goods.nomenclature.item.id") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.goods_nomenclature_item_id)
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:additional.code.type") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.additional_code_type)
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:export.refund.code") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.export_refund_code)
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:productline.suffix") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.productline_suffix)
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:validity.start.date") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  export_refund_nomenclature_indents.tag!("oub:validity.end.date") do export_refund_nomenclature_indents
-    xml_data_item(export_refund_nomenclature_indents, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(export_refund_nomenclature_indents, "export.refund.nomenclature.indents.sid", self.export_refund_nomenclature_indents_sid)
+  xml_data_item_v2(export_refund_nomenclature_indents, "export.refund.nomenclature.sid", self.export_refund_nomenclature_sid)
+  xml_data_item_v2(export_refund_nomenclature_indents, "number.export.refund.nomenclature.indents", self.number_export_refund_nomenclature_indents)
+  xml_data_item_v2(export_refund_nomenclature_indents, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(export_refund_nomenclature_indents, "additional.code.type", self.additional_code_type)
+  xml_data_item_v2(export_refund_nomenclature_indents, "export.refund.code", self.export_refund_code)
+  xml_data_item_v2(export_refund_nomenclature_indents, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(export_refund_nomenclature_indents, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(export_refund_nomenclature_indents, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:footnote") do |footnote|
-  footnote.tag!("oub:footnote.type.id") do footnote
-    xml_data_item(footnote, self.footnote_type_id)
-  end
-
-  footnote.tag!("oub:footnote.id") do footnote
-    xml_data_item(footnote, self.footnote_id)
-  end
-
-  footnote.tag!("oub:validity.start.date") do footnote
-    xml_data_item(footnote, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  footnote.tag!("oub:validity.end.date") do footnote
-    xml_data_item(footnote, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(footnote, "footnote.type.id", self.footnote_type_id)
+  xml_data_item_v2(footnote, "footnote.id", self.footnote_id)
+  xml_data_item_v2(footnote, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(footnote, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_association_additional_code.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_association_additional_code.builder
@@ -1,29 +1,9 @@
 xml.tag!("oub:footnote.association.additional.code") do |footnote_association_additional_code|
-  footnote_association_additional_code.tag!("oub:additional.code.sid") do footnote_association_additional_code
-    xml_data_item(footnote_association_additional_code, self.additional_code_sid)
-  end
-
-  footnote_association_additional_code.tag!("oub:footnote.type.id") do footnote_association_additional_code
-    xml_data_item(footnote_association_additional_code, self.footnote_type_id)
-  end
-
-  footnote_association_additional_code.tag!("oub:footnote.id") do footnote_association_additional_code
-    xml_data_item(footnote_association_additional_code, self.footnote_id)
-  end
-
-  footnote_association_additional_code.tag!("oub:additional.code.type.id") do footnote_association_additional_code
-    xml_data_item(footnote_association_additional_code, self.additional_code_type_id)
-  end
-
-  footnote_association_additional_code.tag!("oub:additional.code") do footnote_association_additional_code
-    xml_data_item(footnote_association_additional_code, self.additional_code)
-  end
-
-  footnote_association_additional_code.tag!("oub:validity.start.date") do footnote_association_additional_code
-    xml_data_item(footnote_association_additional_code, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  footnote_association_additional_code.tag!("oub:validity.end.date") do footnote_association_additional_code
-    xml_data_item(footnote_association_additional_code, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(footnote_association_additional_code, "additional.code.sid", self.additional_code_sid)
+  xml_data_item_v2(footnote_association_additional_code, "footnote.type.id", self.footnote_type_id)
+  xml_data_item_v2(footnote_association_additional_code, "footnote.id", self.footnote_id)
+  xml_data_item_v2(footnote_association_additional_code, "additional.code.type.id", self.additional_code_type_id)
+  xml_data_item_v2(footnote_association_additional_code, "additional.code", self.additional_code)
+  xml_data_item_v2(footnote_association_additional_code, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(footnote_association_additional_code, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_association_ern.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_association_ern.builder
@@ -1,37 +1,11 @@
 xml.tag!("oub:footnote.association.ern") do |footnote_association_ern|
-  footnote_association_ern.tag!("oub:export.refund.nomenclature.sid") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.export_refund_nomenclature_sid)
-  end
-
-  footnote_association_ern.tag!("oub:footnote.type") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.footnote_type)
-  end
-
-  footnote_association_ern.tag!("oub:footnote.id") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.footnote_id)
-  end
-
-  footnote_association_ern.tag!("oub:goods.nomenclature.item.id") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.goods_nomenclature_item_id)
-  end
-
-  footnote_association_ern.tag!("oub:additional.code.type") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.additional_code_type)
-  end
-
-  footnote_association_ern.tag!("oub:export.refund.code") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.export_refund_code)
-  end
-
-  footnote_association_ern.tag!("oub:productline.suffix") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.productline_suffix)
-  end
-
-  footnote_association_ern.tag!("oub:validity.start.date") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  footnote_association_ern.tag!("oub:validity.end.date") do footnote_association_ern
-    xml_data_item(footnote_association_ern, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(footnote_association_ern, "export.refund.nomenclature.sid", self.export_refund_nomenclature_sid)
+  xml_data_item_v2(footnote_association_ern, "footnote.type", self.footnote_type)
+  xml_data_item_v2(footnote_association_ern, "footnote.id", self.footnote_id)
+  xml_data_item_v2(footnote_association_ern, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(footnote_association_ern, "additional.code.type", self.additional_code_type)
+  xml_data_item_v2(footnote_association_ern, "export.refund.code", self.export.refund.code)
+  xml_data_item_v2(footnote_association_ern, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(footnote_association_ern, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(footnote_association_ern, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_association_goods_nomenclature.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_association_goods_nomenclature.builder
@@ -1,29 +1,9 @@
 xml.tag!("oub:footnote.association.goods.nomenclature") do |footnote_association_goods_nomenclature|
-  footnote_association_goods_nomenclature.tag!("oub:goods.nomenclature.sid") do footnote_association_goods_nomenclature
-    xml_data_item(footnote_association_goods_nomenclature, self.goods_nomenclature_sid)
-  end
-
-  footnote_association_goods_nomenclature.tag!("oub:footnote.type") do footnote_association_goods_nomenclature
-    xml_data_item(footnote_association_goods_nomenclature, self.footnote_type)
-  end
-
-  footnote_association_goods_nomenclature.tag!("oub:footnote.id") do footnote_association_goods_nomenclature
-    xml_data_item(footnote_association_goods_nomenclature, self.footnote_id)
-  end
-
-  footnote_association_goods_nomenclature.tag!("oub:goods.nomenclature.item.id") do footnote_association_goods_nomenclature
-    xml_data_item(footnote_association_goods_nomenclature, self.goods_nomenclature_item_id)
-  end
-
-  footnote_association_goods_nomenclature.tag!("oub:productline.suffix") do footnote_association_goods_nomenclature
-    xml_data_item(footnote_association_goods_nomenclature, self.productline_suffix)
-  end
-
-  footnote_association_goods_nomenclature.tag!("oub:validity.start.date") do footnote_association_goods_nomenclature
-    xml_data_item(footnote_association_goods_nomenclature, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  footnote_association_goods_nomenclature.tag!("oub:validity.end.date") do footnote_association_goods_nomenclature
-    xml_data_item(footnote_association_goods_nomenclature, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(footnote_association_goods_nomenclature, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(footnote_association_goods_nomenclature, "footnote.type", self.footnote_type)
+  xml_data_item_v2(footnote_association_goods_nomenclature, "footnote.id", self.footnote_id)
+  xml_data_item_v2(footnote_association_goods_nomenclature, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(footnote_association_goods_nomenclature, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(footnote_association_goods_nomenclature, "validity.start.date", self.self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(footnote_association_goods_nomenclature, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_association_measure.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_association_measure.builder
@@ -1,14 +1,6 @@
 xml.tag!("oub:footnote.association.measure") do |footnote_association_measure|
-  footnote_association_measure.tag!("oub:measure.sid") do footnote_association_measure
-    xml_data_item(footnote_association_measure, self.measure_sid)
-  end
-
-  footnote_association_measure.tag!("oub:footnote.type.id") do footnote_association_measure
-    xml_data_item(footnote_association_measure, self.footnote_type_id)
-  end
-
-  footnote_association_measure.tag!("oub:footnote.id") do footnote_association_measure
-    xml_data_item(footnote_association_measure, self.footnote_id)
-  end
+  xml_data_item_v2(footnote_association_measure, "measure.sid", self.measure_sid)
+  xml_data_item_v2(footnote_association_measure, "footnote.type.id", self.footnote_type_id)
+  xml_data_item_v2(footnote_association_measure, "footnote.id", self.footnote_id)
 end
 

--- a/app/views/xml_generation/templates/footnotes/footnote_association_meursing_heading.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_association_meursing_heading.builder
@@ -1,29 +1,9 @@
 xml.tag!("oub:footnote.association.meursing.heading") do |footnote_association_meursing_heading|
-  footnote_association_meursing_heading.tag!("oub:meursing.table.plan.id") do footnote_association_meursing_heading
-    xml_data_item(footnote_association_meursing_heading, self.meursing_table_plan_id)
-  end
-
-  footnote_association_meursing_heading.tag!("oub:meursing.heading.number") do footnote_association_meursing_heading
-    xml_data_item(footnote_association_meursing_heading, self.meursing_heading_number)
-  end
-
-  footnote_association_meursing_heading.tag!("oub:row.column.code") do footnote_association_meursing_heading
-    xml_data_item(footnote_association_meursing_heading, self.row_column_code)
-  end
-
-  footnote_association_meursing_heading.tag!("oub:footnote.type") do footnote_association_meursing_heading
-    xml_data_item(footnote_association_meursing_heading, self.footnote_type)
-  end
-
-  footnote_association_meursing_heading.tag!("oub:footnote.id") do footnote_association_meursing_heading
-    xml_data_item(footnote_association_meursing_heading, self.footnote_id)
-  end
-
-  footnote_association_meursing_heading.tag!("oub:validity.start.date") do footnote_association_meursing_heading
-    xml_data_item(footnote_association_meursing_heading, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  footnote_association_meursing_heading.tag!("oub:validity.end.date") do footnote_association_meursing_heading
-    xml_data_item(footnote_association_meursing_heading, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(footnote_association_meursing_heading, "meursing.table.plan.id", self.meursing_table_plan_id)
+  xml_data_item_v2(footnote_association_meursing_heading, "meursing.heading.number", self.meursing_heading_number)
+  xml_data_item_v2(footnote_association_meursing_heading, "row.column.code", self.row_column_code)
+  xml_data_item_v2(footnote_association_meursing_heading, "footnote.type", self.footnote_type)
+  xml_data_item_v2(footnote_association_meursing_heading, "footnote.id", self.footnote_id)
+  xml_data_item_v2(footnote_association_meursing_heading, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(footnote_association_meursing_heading, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_description.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_description.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:footnote.description") do |footnote_description|
-  footnote_description.tag!("oub:footnote.description.period.sid") do footnote_description
-    xml_data_item(footnote_description, self.footnote_description_period_sid)
-  end
-
-  footnote_description.tag!("oub:language.id") do footnote_description
-    xml_data_item(footnote_description, self.language_id)
-  end
-
-  footnote_description.tag!("oub:footnote.type.id") do footnote_description
-    xml_data_item(footnote_description, self.footnote_type_id)
-  end
-
-  footnote_description.tag!("oub:footnote.id") do footnote_description
-    xml_data_item(footnote_description, self.footnote_id)
-  end
-
-  footnote_description.tag!("oub:description") do footnote_description
-    xml_data_item(footnote_description, self.description)
-  end
+  xml_data_item_v2(footnote_description, "footnote.description.period.sid", self.footnote_description_period_sid)
+  xml_data_item_v2(footnote_description, "language.id", self.language_id)
+  xml_data_item_v2(footnote_description, "footnote.type.id", self.footnote_type_id)
+  xml_data_item_v2(footnote_description, "footnote.id", self.footnote_id)
+  xml_data_item_v2(footnote_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_description_period.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_description_period.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:footnote.description.period") do |footnote_description_period|
-  footnote_description_period.tag!("oub:footnote.description.period.sid") do footnote_description_period
-    xml_data_item(footnote_description_period, self.footnote_description_period_sid)
-  end
-
-  footnote_description_period.tag!("oub:footnote.type.id") do footnote_description_period
-    xml_data_item(footnote_description_period, self.footnote_type_id)
-  end
-
-  footnote_description_period.tag!("oub:footnote.id") do footnote_description_period
-    xml_data_item(footnote_description_period, self.footnote_id)
-  end
-
-  footnote_description_period.tag!("oub:validity.start.date") do footnote_description_period
-    xml_data_item(footnote_description_period, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  footnote_description_period.tag!("oub:validity.end.date") do footnote_description_period
-    xml_data_item(footnote_description_period, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(footnote_description_period, "footnote.description.period.sid", self.footnote_description_period_sid)
+  xml_data_item_v2(footnote_description_period, "footnote.type.id", self.footnote_type_id)
+  xml_data_item_v2(footnote_description_period, "footnote.id", self.footnote_id)
+  xml_data_item_v2(footnote_description_period, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(footnote_description_period, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_type.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_type.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:footnote.type") do |footnote_type|
-  footnote_type.tag!("oub:footnote.type.id") do footnote_type
-    xml_data_item(footnote_type, self.footnote_type_id)
-  end
-
-  footnote_type.tag!("oub:application.code") do footnote_type
-    xml_data_item(footnote_type, self.application_code)
-  end
-
-  footnote_type.tag!("oub:validity.start.date") do footnote_type
-    xml_data_item(footnote_type, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  footnote_type.tag!("oub:validity.end.date") do footnote_type
-    xml_data_item(footnote_type, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(footnote_type, "footnote.type.id", self.footnote_type_id)
+  xml_data_item_v2(footnote_type, "application.code", self.application_code)
+  xml_data_item_v2(footnote_type, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(footnote_type, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/footnotes/footnote_type_description.builder
+++ b/app/views/xml_generation/templates/footnotes/footnote_type_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:footnote.type.description") do |footnote_type_description|
-  footnote_type_description.tag!("oub:footnote.type.id") do footnote_type_description
-    xml_data_item(footnote_type_description, self.footnote_type_id)
-  end
-
-  footnote_type_description.tag!("oub:language.id") do footnote_type_description
-    xml_data_item(footnote_type_description, self.language_id)
-  end
-
-  footnote_type_description.tag!("oub:description") do footnote_type_description
-    xml_data_item(footnote_type_description, self.description)
-  end
+  xml_data_item_v2(footnote_type_description, "footnote.type.id", self.footnote_type_id)
+  xml_data_item_v2(footnote_type_description, "language.id", self.language_id)
+  xml_data_item_v2(footnote_type_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/geographical_areas/geographical_area.builder
+++ b/app/views/xml_generation/templates/geographical_areas/geographical_area.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:geographical.area") do |geographical_area|
-  geographical_area.tag!("oub:geographical.area.sid") do geographical_area
-    xml_data_item(geographical_area, self.geographical_area_sid)
-  end
-
-  geographical_area.tag!("oub:geographical.area.id") do geographical_area
-    xml_data_item(geographical_area, self.geographical_area_id)
-  end
-
-  geographical_area.tag!("oub:geographical.code") do geographical_area
-    xml_data_item(geographical_area, self.geographical_code)
-  end
-
-  geographical_area.tag!("oub:parent.geographical.area.group.sid") do geographical_area
-    xml_data_item(geographical_area, self.parent_geographical_area_group_sid)
-  end
-
-  geographical_area.tag!("oub:validity.start.date") do geographical_area
-    xml_data_item(geographical_area, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  geographical_area.tag!("oub:validity.end.date") do geographical_area
-    xml_data_item(geographical_area, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(geographical_area, "geographical.area.sid", self.geographical_area_sid)
+  xml_data_item_v2(geographical_area, "geographical.area.id", self.geographical_area_id)
+  xml_data_item_v2(geographical_area, "geographical.code", self.geographical_code)
+  xml_data_item_v2(geographical_area, "parent.geographical.area.group.sid", self.parent_geographical_area_group_sid)
+  xml_data_item_v2(geographical_area, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(geographical_area, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/geographical_areas/geographical_area_description.builder
+++ b/app/views/xml_generation/templates/geographical_areas/geographical_area_description.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:geographical.area.description") do |geographical_area_description|
-  geographical_area_description.tag!("oub:geographical.area.description.period.sid") do geographical_area_description
-    xml_data_item(geographical_area_description, self.geographical_area_description_period_sid)
-  end
-
-  geographical_area_description.tag!("oub:geographical.area.sid") do geographical_area_description
-    xml_data_item(geographical_area_description, self.geographical_area_sid)
-  end
-
-  geographical_area_description.tag!("oub:geographical.area.id") do geographical_area_description
-    xml_data_item(geographical_area_description, self.geographical_area_id)
-  end
-
-  geographical_area_description.tag!("oub:language.id") do geographical_area_description
-    xml_data_item(geographical_area_description, self.language_id)
-  end
-
-  geographical_area_description.tag!("oub:description") do geographical_area_description
-    xml_data_item(geographical_area_description, self.description)
-  end
+  xml_data_item_v2(geographical_area_description, "geographical.area.description.period.sid", self.geographical_area_description_period_sid)
+  xml_data_item_v2(geographical_area_description, "geographical.area.sid", self.geographical_area_sid)
+  xml_data_item_v2(geographical_area_description, "geographical.area.id", self.geographical_area_id)
+  xml_data_item_v2(geographical_area_description, "language.id", self.language_id)
+  xml_data_item_v2(geographical_area_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/geographical_areas/geographical_area_description_period.builder
+++ b/app/views/xml_generation/templates/geographical_areas/geographical_area_description_period.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:geographical.area.description.period") do |geographical_area_description_period|
-  geographical_area_description_period.tag!("oub:geographical.area.description.period.sid") do geographical_area_description_period
-    xml_data_item(geographical_area_description_period, self.geographical_area_description_period_sid)
-  end
-
-  geographical_area_description_period.tag!("oub:geographical.area.sid") do geographical_area_description_period
-    xml_data_item(geographical_area_description_period, self.geographical_area_sid)
-  end
-
-  geographical_area_description_period.tag!("oub:geographical.area.id") do geographical_area_description_period
-    xml_data_item(geographical_area_description_period, self.geographical_area_id)
-  end
-
-  geographical_area_description_period.tag!("oub:validity.start.date") do geographical_area_description_period
-    xml_data_item(geographical_area_description_period, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  geographical_area_description_period.tag!("oub:validity.end.date") do geographical_area_description_period
-    xml_data_item(geographical_area_description_period, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(geographical_area_description_period, "geographical.area.description.period.sid", self.geographical_area_description_period_sid)
+  xml_data_item_v2(geographical_area_description_period, "geographical.area.sid", self.geographical_area_sid)
+  xml_data_item_v2(geographical_area_description_period, "geographical.area.id", self.geographical_area_id)
+  xml_data_item_v2(geographical_area_description_period, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(geographical_area_description_period, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/geographical_areas/geographical_area_membership.builder
+++ b/app/views/xml_generation/templates/geographical_areas/geographical_area_membership.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:geographical.area.membership") do |geographical_area_membership|
-  geographical_area_membership.tag!("oub:geographical.area.sid") do geographical_area_membership
-    xml_data_item(geographical_area_membership, self.geographical_area_sid)
-  end
-
-  geographical_area_membership.tag!("oub:geographical.area.group.sid") do geographical_area_membership
-    xml_data_item(geographical_area_membership, self.geographical_area_group_sid)
-  end
-
-  geographical_area_membership.tag!("oub:validity.start.date") do geographical_area_membership
-    xml_data_item(geographical_area_membership, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  geographical_area_membership.tag!("oub:validity.end.date") do geographical_area_membership
-    xml_data_item(geographical_area_membership, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(geographical_area_membership, "geographical.area.sid", self.geographical_area_sid)
+  xml_data_item_v2(geographical_area_membership, "geographical.area.group.sid", self.geographical_area_group_sid)
+  xml_data_item_v2(geographical_area_membership, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(geographical_area_membership, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:goods.nomenclature") do |goods_nomenclature|
-  goods_nomenclature.tag!("oub:goods.nomenclature.sid") do goods_nomenclature
-    xml_data_item(goods_nomenclature, self.goods_nomenclature_sid)
-  end
-
-  goods_nomenclature.tag!("oub:goods.nomenclature.item.id") do goods_nomenclature
-    xml_data_item(goods_nomenclature, self.goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature.tag!("oub:producline.suffix") do goods_nomenclature
-    xml_data_item(goods_nomenclature, self.producline_suffix)
-  end
-
-  goods_nomenclature.tag!("oub:statistical.indicator") do goods_nomenclature
-    xml_data_item(goods_nomenclature, self.statistical_indicator)
-  end
-
-  goods_nomenclature.tag!("oub:validity.start.date") do goods_nomenclature
-    xml_data_item(goods_nomenclature, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  goods_nomenclature.tag!("oub:validity.end.date") do goods_nomenclature
-    xml_data_item(goods_nomenclature, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(goods_nomenclature, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(goods_nomenclature, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature, "producline.suffix", self.producline_suffix)
+  xml_data_item_v2(goods_nomenclature, "statistical.indicator", self.statistical_indicator)
+  xml_data_item_v2(goods_nomenclature, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(goods_nomenclature, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_description.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_description.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:goods.nomenclature.description") do |goods_nomenclature_description|
-  goods_nomenclature_description.tag!("oub:goods.nomenclature.description.period.sid") do goods_nomenclature_description
-    xml_data_item(goods_nomenclature_description, self.goods_nomenclature_description_period_sid)
-  end
-
-  goods_nomenclature_description.tag!("oub:goods.nomenclature.sid") do goods_nomenclature_description
-    xml_data_item(goods_nomenclature_description, self.goods_nomenclature_sid)
-  end
-
-  goods_nomenclature_description.tag!("oub:goods.nomenclature.item.id") do goods_nomenclature_description
-    xml_data_item(goods_nomenclature_description, self.goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature_description.tag!("oub:productline.suffix") do goods_nomenclature_description
-    xml_data_item(goods_nomenclature_description, self.productline_suffix)
-  end
-
-  goods_nomenclature_description.tag!("oub:language.id") do goods_nomenclature_description
-    xml_data_item(goods_nomenclature_description, self.language_id)
-  end
-
-  goods_nomenclature_description.tag!("oub:description") do goods_nomenclature_description
-    xml_data_item(goods_nomenclature_description, self.description)
-  end
+  xml_data_item_v2(goods_nomenclature_description, "goods.nomenclature.description.period.sid", self.goods_nomenclature_description_period_sid)
+  xml_data_item_v2(goods_nomenclature_description, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(goods_nomenclature_description, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature_description, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(goods_nomenclature_description, "language.id", self.language_id)
+  xml_data_item_v2(goods_nomenclature_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_description_period.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_description_period.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:goods.nomenclature.description.period") do |goods_nomenclature_description_period|
-  goods_nomenclature_description_period.tag!("oub:goods.nomenclature.description.period.sid") do goods_nomenclature_description_period
-    xml_data_item(goods_nomenclature_description_period, self.goods_nomenclature_description_period_sid)
-  end
-
-  goods_nomenclature_description_period.tag!("oub:goods.nomenclature.sid") do goods_nomenclature_description_period
-    xml_data_item(goods_nomenclature_description_period, self.goods_nomenclature_sid)
-  end
-
-  goods_nomenclature_description_period.tag!("oub:goods.nomenclature.item.id") do goods_nomenclature_description_period
-    xml_data_item(goods_nomenclature_description_period, self.goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature_description_period.tag!("oub:productline.suffix") do goods_nomenclature_description_period
-    xml_data_item(goods_nomenclature_description_period, self.productline_suffix)
-  end
-
-  goods_nomenclature_description_period.tag!("oub:validity.start.date") do goods_nomenclature_description_period
-    xml_data_item(goods_nomenclature_description_period, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  goods_nomenclature_description_period.tag!("oub:validity.end.date") do goods_nomenclature_description_period
-    xml_data_item(goods_nomenclature_description_period, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(goods_nomenclature_description_period, "goods.nomenclature.description.period.sid", self.goods_nomenclature_description_period_sid)
+  xml_data_item_v2(goods_nomenclature_description_period, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(goods_nomenclature_description_period, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature_description_period, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(goods_nomenclature_description_period, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(goods_nomenclature_description_period, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_group.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_group.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:goods.nomenclature.group") do |goods_nomenclature_group|
-  goods_nomenclature_group.tag!("oub:goods.nomenclature.group.type") do goods_nomenclature_group
-    xml_data_item(goods_nomenclature_group, self.goods_nomenclature_group_type)
-  end
-
-  goods_nomenclature_group.tag!("oub:goods.nomenclature.group.id") do goods_nomenclature_group
-    xml_data_item(goods_nomenclature_group, self.goods_nomenclature_group_id)
-  end
-
-  goods_nomenclature_group.tag!("oub:nomenclature.group.facility.code") do goods_nomenclature_group
-    xml_data_item(goods_nomenclature_group, self.nomenclature_group_facility_code)
-  end
-
-  goods_nomenclature_group.tag!("oub:validity.start.date") do goods_nomenclature_group
-    xml_data_item(goods_nomenclature_group, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  goods_nomenclature_group.tag!("oub:validity.end.date") do goods_nomenclature_group
-    xml_data_item(goods_nomenclature_group, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(goods_nomenclature_group, "goods.nomenclature.group.type", self.goods_nomenclature_group_type)
+  xml_data_item_v2(goods_nomenclature_group, "goods.nomenclature.group.id", self.goods_nomenclature_group_id)
+  xml_data_item_v2(goods_nomenclature_group, "nomenclature.group.facility.code", self.nomenclature_group_facility_code)
+  xml_data_item_v2(goods_nomenclature_group, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(goods_nomenclature_group, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_group_description.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_group_description.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:goods.nomenclature.group.description") do |goods_nomenclature_group_description|
-  goods_nomenclature_group_description.tag!("oub:goods.nomenclature.group.type") do goods_nomenclature_group_description
-    xml_data_item(goods_nomenclature_group_description, self.goods_nomenclature_group_type)
-  end
-
-  goods_nomenclature_group_description.tag!("oub:goods.nomenclature.group.id") do goods_nomenclature_group_description
-    xml_data_item(goods_nomenclature_group_description, self.goods_nomenclature_group_id)
-  end
-
-  goods_nomenclature_group_description.tag!("oub:language.id") do goods_nomenclature_group_description
-    xml_data_item(goods_nomenclature_group_description, self.language_id)
-  end
-
-  goods_nomenclature_group_description.tag!("oub:description") do goods_nomenclature_group_description
-    xml_data_item(goods_nomenclature_group_description, self.description)
-  end
+  xml_data_item_v2(goods_nomenclature_group_description, "goods.nomenclature.group.type", self.goods_nomenclature_group_type)
+  xml_data_item_v2(goods_nomenclature_group_description, "goods.nomenclature.group.id", self.goods_nomenclature_group_id)
+  xml_data_item_v2(goods_nomenclature_group_description, "language.id", self.language_id)
+  xml_data_item_v2(goods_nomenclature_group_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_indent.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_indent.builder
@@ -1,29 +1,9 @@
 xml.tag!("oub:goods.nomenclature.indents") do |goods_nomenclature_indent|
-  goods_nomenclature_indent.tag!("oub:goods.nomenclature.indent.sid") do goods_nomenclature_indent
-    xml_data_item(goods_nomenclature_indent, self.goods_nomenclature_indent_sid)
-  end
-
-  goods_nomenclature_indent.tag!("oub:goods.nomenclature.sid") do goods_nomenclature_indent
-    xml_data_item(goods_nomenclature_indent, self.goods_nomenclature_sid)
-  end
-
-  goods_nomenclature_indent.tag!("oub:goods.nomenclature.item.id") do goods_nomenclature_indent
-    xml_data_item(goods_nomenclature_indent, self.goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature_indent.tag!("oub:number.indents") do goods_nomenclature_indent
-    xml_data_item(goods_nomenclature_indent, self.number_indents)
-  end
-
-  goods_nomenclature_indent.tag!("oub:productline.suffix") do goods_nomenclature_indent
-    xml_data_item(goods_nomenclature_indent, self.productline_suffix)
-  end
-
-  goods_nomenclature_indent.tag!("oub:validity.start.date") do goods_nomenclature_indent
-    xml_data_item(goods_nomenclature_indent, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  goods_nomenclature_indent.tag!("oub:validity.end.date") do goods_nomenclature_indent
-    xml_data_item(goods_nomenclature_indent, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(goods_nomenclature_indent, "goods.nomenclature.indent.sid", self.goods_nomenclature_indent_sid)
+  xml_data_item_v2(goods_nomenclature_indent, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(goods_nomenclature_indent, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature_indent, "number.indents", self.number_indents)
+  xml_data_item_v2(goods_nomenclature_indent, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(goods_nomenclature_indent, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(goods_nomenclature_indent, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_origin.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_origin.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:goods.nomenclature.origin") do |goods_nomenclature_origin|
-  goods_nomenclature_origin.tag!("oub:goods.nomenclature.sid") do goods_nomenclature_origin
-    xml_data_item(goods_nomenclature_origin, self.goods_nomenclature_sid)
-  end
-
-  goods_nomenclature_origin.tag!("oub:derived.goods.nomenclature.item.id") do goods_nomenclature_origin
-    xml_data_item(goods_nomenclature_origin, self.derived_goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature_origin.tag!("oub:derived.productline.suffix") do goods_nomenclature_origin
-    xml_data_item(goods_nomenclature_origin, self.derived_productline_suffix)
-  end
-
-  goods_nomenclature_origin.tag!("oub:goods.nomenclature.item.id") do goods_nomenclature_origin
-    xml_data_item(goods_nomenclature_origin, self.goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature_origin.tag!("oub:productline.suffix") do goods_nomenclature_origin
-    xml_data_item(goods_nomenclature_origin, self.productline_suffix)
-  end
+  xml_data_item_v2(goods_nomenclature_origin, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(goods_nomenclature_origin, "derived.goods.nomenclature.item.id", self.derived_goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature_origin, "derived.productline.suffix", self.derived_productline_suffix)
+  xml_data_item_v2(goods_nomenclature_origin, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature_origin, "productline.suffix", self.productline_suffix)
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_successor.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/goods_nomenclature_successor.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:goods.nomenclature.successor") do |goods_nomenclature_successor|
-  goods_nomenclature_successor.tag!("oub:goods.nomenclature.sid") do goods_nomenclature_successor
-    xml_data_item(goods_nomenclature_successor, self.goods_nomenclature_sid)
-  end
-
-  goods_nomenclature_successor.tag!("oub:absorbed.goods.nomenclature.item.id") do goods_nomenclature_successor
-    xml_data_item(goods_nomenclature_successor, self.absorbed_goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature_successor.tag!("oub:absorbed.productline.suffix") do goods_nomenclature_successor
-    xml_data_item(goods_nomenclature_successor, self.absorbed_productline_suffix)
-  end
-
-  goods_nomenclature_successor.tag!("oub:goods.nomenclature.item.id") do goods_nomenclature_successor
-    xml_data_item(goods_nomenclature_successor, self.goods_nomenclature_item_id)
-  end
-
-  goods_nomenclature_successor.tag!("oub:productline.suffix") do goods_nomenclature_successor
-    xml_data_item(goods_nomenclature_successor, self.productline_suffix)
-  end
+  xml_data_item_v2(goods_nomenclature_successor, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(goods_nomenclature_successor, "absorbed.goods.nomenclature.item.id", self.absorbed_goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature_successor, "absorbed.productline.suffix", self.absorbed_productline_suffix)
+  xml_data_item_v2(goods_nomenclature_successor, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(goods_nomenclature_successor, "productline.suffix", self.productline_suffix)
 end

--- a/app/views/xml_generation/templates/goods_nomenclatures/nomenclature_group_membership.builder
+++ b/app/views/xml_generation/templates/goods_nomenclatures/nomenclature_group_membership.builder
@@ -1,29 +1,9 @@
 xml.tag!("oub:nomenclature.group.membership") do |nomenclature_group_membership|
-  nomenclature_group_membership.tag!("oub:goods.nomenclature.sid") do nomenclature_group_membership
-    xml_data_item(nomenclature_group_membership, self.goods_nomenclature_sid)
-  end
-
-  nomenclature_group_membership.tag!("oub:goods.nomenclature.group.type") do nomenclature_group_membership
-    xml_data_item(nomenclature_group_membership, self.goods_nomenclature_group_type)
-  end
-
-  nomenclature_group_membership.tag!("oub:goods.nomenclature.group.id") do nomenclature_group_membership
-    xml_data_item(nomenclature_group_membership, self.goods_nomenclature_group_id)
-  end
-
-  nomenclature_group_membership.tag!("oub:goods.nomenclature.item.id") do nomenclature_group_membership
-    xml_data_item(nomenclature_group_membership, self.goods_nomenclature_item_id)
-  end
-
-  nomenclature_group_membership.tag!("oub:productline.suffix") do nomenclature_group_membership
-    xml_data_item(nomenclature_group_membership, self.productline_suffix)
-  end
-
-  nomenclature_group_membership.tag!("oub:validity.start.date") do nomenclature_group_membership
-    xml_data_item(nomenclature_group_membership, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  nomenclature_group_membership.tag!("oub:validity.end.date") do nomenclature_group_membership
-    xml_data_item(nomenclature_group_membership, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(nomenclature_group_membership, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(nomenclature_group_membership, "goods.nomenclature.group.type", self.goods_nomenclature_group_type)
+  xml_data_item_v2(nomenclature_group_membership, "goods.nomenclature.group.id", self.goods_nomenclature_group_id)
+  xml_data_item_v2(nomenclature_group_membership, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(nomenclature_group_membership, "productline.suffix", self.productline_suffix)
+  xml_data_item_v2(nomenclature_group_membership, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(nomenclature_group_membership, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measurements/measurement.builder
+++ b/app/views/xml_generation/templates/measurements/measurement.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:measurement") do |measurement|
-  measurement.tag!("oub:measurement.unit.code") do measurement
-    xml_data_item(measurement, self.measurement_unit_code)
-  end
-
-  measurement.tag!("oub:measurement.unit.qualifier.code") do measurement
-    xml_data_item(measurement, self.measurement_unit_qualifier_code)
-  end
-
-  measurement.tag!("oub:validity.start.date") do measurement
-    xml_data_item(measurement, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measurement.tag!("oub:validity.end.date") do measurement
-    xml_data_item(measurement, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(measurement, "measurement.unit.code", self.measurement_unit_code)
+  xml_data_item_v2(measurement, "measurement.unit.qualifier.code", self.measurement_unit_qualifier_code)
+  xml_data_item_v2(measurement, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measurement, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measurements/measurement_unit.builder
+++ b/app/views/xml_generation/templates/measurements/measurement_unit.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measurement.unit") do |measurement_unit|
-  measurement_unit.tag!("oub:measurement.unit.code") do measurement_unit
-    xml_data_item(measurement_unit, self.measurement_unit_code)
-  end
-
-  measurement_unit.tag!("oub:validity.start.date") do measurement_unit
-    xml_data_item(measurement_unit, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measurement_unit.tag!("oub:validity.end.date") do measurement_unit
-    xml_data_item(measurement_unit, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(measurement_unit, "measurement.unit.code", self.measurement_unit_code)
+  xml_data_item_v2(measurement_unit, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measurement_unit, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measurements/measurement_unit_description.builder
+++ b/app/views/xml_generation/templates/measurements/measurement_unit_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measurement.unit.description") do |measurement_unit_description|
-  measurement_unit_description.tag!("oub:measurement.unit.code") do measurement_unit_description
-    xml_data_item(measurement_unit_description, self.measurement_unit_code)
-  end
-
-  measurement_unit_description.tag!("oub:language.id") do measurement_unit_description
-    xml_data_item(measurement_unit_description, self.language_id)
-  end
-
-  measurement_unit_description.tag!("oub:description") do measurement_unit_description
-    xml_data_item(measurement_unit_description, self.description)
-  end
+  xml_data_item_v2(measurement_unit_description, "measurement.unit.code", self.measurement_unit_code)
+  xml_data_item_v2(measurement_unit_description, "language.id", self.language_id)
+  xml_data_item_v2(measurement_unit_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/measurements/measurement_unit_qualifier.builder
+++ b/app/views/xml_generation/templates/measurements/measurement_unit_qualifier.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measurement.unit.qualifier") do |measurement_unit_qualifier|
-  measurement_unit_qualifier.tag!("oub:measurement.unit.qualifier.code") do measurement_unit_qualifier
-    xml_data_item(measurement_unit_qualifier, self.measurement_unit_qualifier_code)
-  end
-
-  measurement_unit_qualifier.tag!("oub:validity.start.date") do measurement_unit_qualifier
-    xml_data_item(measurement_unit_qualifier, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measurement_unit_qualifier.tag!("oub:validity.end.date") do measurement_unit_qualifier
-    xml_data_item(measurement_unit_qualifier, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(measurement_unit_qualifier, "measurement.unit.qualifier.code", self.measurement_unit_qualifier_code)
+  xml_data_item_v2(measurement_unit_qualifier, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measurement_unit_qualifier, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measurements/measurement_unit_qualifier_description.builder
+++ b/app/views/xml_generation/templates/measurements/measurement_unit_qualifier_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measurement.unit.qualifier.description") do |measurement_unit_qualifier_description|
-  measurement_unit_qualifier_description.tag!("oub:measurement.unit.qualifier.code") do measurement_unit_qualifier_description
-    xml_data_item(measurement_unit_qualifier_description, self.measurement_unit_qualifier_code)
-  end
-
-  measurement_unit_qualifier_description.tag!("oub:language.id") do measurement_unit_qualifier_description
-    xml_data_item(measurement_unit_qualifier_description, self.language_id)
-  end
-
-  measurement_unit_qualifier_description.tag!("oub:description") do measurement_unit_qualifier_description
-    xml_data_item(measurement_unit_qualifier_description, self.description)
-  end
+  xml_data_item_v2(measurement_unit_qualifier_description, "measurement.unit.qualifier.code", self.measurement_unit_qualifier_code)
+  xml_data_item_v2(measurement_unit_qualifier_description, "language.id", self.language_id)
+  xml_data_item_v2(measurement_unit_qualifier_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/measures/measure.builder
+++ b/app/views/xml_generation/templates/measures/measure.builder
@@ -1,77 +1,21 @@
 xml.tag!("oub:measure") do |measure|
-  measure.tag!("oub:measure.sid") do measure
-    xml_data_item(measure, self.measure_sid)
-  end
-
-  measure.tag!("oub:measure.type") do measure
-    xml_data_item(measure, self.measure_type_id)
-  end
-
-  measure.tag!("oub:validity.start.date") do measure
-    xml_data_item(measure, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measure.tag!("oub:validity.end.date") do measure
-    xml_data_item(measure, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  measure.tag!("oub:geographical.area") do measure
-    xml_data_item(measure, self.geographical_area_id)
-  end
-
-  measure.tag!("oub:geographical.area.sid") do measure
-    xml_data_item(measure, self.geographical_area_sid)
-  end
-
-  measure.tag!("oub:goods.nomenclature.item.id") do measure
-    xml_data_item(measure, self.goods_nomenclature_item_id)
-  end
-
-  measure.tag!("oub:goods.nomenclature.sid") do measure
-    xml_data_item(measure, self.goods_nomenclature_sid)
-  end
-
-  measure.tag!("oub:additional.code.sid") do measure
-    xml_data_item(measure, self.additional_code_sid)
-  end
-
-  measure.tag!("oub:additional.code") do measure
-    xml_data_item(measure, self.additional_code_id)
-  end
-
-  measure.tag!("oub:additional.code.type") do measure
-    xml_data_item(measure, self.additional_code_type_id)
-  end
-
-  measure.tag!("oub:measure.generating.regulation.role") do measure
-    xml_data_item(measure, self.measure_generating_regulation_role)
-  end
-
-  measure.tag!("oub:measure.generating.regulation.id") do measure
-    xml_data_item(measure, self.measure_generating_regulation_id)
-  end
-
-  measure.tag!("oub:justification.regulation.role") do measure
-    xml_data_item(measure, self.justification_regulation_role)
-  end
-
-  measure.tag!("oub:justification.regulation.id") do measure
-    xml_data_item(measure, self.justification_regulation_id)
-  end
-
-  measure.tag!("oub:export.refund.nomenclature.sid") do measure
-    xml_data_item(measure, self.export_refund_nomenclature_sid)
-  end
-
-  measure.tag!("oub:ordernumber") do measure
-    xml_data_item(measure, self.ordernumber)
-  end
-
-  measure.tag!("oub:reduction.indicator") do measure
-    xml_data_item(measure, self.reduction_indicator)
-  end
-
-  measure.tag!("oub:stopped.flag") do measure
-    xml_data_item(measure, self.stopped_flag)
-  end
+  xml_data_item_v2(measure, "measure.sid", self.measure_sid)
+  xml_data_item_v2(measure, "measure.type", self.measure_type_id)
+  xml_data_item_v2(measure, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measure, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(measure, "geographical.area", self.geographical_area_id)
+  xml_data_item_v2(measure, "geographical.area.sid", self.geographical_area_sid)
+  xml_data_item_v2(measure, "goods.nomenclature.item.id", self.goods_nomenclature_item_id)
+  xml_data_item_v2(measure, "goods.nomenclature.sid", self.goods_nomenclature_sid)
+  xml_data_item_v2(measure, "additional.code.sid", self.additional_code_sid)
+  xml_data_item_v2(measure, "additional.code", self.additional_code_id)
+  xml_data_item_v2(measure, "additional.code.type", self.additional_code_type_id)
+  xml_data_item_v2(measure, "measure.generating.regulation.role", self.measure_generating_regulation_role)
+  xml_data_item_v2(measure, "measure.generating.regulation.id", self.measure_generating_regulation_id)
+  xml_data_item_v2(measure, "justification.regulation.role", self.justification_regulation_role)
+  xml_data_item_v2(measure, "justification.regulation.id", self.justification_regulation_id)
+  xml_data_item_v2(measure, "export.refund.nomenclature.sid", self.export_refund_nomenclature_sid)
+  xml_data_item_v2(measure, "ordernumber", self.ordernumber)
+  xml_data_item_v2(measure, "reduction.indicator", self.reduction_indicator)
+  xml_data_item_v2(measure, "stopped.flag", self.stopped_flag)
 end

--- a/app/views/xml_generation/templates/measures/measure_action.builder
+++ b/app/views/xml_generation/templates/measures/measure_action.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measure.action") do |measure_action|
-  measure_action.tag!("oub:action.code") do measure_action
-    xml_data_item(measure_action, self.action_code)
-  end
-
-  measure_action.tag!("oub:validity.start.date") do measure_action
-    xml_data_item(measure_action, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measure_action.tag!("oub:validity.end.date") do measure_action
-    xml_data_item(measure_action, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(measure_action, "action.code", self.action_code)
+  xml_data_item_v2(measure_action, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measure_action, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measures/measure_action_description.builder
+++ b/app/views/xml_generation/templates/measures/measure_action_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measure.action.description") do |measure_action_description|
-  measure_action_description.tag!("oub:action.code") do measure_action_description
-    xml_data_item(measure_action_description, self.action_code)
-  end
-
-  measure_action_description.tag!("oub:language.id") do measure_action_description
-    xml_data_item(measure_action_description, self.language_id)
-  end
-
-  measure_action_description.tag!("oub:description") do measure_action_description
-    xml_data_item(measure_action_description, self.description)
-  end
+  xml_data_item_v2(measure_action_description, "action.code", self.action_code)
+  xml_data_item_v2(measure_action_description, "language.id", self.language_id)
+  xml_data_item_v2(measure_action_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/measures/measure_component.builder
+++ b/app/views/xml_generation/templates/measures/measure_component.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:measure.component") do |measure_component|
-  measure_component.tag!("oub:measure.sid") do measure_component
-    xml_data_item(measure_component, self.measure_sid)
-  end
-
-  measure_component.tag!("oub:duty.expression.id") do measure_component
-    xml_data_item(measure_component, self.duty_expression_id)
-  end
-
-  measure_component.tag!("oub:duty.amount") do measure_component
-    xml_data_item(measure_component, self.duty_amount)
-  end
-
-  measure_component.tag!("oub:monetary.unit.code") do measure_component
-    xml_data_item(measure_component, self.monetary_unit_code)
-  end
-
-  measure_component.tag!("oub:measurement.unit.code") do measure_component
-    xml_data_item(measure_component, self.measurement_unit_code)
-  end
-
-  measure_component.tag!("oub:measurement.unit.qualifier.code") do measure_component
-    xml_data_item(measure_component, self.measurement_unit_qualifier_code)
-  end
+  xml_data_item_v2(measure_component, "measure.sid", self.measure_sid)
+  xml_data_item_v2(measure_component, "duty.expression.id", self.duty_expression_id)
+  xml_data_item_v2(measure_component, "duty.amount", self.duty_amount)
+  xml_data_item_v2(measure_component, "monetary.unit.code", self.monetary_unit_code)
+  xml_data_item_v2(measure_component, "measurement.unit.code", self.measurement_unit_code)
+  xml_data_item_v2(measure_component, "measurement.unit.qualifier.code", self.measurement_unit_qualifier_code)
 end

--- a/app/views/xml_generation/templates/measures/measure_condition.builder
+++ b/app/views/xml_generation/templates/measures/measure_condition.builder
@@ -1,45 +1,13 @@
 xml.tag!("oub:measure.condition") do |measure_condition|
-  measure_condition.tag!("oub:measure.condition.sid") do measure_condition
-    xml_data_item(measure_condition, self.measure_condition_sid)
-  end
-
-  measure_condition.tag!("oub:measure.sid") do measure_condition
-    xml_data_item(measure_condition, self.measure_sid)
-  end
-
-  measure_condition.tag!("oub:condition.code") do measure_condition
-    xml_data_item(measure_condition, self.condition_code)
-  end
-
-  measure_condition.tag!("oub:component.sequence.number") do measure_condition
-    xml_data_item(measure_condition, self.component_sequence_number)
-  end
-
-  measure_condition.tag!("oub:condition.duty.amount") do measure_condition
-    xml_data_item(measure_condition, self.condition_duty_amount)
-  end
-
-  measure_condition.tag!("oub:condition.monetary.unit.code") do measure_condition
-    xml_data_item(measure_condition, self.condition_monetary_unit_code)
-  end
-
-  measure_condition.tag!("oub:condition.measurement.unit.code") do measure_condition
-    xml_data_item(measure_condition, self.condition_measurement_unit_code)
-  end
-
-  measure_condition.tag!("oub:condition.measurement.unit.qualifier.code") do measure_condition
-    xml_data_item(measure_condition, self.condition_measurement_unit_qualifier_code)
-  end
-
-  measure_condition.tag!("oub:action.code") do measure_condition
-    xml_data_item(measure_condition, self.action_code)
-  end
-
-  measure_condition.tag!("oub:certificate.type.code") do measure_condition
-    xml_data_item(measure_condition, self.certificate_type_code)
-  end
-
-  measure_condition.tag!("oub:certificate.code") do measure_condition
-    xml_data_item(measure_condition, self.certificate_code)
-  end
+  xml_data_item_v2(measure_condition, "measure.condition.sid", self.measure_condition_sid)
+  xml_data_item_v2(measure_condition, "measure.sid", self.measure_sid)
+  xml_data_item_v2(measure_condition, "condition.code", self.condition_code)
+  xml_data_item_v2(measure_condition, "component.sequence.number", self.component_sequence_number)
+  xml_data_item_v2(measure_condition, "condition.duty.amount", self.condition_duty_amount)
+  xml_data_item_v2(measure_condition, "condition.monetary.unit.code", self.condition_monetary_unit_code)
+  xml_data_item_v2(measure_condition, "ondition.measurement.unit.code", self.condition_measurement_unit_code)
+  xml_data_item_v2(measure_condition, "condition.measurement.unit.qualifier.code", self.condition_measurement_unit_qualifier_code)
+  xml_data_item_v2(measure_condition, "action.code", self.action_code)
+  xml_data_item_v2(measure_condition, "certificate.type.code", self.certificate_type_code)
+  xml_data_item_v2(measure_condition, "certificate.code", self.certificate_code)
 end

--- a/app/views/xml_generation/templates/measures/measure_condition.builder
+++ b/app/views/xml_generation/templates/measures/measure_condition.builder
@@ -5,7 +5,7 @@ xml.tag!("oub:measure.condition") do |measure_condition|
   xml_data_item_v2(measure_condition, "component.sequence.number", self.component_sequence_number)
   xml_data_item_v2(measure_condition, "condition.duty.amount", self.condition_duty_amount)
   xml_data_item_v2(measure_condition, "condition.monetary.unit.code", self.condition_monetary_unit_code)
-  xml_data_item_v2(measure_condition, "ondition.measurement.unit.code", self.condition_measurement_unit_code)
+  xml_data_item_v2(measure_condition, "condition.measurement.unit.code", self.condition_measurement_unit_code)
   xml_data_item_v2(measure_condition, "condition.measurement.unit.qualifier.code", self.condition_measurement_unit_qualifier_code)
   xml_data_item_v2(measure_condition, "action.code", self.action_code)
   xml_data_item_v2(measure_condition, "certificate.type.code", self.certificate_type_code)

--- a/app/views/xml_generation/templates/measures/measure_condition_code.builder
+++ b/app/views/xml_generation/templates/measures/measure_condition_code.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measure.condition.code") do |measure_condition_code|
-  measure_condition_code.tag!("oub:condition.code") do measure_condition_code
-    xml_data_item(measure_condition_code, self.condition_code)
-  end
-
-  measure_condition_code.tag!("oub:validity.start.date") do measure_condition_code
-    xml_data_item(measure_condition_code, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measure_condition_code.tag!("oub:validity.end.date") do measure_condition_code
-    xml_data_item(measure_condition_code, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(measure_condition_code, "condition.code", self.condition_code)
+  xml_data_item_v2(measure_condition_code, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measure_condition_code, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measures/measure_condition_code_description.builder
+++ b/app/views/xml_generation/templates/measures/measure_condition_code_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measure.condition.code.description") do |measure_condition_code_description|
-  measure_condition_code_description.tag!("oub:condition.code") do measure_condition_code_description
-    xml_data_item(measure_condition_code_description, self.condition_code)
-  end
-
-  measure_condition_code_description.tag!("oub:language.id") do measure_condition_code_description
-    xml_data_item(measure_condition_code_description, self.language_id)
-  end
-
-  measure_condition_code_description.tag!("oub:description") do measure_condition_code_description
-    xml_data_item(measure_condition_code_description, self.description)
-  end
+  xml_data_item_v2(measure_condition_code_description, "condition.code", self.condition_code)
+  xml_data_item_v2(measure_condition_code_description, "language.id", self.language_id)
+  xml_data_item_v2(measure_condition_code_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/measures/measure_condition_component.builder
+++ b/app/views/xml_generation/templates/measures/measure_condition_component.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:measure.condition.component") do |measure_condition_component|
-  measure_condition_component.tag!("oub:measure.condition.sid") do measure_condition_component
-    xml_data_item(measure_condition_component, self.measure_condition_sid)
-  end
-
-  measure_condition_component.tag!("oub:duty.expression.id") do measure_condition_component
-    xml_data_item(measure_condition_component, self.duty_expression_id)
-  end
-
-  measure_condition_component.tag!("oub:duty.amount") do measure_condition_component
-    xml_data_item(measure_condition_component, self.duty_amount)
-  end
-
-  measure_condition_component.tag!("oub:monetary.unit.code") do measure_condition_component
-    xml_data_item(measure_condition_component, self.monetary_unit_code)
-  end
-
-  measure_condition_component.tag!("oub:measurement.unit.code") do measure_condition_component
-    xml_data_item(measure_condition_component, self.measurement_unit_code)
-  end
-
-  measure_condition_component.tag!("oub:measurement.unit.qualifier.code") do measure_condition_component
-    xml_data_item(measure_condition_component, self.measurement_unit_qualifier_code)
-  end
+  xml_data_item_v2(measure_condition_component, "measure.condition.sid", self.measure_condition_sid)
+  xml_data_item_v2(measure_condition_component, "duty.expression.id", self.duty_expression_id)
+  xml_data_item_v2(measure_condition_component, "duty.amount", self.duty_amount)
+  xml_data_item_v2(measure_condition_component, "monetary.unit.code", self.monetary_unit_code)
+  xml_data_item_v2(measure_condition_component, "measurement.unit.code", self.measurement_unit_code)
+  xml_data_item_v2(measure_condition_component, "measurement.unit.qualifier.code", self.measurement_unit_qualifier_code)
 end

--- a/app/views/xml_generation/templates/measures/measure_excluded_geographical_area.builder
+++ b/app/views/xml_generation/templates/measures/measure_excluded_geographical_area.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measure.excluded.geographical.area") do |measure_excluded_geographical_area|
-  measure_excluded_geographical_area.tag!("oub:measure.sid") do measure_excluded_geographical_area
-    xml_data_item(measure_excluded_geographical_area, self.measure_sid)
-  end
-
-  measure_excluded_geographical_area.tag!("oub:excluded.geographical.area") do measure_excluded_geographical_area
-    xml_data_item(measure_excluded_geographical_area, self.excluded_geographical_area)
-  end
-
-  measure_excluded_geographical_area.tag!("oub:geographical.area.sid") do measure_excluded_geographical_area
-    xml_data_item(measure_excluded_geographical_area, self.geographical_area_sid)
-  end
+  xml_data_item_v2(measure_excluded_geographical_area, "measure.sid", self.measure_sid)
+  xml_data_item_v2(measure_excluded_geographical_area, "excluded.geographical.area", self.excluded_geographical_area)
+  xml_data_item_v2(measure_excluded_geographical_area, "geographical.area.sid", self.geographical_area_sid)
 end

--- a/app/views/xml_generation/templates/measures/measure_partial_temporary_stop.builder
+++ b/app/views/xml_generation/templates/measures/measure_partial_temporary_stop.builder
@@ -1,37 +1,11 @@
 xml.tag!("oub:measure.partial.temporary.stop") do |measure_partial_temporary_stop|
-  measure_partial_temporary_stop.tag!("oub:measure.sid") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.measure_sid)
-  end
-
-  measure_partial_temporary_stop.tag!("oub:partial.temporary.stop.regulation.id") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.partial_temporary_stop_regulation_id)
-  end
-
-  measure_partial_temporary_stop.tag!("oub:partial.temporary.stop.regulation.officialjournal.number") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.partial_temporary_stop_regulation_officialjournal_number)
-  end
-
-  measure_partial_temporary_stop.tag!("oub:partial.temporary.stop.regulation.officialjournal.page") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.partial_temporary_stop_regulation_officialjournal_page)
-  end
-
-  measure_partial_temporary_stop.tag!("oub:abrogation.regulation.id") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.abrogation_regulation_id)
-  end
-
-  measure_partial_temporary_stop.tag!("oub:abrogation.regulation.officialjournal.number") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.abrogation_regulation_officialjournal_number)
-  end
-
-  measure_partial_temporary_stop.tag!("oub:abrogation.regulation.officialjournal.page") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.abrogation_regulation_officialjournal_page)
-  end
-
-  measure_partial_temporary_stop.tag!("oub:validity.start.date") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measure_partial_temporary_stop.tag!("oub:validity.end.date") do measure_partial_temporary_stop
-    xml_data_item(measure_partial_temporary_stop, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(measure_partial_temporary_stop, "measure.sid", self.measure_sid)
+  xml_data_item_v2(measure_partial_temporary_stop, "partial.temporary.stop.regulation.id", self.partial_temporary_stop_regulation_id)
+  xml_data_item_v2(measure_partial_temporary_stop, "partial.temporary.stop.regulation.officialjournal.number", self.partial_temporary_stop_regulation_officialjournal_number)
+  xml_data_item_v2(measure_partial_temporary_stop, "partial.temporary.stop.regulation.officialjournal.page", self.partial_temporary_stop_regulation_officialjournal_page)
+  xml_data_item_v2(measure_partial_temporary_stop, "abrogation.regulation.id", self.abrogation_regulation_id)
+  xml_data_item_v2(measure_partial_temporary_stop, "abrogation.regulation.officialjournal.number", self.abrogation_regulation_officialjournal_number)
+  xml_data_item_v2(measure_partial_temporary_stop, "abrogation.regulation.officialjournal.page", self.abrogation_regulation_officialjournal_page)
+  xml_data_item_v2(measure_partial_temporary_stop, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measure_partial_temporary_stop, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measures/measure_type.builder
+++ b/app/views/xml_generation/templates/measures/measure_type.builder
@@ -1,41 +1,12 @@
 xml.tag!("oub:measure.type") do |measure_type|
-  measure_type.tag!("oub:measure.type.id") do measure_type
-    xml_data_item(measure_type, self.measure_type_id)
-  end
-
-  measure_type.tag!("oub:validity.start.date") do measure_type
-    xml_data_item(measure_type, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measure_type.tag!("oub:validity.end.date") do measure_type
-    xml_data_item(measure_type, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  measure_type.tag!("oub:trade.movement.code") do measure_type
-    xml_data_item(measure_type, self.trade_movement_code)
-  end
-
-  measure_type.tag!("oub:priority.code") do measure_type
-    xml_data_item(measure_type, self.priority_code)
-  end
-
-  measure_type.tag!("oub:measure.component.applicable.code") do measure_type
-    xml_data_item(measure_type, self.measure_component_applicable_code)
-  end
-
-  measure_type.tag!("oub:origin.dest.code") do measure_type
-    xml_data_item(measure_type, self.origin_dest_code)
-  end
-
-  measure_type.tag!("oub:order.number.capture.code") do measure_type
-    xml_data_item(measure_type, self.order_number_capture_code)
-  end
-
-  measure_type.tag!("oub:measure.explosion.level") do measure_type
-    xml_data_item(measure_type, self.measure_explosion_level)
-  end
-
-  measure_type.tag!("oub:measure.type.series.id") do measure_type
-    xml_data_item(measure_type, self.measure_type_series_id)
-  end
+  xml_data_item_v2(measure_type, "measure.type.id", self.measure_type_id)
+  xml_data_item_v2(measure_type, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measure_type, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(measure_type, "trade.movement.code", self.trade_movement_code)
+  xml_data_item_v2(measure_type, "priority.code", self.priority_code)
+  xml_data_item_v2(measure_type, "measure.component.applicable.code", self.measure_component_applicable_code)
+  xml_data_item_v2(measure_type, "origin.dest.code", self.origin_dest_code)
+  xml_data_item_v2(measure_type, "order.number.capture.code", self.order_number_capture_code)
+  xml_data_item_v2(measure_type, "measure.explosion.level", self.measure_explosion_level)
+  xml_data_item_v2(measure_type, "measure.type.series.id", self.measure_type_series_id)
 end

--- a/app/views/xml_generation/templates/measures/measure_type_description.builder
+++ b/app/views/xml_generation/templates/measures/measure_type_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measure.type.description") do |measure_type_description|
-  measure_type_description.tag!("oub:measure.type.id") do measure_type_description
-    xml_data_item(measure_type_description, self.measure_type_id)
-  end
-
-  measure_type_description.tag!("oub:language.id") do measure_type_description
-    xml_data_item(measure_type_description, self.language_id)
-  end
-
-  measure_type_description.tag!("oub:description") do measure_type_description
-    xml_data_item(measure_type_description, self.description)
-  end
+  xml_data_item_v2(measure_type_description, "measure.type.id", self.measure_type_id)
+  xml_data_item_v2(measure_type_description, "language.id", self.language_id)
+  xml_data_item_v2(measure_type_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/measures/measure_type_series.builder
+++ b/app/views/xml_generation/templates/measures/measure_type_series.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:measure.type.series") do |measure_type_series|
-  measure_type_series.tag!("oub:measure.type.series.id") do measure_type_series
-    xml_data_item(measure_type_series, self.measure_type_series_id)
-  end
-
-  measure_type_series.tag!("oub:measure.type.combination") do measure_type_series
-    xml_data_item(measure_type_series, self.measure_type_combination)
-  end
-
-  measure_type_series.tag!("oub:validity.start.date") do measure_type_series
-    xml_data_item(measure_type_series, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  measure_type_series.tag!("oub:validity.end.date") do measure_type_series
-    xml_data_item(measure_type_series, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(measure_type_series, "measure.type.series.id", self.measure_type_series_id)
+  xml_data_item_v2(measure_type_series, "measure.type.combination", self.measure_type_combination)
+  xml_data_item_v2(measure_type_series, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(measure_type_series, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/measures/measure_type_series_description.builder
+++ b/app/views/xml_generation/templates/measures/measure_type_series_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:measure.type.series.description") do |measure_type_series_description|
-  measure_type_series_description.tag!("oub:measure.type.series.id") do measure_type_series_description
-    xml_data_item(measure_type_series_description, self.measure_type_series_id)
-  end
-
-  measure_type_series_description.tag!("oub:language.id") do measure_type_series_description
-    xml_data_item(measure_type_series_description, self.language_id)
-  end
-
-  measure_type_series_description.tag!("oub:description") do measure_type_series_description
-    xml_data_item(measure_type_series_description, self.description)
-  end
+  xml_data_item_v2(measure_type_series_description, "measure.type.series.id", self.measure_type_series_id)
+  xml_data_item_v2(measure_type_series_description, "language.id", self.language_id)
+  xml_data_item_v2(measure_type_series_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/meursing/meursing_additional_code.builder
+++ b/app/views/xml_generation/templates/meursing/meursing_additional_code.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:meursing.additional.code") do |meursing_additional_code|
-  meursing_additional_code.tag!("oub:meursing.additional.code.sid") do meursing_additional_code
-    xml_data_item(meursing_additional_code, self.meursing_additional_code_sid)
-  end
-
-  meursing_additional_code.tag!("oub:additional.code") do meursing_additional_code
-    xml_data_item(meursing_additional_code, self.additional_code)
-  end
-
-  meursing_additional_code.tag!("oub:validity.start.date") do meursing_additional_code
-    xml_data_item(meursing_additional_code, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  meursing_additional_code.tag!("oub:validity.end.date") do meursing_additional_code
-    xml_data_item(meursing_additional_code, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(meursing_additional_code, "meursing.additional.code.sid", self.meursing_additional_code_sid)
+  xml_data_item_v2(meursing_additional_code, "additional.code", self.additional_code)
+  xml_data_item_v2(meursing_additional_code, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(meursing_additional_code, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/meursing/meursing_heading.builder
+++ b/app/views/xml_generation/templates/meursing/meursing_heading.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:meursing.heading") do |meursing_heading|
-  meursing_heading.tag!("oub:meursing.table.plan.id") do meursing_heading
-    xml_data_item(meursing_heading, self.meursing_table_plan_id)
-  end
-
-  meursing_heading.tag!("oub:meursing.heading.number") do meursing_heading
-    xml_data_item(meursing_heading, self.meursing_heading_number)
-  end
-
-  meursing_heading.tag!("oub:row.column.code") do meursing_heading
-    xml_data_item(meursing_heading, self.row_column_code)
-  end
-
-  meursing_heading.tag!("oub:validity.start.date") do meursing_heading
-    xml_data_item(meursing_heading, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  meursing_heading.tag!("oub:validity.end.date") do meursing_heading
-    xml_data_item(meursing_heading, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(meursing_heading, "meursing.table.plan.id", self.meursing_table_plan_id)
+  xml_data_item_v2(meursing_heading, "meursing.heading.number", self.meursing_heading_number)
+  xml_data_item_v2(meursing_heading, "row.column.code", self.row_column_code)
+  xml_data_item_v2(meursing_heading, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(meursing_heading, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/meursing/meursing_heading_text.builder
+++ b/app/views/xml_generation/templates/meursing/meursing_heading_text.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:meursing.heading.text") do |meursing_heading_text|
-  meursing_heading_text.tag!("oub:meursing.table.plan.id") do meursing_heading_text
-    xml_data_item(meursing_heading_text, self.meursing_table_plan_id)
-  end
-
-  meursing_heading_text.tag!("oub:meursing.heading.number") do meursing_heading_text
-    xml_data_item(meursing_heading_text, self.meursing_heading_number)
-  end
-
-  meursing_heading_text.tag!("oub:row.column.code") do meursing_heading_text
-    xml_data_item(meursing_heading_text, self.row_column_code)
-  end
-
-  meursing_heading_text.tag!("oub:language.id") do meursing_heading_text
-    xml_data_item(meursing_heading_text, self.language_id)
-  end
-
-  meursing_heading_text.tag!("oub:description") do meursing_heading_text
-    xml_data_item(meursing_heading_text, self.description)
-  end
+  xml_data_item_v2(meursing_heading_text, "meursing.table.plan.id", self.meursing_table_plan_id)
+  xml_data_item_v2(meursing_heading_text, "meursing.heading.number", self.meursing_heading_number)
+  xml_data_item_v2(meursing_heading_text, "row.column.code", self.row_column_code)
+  xml_data_item_v2(meursing_heading_text, "language.id", self.language_id)
+  xml_data_item_v2(meursing_heading_text, "description", self.description)
 end

--- a/app/views/xml_generation/templates/meursing/meursing_subheading.builder
+++ b/app/views/xml_generation/templates/meursing/meursing_subheading.builder
@@ -1,29 +1,9 @@
 xml.tag!("oub:meursing.subheading") do |meursing_subheading|
-  meursing_subheading.tag!("oub:meursing.table.plan.id") do meursing_subheading
-    xml_data_item(meursing_subheading, self.meursing_table_plan_id)
-  end
-
-  meursing_subheading.tag!("oub:meursing.heading.number") do meursing_subheading
-    xml_data_item(meursing_subheading, self.meursing_heading_number)
-  end
-
-  meursing_subheading.tag!("oub:row.column.code") do meursing_subheading
-    xml_data_item(meursing_subheading, self.row_column_code)
-  end
-
-  meursing_subheading.tag!("oub:subheading.sequence.number") do meursing_subheading
-    xml_data_item(meursing_subheading, self.subheading_sequence_number)
-  end
-
-  meursing_subheading.tag!("oub:description") do meursing_subheading
-    xml_data_item(meursing_subheading, self.description)
-  end
-
-  meursing_subheading.tag!("oub:validity.start.date") do meursing_subheading
-    xml_data_item(meursing_subheading, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  meursing_subheading.tag!("oub:validity.end.date") do meursing_subheading
-    xml_data_item(meursing_subheading, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(meursing_subheading, "meursing.table.plan.id", self.meursing_table_plan_id)
+  xml_data_item_v2(meursing_subheading, "meursing.heading.number", self.meursing_heading_number)
+  xml_data_item_v2(meursing_subheading, "row.column.code", self.row_column_code)
+  xml_data_item_v2(meursing_subheading, "subheading.sequence.number", self.subheading_sequence_number)
+  xml_data_item_v2(meursing_subheading, "description", self.description)
+  xml_data_item_v2(meursing_subheading, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(meursing_subheading, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/meursing/meursing_table_cell_component.builder
+++ b/app/views/xml_generation/templates/meursing/meursing_table_cell_component.builder
@@ -1,33 +1,10 @@
 xml.tag!("oub:meursing.table.cell.component") do |meursing_table_cell_component|
-  meursing_table_cell_component.tag!("oub:meursing.additional.code.sid") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.meursing_additional_code_sid)
-  end
-
-  meursing_table_cell_component.tag!("oub:meursing.table.plan.id") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.meursing_table_plan_id)
-  end
-
-  meursing_table_cell_component.tag!("oub:heading.number") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.heading_number)
-  end
-
-  meursing_table_cell_component.tag!("oub:row.column.code") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.row_column_code)
-  end
-
-  meursing_table_cell_component.tag!("oub:subheading.sequence.number") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.subheading_sequence_number)
-  end
-
-  meursing_table_cell_component.tag!("oub:additional.code") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.additional_code)
-  end
-
-  meursing_table_cell_component.tag!("oub:validity.start.date") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  meursing_table_cell_component.tag!("oub:validity.end.date") do meursing_table_cell_component
-    xml_data_item(meursing_table_cell_component, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(meursing_table_cell_component, "meursing.additional.code.sid", self.meursing_additional_code_sid)
+  xml_data_item_v2(meursing_table_cell_component, "meursing.table.plan.id", self.meursing_table_plan_id)
+  xml_data_item_v2(meursing_table_cell_component, "heading.number", self.heading_number)
+  xml_data_item_v2(meursing_table_cell_component, "row.column.code", self.row_column_code)
+  xml_data_item_v2(meursing_table_cell_component, "subheading.sequence.number", self.subheading_sequence_number)
+  xml_data_item_v2(meursing_table_cell_component, "additional.code", self.additional_code)
+  xml_data_item_v2(meursing_table_cell_component, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(meursing_table_cell_component, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/meursing/meursing_table_plan.builder
+++ b/app/views/xml_generation/templates/meursing/meursing_table_plan.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:meursing.table.plan") do |meursing_table_plan|
-  meursing_table_plan.tag!("oub:meursing.table.plan.id") do meursing_table_plan
-    xml_data_item(meursing_table_plan, self.meursing_table_plan_id)
-  end
-
-  meursing_table_plan.tag!("oub:validity.start.date") do meursing_table_plan
-    xml_data_item(meursing_table_plan, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  meursing_table_plan.tag!("oub:validity.end.date") do meursing_table_plan
-    xml_data_item(meursing_table_plan, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(meursing_table_plan, "meursing.table.plan.id", self.meursing_table_plan_id)
+  xml_data_item_v2(meursing_table_plan, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(meursing_table_plan, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/monetary/monetary_exchange_period.builder
+++ b/app/views/xml_generation/templates/monetary/monetary_exchange_period.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:monetary.exchange.period") do |monetary_exchange_period|
-  monetary_exchange_period.tag!("oub:monetary.exchange.period.sid") do monetary_exchange_period
-    xml_data_item(monetary_exchange_period, self.monetary_exchange_period_sid)
-  end
-
-  monetary_exchange_period.tag!("oub:parent.monetary.unit.code") do monetary_exchange_period
-    xml_data_item(monetary_exchange_period, self.parent_monetary_unit_code)
-  end
-
-  monetary_exchange_period.tag!("oub:validity.start.date") do monetary_exchange_period
-    xml_data_item(monetary_exchange_period, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  monetary_exchange_period.tag!("oub:validity.end.date") do monetary_exchange_period
-    xml_data_item(monetary_exchange_period, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(monetary_exchange_period, "monetary.exchange.period.sid", self.monetary_exchange_period_sid)
+  xml_data_item_v2(monetary_exchange_period, "parent.monetary.unit.code", self.parent_monetary_unit_code)
+  xml_data_item_v2(monetary_exchange_period, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(monetary_exchange_period, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/monetary/monetary_exchange_rate.builder
+++ b/app/views/xml_generation/templates/monetary/monetary_exchange_rate.builder
@@ -1,5 +1,5 @@
 xml.tag!("oub:monetary.exchange.rate") do |monetary_exchange_rate|
   xml_data_item_v2(monetary_exchange_rate, "monetary.exchange.period.sid", self.monetary_exchange_period_sid)
   xml_data_item_v2(monetary_exchange_rate, "child.monetary.unit.code", self.child_monetary_unit_code)
-  xml_data_item_v2(monetary_exchange_rate, "exchange.rate", self.exchange_rate))
+  xml_data_item_v2(monetary_exchange_rate, "exchange.rate", self.exchange_rate)
 end

--- a/app/views/xml_generation/templates/monetary/monetary_exchange_rate.builder
+++ b/app/views/xml_generation/templates/monetary/monetary_exchange_rate.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:monetary.exchange.rate") do |monetary_exchange_rate|
-  monetary_exchange_rate.tag!("oub:monetary.exchange.period.sid") do monetary_exchange_rate
-    xml_data_item(monetary_exchange_rate, self.monetary_exchange_period_sid)
-  end
-
-  monetary_exchange_rate.tag!("oub:child.monetary.unit.code") do monetary_exchange_rate
-    xml_data_item(monetary_exchange_rate, self.child_monetary_unit_code)
-  end
-
-  monetary_exchange_rate.tag!("oub:exchange.rate") do monetary_exchange_rate
-    xml_data_item(monetary_exchange_rate, self.exchange_rate)
-  end
+  xml_data_item_v2(monetary_exchange_rate, "monetary.exchange.period.sid", self.monetary_exchange_period_sid)
+  xml_data_item_v2(monetary_exchange_rate, "child.monetary.unit.code", self.child_monetary_unit_code)
+  xml_data_item_v2(monetary_exchange_rate, "exchange.rate", self.exchange_rate))
 end

--- a/app/views/xml_generation/templates/monetary/monetary_unit.builder
+++ b/app/views/xml_generation/templates/monetary/monetary_unit.builder
@@ -1,5 +1,5 @@
 xml.tag!("oub:monetary.unit") do |monetary_unit|
   xml_data_item_v2(monetary_unit, "monetary.unit.code", self.monetary_unit_code)
   xml_data_item_v2(monetary_unit, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
-  xml_data_item_v2(monetary_unit, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d")
+  xml_data_item_v2(monetary_unit, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/monetary/monetary_unit.builder
+++ b/app/views/xml_generation/templates/monetary/monetary_unit.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:monetary.unit") do |monetary_unit|
-  monetary_unit.tag!("oub:monetary.unit.code") do monetary_unit
-    xml_data_item(monetary_unit, self.monetary_unit_code)
-  end
-
-  monetary_unit.tag!("oub:validity.start.date") do monetary_unit
-    xml_data_item(monetary_unit, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  monetary_unit.tag!("oub:validity.end.date") do monetary_unit
-    xml_data_item(monetary_unit, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(monetary_unit, "monetary.unit.code", self.monetary_unit_code)
+  xml_data_item_v2(monetary_unit, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(monetary_unit, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d")
 end

--- a/app/views/xml_generation/templates/monetary/monetary_unit_description.builder
+++ b/app/views/xml_generation/templates/monetary/monetary_unit_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:monetary.unit.description") do |monetary_unit_description|
-  monetary_unit_description.tag!("oub:monetary.unit.code") do monetary_unit_description
-    xml_data_item(monetary_unit_description, self.monetary_unit_code)
-  end
-
-  monetary_unit_description.tag!("oub:language.id") do monetary_unit_description
-    xml_data_item(monetary_unit_description, self.language_id)
-  end
-
-  monetary_unit_description.tag!("oub:description") do monetary_unit_description
-    xml_data_item(monetary_unit_description, self.description)
-  end
+  xml_data_item_v2(monetary_unit_description, "monetary.unit.code", self.monetary_unit_code)
+  xml_data_item_v2(monetary_unit_description, "language.id", self.language_id)
+  xml_data_item_v2(monetary_unit_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/quota/quota_association.builder
+++ b/app/views/xml_generation/templates/quota/quota_association.builder
@@ -1,21 +1,6 @@
 xml.tag!("oub:quota.association") do |quota_association|
   xml_data_item_v2(quota_association, "main.quota.definition.sid", self.main_quota_definition_sid)
-  quota_association.tag!("oub:") do quota_association
-    xml_data_item(quota_association, self.)
-  end
-
   xml_data_item_v2(quota_association, "sub.quota.definition.sid", self.sub_quota_definition_sid)
-  quota_association.tag!("oub:") do quota_association
-    xml_data_item(quota_association, self.)
-  end
-
   xml_data_item_v2(quota_association, "relation.type", self.relation_type)
-  quota_association.tag!("oub:") do quota_association
-    xml_data_item(quota_association, self.)
-  end
-
-  xml_data_item_v2(quota_association, ""coefficient, self.coefficient)
-  quota_association.tag!("oub:") do quota_association
-    xml_data_item(quota_association, self.)
-  end
+  xml_data_item_v2(quota_association, "coefficient", self.coefficient)
 end

--- a/app/views/xml_generation/templates/quota/quota_association.builder
+++ b/app/views/xml_generation/templates/quota/quota_association.builder
@@ -1,17 +1,21 @@
 xml.tag!("oub:quota.association") do |quota_association|
-  quota_association.tag!("oub:main.quota.definition.sid") do quota_association
-    xml_data_item(quota_association, self.main_quota_definition_sid)
+  xml_data_item_v2(quota_association, "main.quota.definition.sid", self.main_quota_definition_sid)
+  quota_association.tag!("oub:") do quota_association
+    xml_data_item(quota_association, self.)
   end
 
-  quota_association.tag!("oub:sub.quota.definition.sid") do quota_association
-    xml_data_item(quota_association, self.sub_quota_definition_sid)
+  xml_data_item_v2(quota_association, "sub.quota.definition.sid", self.sub_quota_definition_sid)
+  quota_association.tag!("oub:") do quota_association
+    xml_data_item(quota_association, self.)
   end
 
-  quota_association.tag!("oub:relation.type") do quota_association
-    xml_data_item(quota_association, self.relation_type)
+  xml_data_item_v2(quota_association, "relation.type", self.relation_type)
+  quota_association.tag!("oub:") do quota_association
+    xml_data_item(quota_association, self.)
   end
 
-  quota_association.tag!("oub:coefficient") do quota_association
-    xml_data_item(quota_association, self.coefficient)
+  xml_data_item_v2(quota_association, ""coefficient, self.coefficient)
+  quota_association.tag!("oub:") do quota_association
+    xml_data_item(quota_association, self.)
   end
 end

--- a/app/views/xml_generation/templates/quota/quota_balance_event.builder
+++ b/app/views/xml_generation/templates/quota/quota_balance_event.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:quota.balance.event") do |quota_balance_event|
-  quota_balance_event.tag!("oub:quota.definition.sid") do quota_balance_event
-    xml_data_item(quota_balance_event, self.quota_definition_sid)
-  end
-
-  quota_balance_event.tag!("oub:occurrence.timestamp") do quota_balance_event
-    xml_data_item(quota_balance_event, timestamp_value(self.occurrence_timestamp))
-  end
-
-  quota_balance_event.tag!("oub:old.balance") do quota_balance_event
-    xml_data_item(quota_balance_event, self.old_balance)
-  end
-
-  quota_balance_event.tag!("oub:new.balance") do quota_balance_event
-    xml_data_item(quota_balance_event, self.new_balance)
-  end
-
-  quota_balance_event.tag!("oub:imported.amount") do quota_balance_event
-    xml_data_item(quota_balance_event, self.imported_amount)
-  end
-
-  quota_balance_event.tag!("oub:last.import.date.in.allocation") do quota_balance_event
-    xml_data_item(quota_balance_event, self.last_import_date_in_allocation)
-  end
+  xml_data_item_v2(quota_balance_event, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_balance_event, "occurrence.timestamp", timestamp_value(self.occurrence_timestamp))
+  xml_data_item_v2(quota_balance_event, "old.balance", self.old_balance)
+  xml_data_item_v2(quota_balance_event, "new.balance", self.new_balance)
+  xml_data_item_v2(quota_balance_event, "imported.amount", self.imported_amount)
+  xml_data_item_v2(quota_balance_event, "last.import.date.in.allocation", self.last_import_date_in_allocation)
 end

--- a/app/views/xml_generation/templates/quota/quota_blocking_period.builder
+++ b/app/views/xml_generation/templates/quota/quota_blocking_period.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:quota.blocking.period") do |quota_blocking_period|
-  quota_blocking_period.tag!("oub:quota.blocking.period.sid") do quota_blocking_period
-    xml_data_item(quota_blocking_period, self.quota_blocking_period_sid)
-  end
-
-  quota_blocking_period.tag!("oub:quota.definition.sid") do quota_blocking_period
-    xml_data_item(quota_blocking_period, self.quota_definition_sid)
-  end
-
-  quota_blocking_period.tag!("oub:blocking.period.type") do quota_blocking_period
-    xml_data_item(quota_blocking_period, self.blocking_period_type)
-  end
-
-  quota_blocking_period.tag!("oub:description") do quota_blocking_period
-    xml_data_item(quota_blocking_period, self.description)
-  end
-
-  quota_blocking_period.tag!("oub:blocking.start.date") do quota_blocking_period
-    xml_data_item(quota_blocking_period, self.blocking_start_date.strftime("%Y-%m-%d"))
-  end
-
-  quota_blocking_period.tag!("oub:blocking.end.date") do quota_blocking_period
-    xml_data_item(quota_blocking_period, self.blocking_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_blocking_period, "quota.blocking.period.sid", self.quota_blocking_period_sid)
+  xml_data_item_v2(quota_blocking_period, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_blocking_period, "blocking.period.type", self.blocking_period_type)
+  xml_data_item_v2(quota_blocking_period, "description", self.description)
+  xml_data_item_v2(quota_blocking_period, "blocking.start.date", self.blocking_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(quota_blocking_period, "blocking.end.date", self.blocking_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_critical_event.builder
+++ b/app/views/xml_generation/templates/quota/quota_critical_event.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:quota.critical.event") do |quota_critical_event|
-  quota_critical_event.tag!("oub:quota.definition.sid") do quota_critical_event
-    xml_data_item(quota_critical_event, self.quota_definition_sid)
-  end
-
-  quota_critical_event.tag!("oub:occurrence.timestamp") do quota_critical_event
-    xml_data_item(quota_critical_event, timestamp_value(self.occurrence_timestamp))
-  end
-
-  quota_critical_event.tag!("oub:critical.state") do quota_critical_event
-    xml_data_item(quota_critical_event, self.critical_state)
-  end
-
-  quota_critical_event.tag!("oub:critical.state.change.date") do quota_critical_event
-    xml_data_item(quota_critical_event, self.critical_state_change_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_critical_event, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_critical_event, "occurrence.timestamp", self.timestamp_value(self.occurrence_timestamp))
+  xml_data_item_v2(quota_critical_event, "critical.state", self.critical_state)
+  xml_data_item_v2(quota_critical_event, "critical.state.change.date", self.critical_state_change_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_definition.builder
+++ b/app/views/xml_generation/templates/quota/quota_definition.builder
@@ -1,57 +1,16 @@
 xml.tag!("oub:quota.definition") do |quota_definition|
-  quota_definition.tag!("oub:quota.definition.sid") do quota_definition
-    xml_data_item(quota_definition, self.quota_definition_sid)
-  end
-
-  quota_definition.tag!("oub:quota.order.number.id") do quota_definition
-    xml_data_item(quota_definition, self.quota_order_number_id)
-  end
-
-  quota_definition.tag!("oub:quota.order.number.sid") do quota_definition
-    xml_data_item(quota_definition, self.quota_order_number_sid)
-  end
-
-  quota_definition.tag!("oub:volume") do quota_definition
-    xml_data_item(quota_definition, self.volume)
-  end
-
-  quota_definition.tag!("oub:initial.volume") do quota_definition
-    xml_data_item(quota_definition, self.initial_volume)
-  end
-
-  quota_definition.tag!("oub:monetary.unit.code") do quota_definition
-    xml_data_item(quota_definition, self.monetary_unit_code)
-  end
-
-  quota_definition.tag!("oub:measurement.unit.code") do quota_definition
-    xml_data_item(quota_definition, self.measurement_unit_code)
-  end
-
-  quota_definition.tag!("oub:measurement.unit.qualifier.code") do quota_definition
-    xml_data_item(quota_definition, self.measurement_unit_qualifier_code)
-  end
-
-  quota_definition.tag!("oub:maximum.precision") do quota_definition
-    xml_data_item(quota_definition, self.maximum_precision)
-  end
-
-  quota_definition.tag!("oub:critical.state") do quota_definition
-    xml_data_item(quota_definition, self.critical_state)
-  end
-
-  quota_definition.tag!("oub:critical.threshold") do quota_definition
-    xml_data_item(quota_definition, self.critical_threshold)
-  end
-
-  quota_definition.tag!("oub:description") do quota_definition
-    xml_data_item(quota_definition, self.description)
-  end
-
-  quota_definition.tag!("oub:validity.start.date") do quota_definition
-    xml_data_item(quota_definition, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  quota_definition.tag!("oub:validity.end.date") do quota_definition
-    xml_data_item(quota_definition, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_definition, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_definition, "quota.order.number.id", self.quota_order_number_id)
+  xml_data_item_v2(quota_definition, "quota.order.number.sid", self.quota_order_number_sid)
+  xml_data_item_v2(quota_definition, "volume", self.volume)
+  xml_data_item_v2(quota_definition, "initial.volume", self.initial.volume)
+  xml_data_item_v2(quota_definition, "monetary.unit.code", self.monetary_unit_code)
+  xml_data_item_v2(quota_definition, "measurement.unit.code", self.measurement_unit_code)
+  xml_data_item_v2(quota_definition, "measurement.unit.qualifier.code", self.measurement_unit_qualifier_code)
+  xml_data_item_v2(quota_definition, "maximum.precision", self.maximum_precision)
+  xml_data_item_v2(quota_definition, "critical.state", self.critical_state)
+  xml_data_item_v2(quota_definition, "critical.threshold", self.critical_threshold)
+  xml_data_item_v2(quota_definition, "description", self.description)
+  xml_data_item_v2(quota_definition, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(quota_definition, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_exhaustion_event.builder
+++ b/app/views/xml_generation/templates/quota/quota_exhaustion_event.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:quota.exhaustion.event") do |quota_exhaustion_event|
-  quota_exhaustion_event.tag!("oub:quota.definition.sid") do quota_exhaustion_event
-    xml_data_item(quota_exhaustion_event, self.quota_definition_sid)
-  end
-
-  quota_exhaustion_event.tag!("oub:occurrence.timestamp") do quota_exhaustion_event
-    xml_data_item(quota_exhaustion_event, timestamp_value(self.occurrence_timestamp))
-  end
-
-  quota_exhaustion_event.tag!("oub:exhaustion.date") do quota_exhaustion_event
-    xml_data_item(quota_exhaustion_event, self.exhaustion_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_exhaustion_event, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_exhaustion_event, "occurrence.timestamp", self.timestamp_value(self.occurrence_timestamp))
+  xml_data_item_v2(quota_exhaustion_event, "exhaustion.date", self.exhaustion_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_order_number.builder
+++ b/app/views/xml_generation/templates/quota/quota_order_number.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:quota.order.number") do |quota_order_number|
-  quota_order_number.tag!("oub:quota.order.number.sid") do quota_order_number
-    xml_data_item(quota_order_number, self.quota_order_number_sid)
-  end
-
-  quota_order_number.tag!("oub:quota.order.number.id") do quota_order_number
-    xml_data_item(quota_order_number, self.quota_order_number_id)
-  end
-
-  quota_order_number.tag!("oub:validity.start.date") do quota_order_number
-    xml_data_item(quota_order_number, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  quota_order_number.tag!("oub:validity.end.date") do quota_order_number
-    xml_data_item(quota_order_number, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_order_number, "quota.order.number.sid", self.quota_order_number_sid)
+  xml_data_item_v2(quota_order_number, "quota.order.number.id", self.quota_order_number_id)
+  xml_data_item_v2(quota_order_number, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(quota_order_number, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_order_number_origin.builder
+++ b/app/views/xml_generation/templates/quota/quota_order_number_origin.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:quota.order.number.origin") do |quota_order_number_origin|
-  quota_order_number_origin.tag!("oub:quota.order.number.origin.sid") do quota_order_number_origin
-    xml_data_item(quota_order_number_origin, self.quota_order_number_origin_sid)
-  end
-
-  quota_order_number_origin.tag!("oub:quota.order.number.sid") do quota_order_number_origin
-    xml_data_item(quota_order_number_origin, self.quota_order_number_sid)
-  end
-
-  quota_order_number_origin.tag!("oub:geographical.area.id") do quota_order_number_origin
-    xml_data_item(quota_order_number_origin, self.geographical_area_id)
-  end
-
-  quota_order_number_origin.tag!("oub:geographical.area.sid") do quota_order_number_origin
-    xml_data_item(quota_order_number_origin, self.geographical_area_sid)
-  end
-
-  quota_order_number_origin.tag!("oub:validity.start.date") do quota_order_number_origin
-    xml_data_item(quota_order_number_origin, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  quota_order_number_origin.tag!("oub:validity.end.date") do quota_order_number_origin
-    xml_data_item(quota_order_number_origin, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_order_number_origin, "quota.order.number.origin.sid", self.quota_order_number_origin_sid)
+  xml_data_item_v2(quota_order_number_origin, "quota.order.number.sid", self.quota_order_number_sid)
+  xml_data_item_v2(quota_order_number_origin, "geographical.area.id", self.geographical_area_id)
+  xml_data_item_v2(quota_order_number_origin, "geographical.area.sid", self.geographical_area_sid)
+  xml_data_item_v2(quota_order_number_origin, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(quota_order_number_origin, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_order_number_origin_exclusion.builder
+++ b/app/views/xml_generation/templates/quota/quota_order_number_origin_exclusion.builder
@@ -1,9 +1,4 @@
 xml.tag!("oub:quota.order.number.origin.exclusions") do |quota_order_number_origin_exclusions|
-  quota_order_number_origin_exclusions.tag!("oub:quota.order.number.origin.sid") do quota_order_number_origin_exclusions
-    xml_data_item(quota_order_number_origin_exclusions, self.quota_order_number_origin_sid)
-  end
-
-  quota_order_number_origin_exclusions.tag!("oub:excluded.geographical.area.sid") do quota_order_number_origin_exclusions
-    xml_data_item(quota_order_number_origin_exclusions, self.excluded_geographical_area_sid)
-  end
+  xml_data_item_v2(quota_order_number_origin_exclusions, "quota.order.number.origin.sid", self.quota_order_number_origin_sid)
+  xml_data_item_v2(quota_order_number_origin_exclusions, "excluded.geographical.area.sid", self.excluded_geographical_area_sid)
 end

--- a/app/views/xml_generation/templates/quota/quota_reopening_event.builder
+++ b/app/views/xml_generation/templates/quota/quota_reopening_event.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:quota.reopening.event") do |quota_reopening_event|
-  quota_reopening_event.tag!("oub:quota.definition.sid") do quota_reopening_event
-    xml_data_item(quota_reopening_event, self.quota_definition_sid)
-  end
-
-  quota_reopening_event.tag!("oub:occurrence.timestamp") do quota_reopening_event
-    xml_data_item(quota_reopening_event, timestamp_value(self.occurrence_timestamp))
-  end
-
-  quota_reopening_event.tag!("oub:reopening.date") do quota_reopening_event
-    xml_data_item(quota_reopening_event, self.reopening_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_reopening_event, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_reopening_event, "occurrence.timestamp", self.timestamp_value(self.occurrence_timestamp))
+  xml_data_item_v2(quota_reopening_event, "reopening.date", self.reopening_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_suspension_period.builder
+++ b/app/views/xml_generation/templates/quota/quota_suspension_period.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:quota.suspension.period") do |quota_suspension_period|
-  quota_suspension_period.tag!("oub:quota.suspension.period.sid") do quota_suspension_period
-    xml_data_item(quota_suspension_period, self.quota_suspension_period_sid)
-  end
-
-  quota_suspension_period.tag!("oub:quota.definition.sid") do quota_suspension_period
-    xml_data_item(quota_suspension_period, self.quota_definition_sid)
-  end
-
-  quota_suspension_period.tag!("oub:description") do quota_suspension_period
-    xml_data_item(quota_suspension_period, self.description)
-  end
-
-  quota_suspension_period.tag!("oub:suspension.start.date") do quota_suspension_period
-    xml_data_item(quota_suspension_period, self.suspension_start_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  quota_suspension_period.tag!("oub:suspension.end.date") do quota_suspension_period
-    xml_data_item(quota_suspension_period, self.suspension_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_suspension_period, "quota.suspension.period.sid", self.quota_suspension_period_sid)
+  xml_data_item_v2(quota_suspension_period, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_suspension_period, "description", self.description)
+  xml_data_item_v2(quota_suspension_period, "suspension.start.date", self.suspension_start_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(quota_suspension_period, "suspension.end.date", self.suspension_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_unblocking_event.builder
+++ b/app/views/xml_generation/templates/quota/quota_unblocking_event.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:quota.unblocking.event") do |quota_unblocking_event|
-  quota_unblocking_event.tag!("oub:quota.definition.sid") do quota_unblocking_event
-    xml_data_item(quota_unblocking_event, self.quota_definition_sid)
-  end
-
-  quota_unblocking_event.tag!("oub:occurrence.timestamp") do quota_unblocking_event
-    xml_data_item(quota_unblocking_event, timestamp_value(self.occurrence_timestamp))
-  end
-
-  quota_unblocking_event.tag!("oub:unblocking.date") do quota_unblocking_event
-    xml_data_item(quota_unblocking_event, self.unblocking_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_unblocking_event, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_unblocking_event, "occurrence.timestamp", self.timestamp_value(self.occurrence_timestamp))
+  xml_data_item_v2(quota_unblocking_event, "unblocking.date", self.unblocking_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/quota/quota_unsuspension_event.builder
+++ b/app/views/xml_generation/templates/quota/quota_unsuspension_event.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:quota.unsuspension.event") do |quota_unsuspension_event|
-  quota_unsuspension_event.tag!("oub:quota.definition.sid") do quota_unsuspension_event
-    xml_data_item(quota_unsuspension_event, self.quota_definition_sid)
-  end
-
-  quota_unsuspension_event.tag!("oub:occurrence.timestamp") do quota_unsuspension_event
-    xml_data_item(quota_unsuspension_event, timestamp_value(self.occurrence_timestamp))
-  end
-
-  quota_unsuspension_event.tag!("oub:unsuspension.date") do quota_unsuspension_event
-    xml_data_item(quota_unsuspension_event, self.unsuspension_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(quota_unsuspension_event, "quota.definition.sid", self.quota_definition_sid)
+  xml_data_item_v2(quota_unsuspension_event, "occurrence.timestamp", self.timestamp_value(self.occurrence_timestamp))
+  xml_data_item_v2(quota_unsuspension_event, "unsuspension.date", self.unsuspension_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/regulations/base_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/base_regulation.builder
@@ -1,81 +1,22 @@
 xml.tag!("oub:base.regulation") do |base_regulation|
-  base_regulation.tag!("oub:base.regulation.role") do base_regulation
-    xml_data_item(base_regulation, self.base_regulation_role)
-  end
-
-  base_regulation.tag!("oub:base.regulation.id") do base_regulation
-    xml_data_item(base_regulation, self.base_regulation_id)
-  end
-
-  base_regulation.tag!("oub:published.date") do base_regulation
-    xml_data_item(base_regulation, self.published_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  base_regulation.tag!("oub:officialjournal.number") do base_regulation
-    xml_data_item(base_regulation, self.officialjournal_number)
-  end
-
-  base_regulation.tag!("oub:officialjournal.page") do base_regulation
-    xml_data_item(base_regulation, self.officialjournal_page)
-  end
-
-  base_regulation.tag!("oub:validity.start.date") do base_regulation
-    xml_data_item(base_regulation, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  base_regulation.tag!("oub:validity.end.date") do base_regulation
-    xml_data_item(base_regulation, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  base_regulation.tag!("oub:effective.end.date") do base_regulation
-    xml_data_item(base_regulation, self.effective_end_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  base_regulation.tag!("oub:community.code") do base_regulation
-    xml_data_item(base_regulation, self.community_code)
-  end
-
-  base_regulation.tag!("oub:regulation.group.id") do base_regulation
-    xml_data_item(base_regulation, self.regulation_group_id)
-  end
-
-  base_regulation.tag!("oub:antidumping.regulation.role") do base_regulation
-    xml_data_item(base_regulation, self.antidumping_regulation_role)
-  end
-
-  base_regulation.tag!("oub:related.antidumping.regulation.id") do base_regulation
-    xml_data_item(base_regulation, self.related_antidumping_regulation_id)
-  end
-
-  base_regulation.tag!("oub:complete.abrogation.regulation.role") do base_regulation
-    xml_data_item(base_regulation, self.complete_abrogation_regulation_role)
-  end
-
-  base_regulation.tag!("oub:complete.abrogation.regulation.id") do base_regulation
-    xml_data_item(base_regulation, self.complete_abrogation_regulation_id)
-  end
-
-  base_regulation.tag!("oub:explicit.abrogation.regulation.role") do base_regulation
-    xml_data_item(base_regulation, self.explicit_abrogation_regulation_role)
-  end
-
-  base_regulation.tag!("oub:explicit.abrogation.regulation.id") do base_regulation
-    xml_data_item(base_regulation, self.explicit_abrogation_regulation_id)
-  end
-
-  base_regulation.tag!("oub:replacement.indicator") do base_regulation
-    xml_data_item(base_regulation, self.replacement_indicator)
-  end
-
-  base_regulation.tag!("oub:stopped.flag") do base_regulation
-    xml_data_item(base_regulation, self.stopped_flag)
-  end
-
-  base_regulation.tag!("oub:information.text") do base_regulation
-    xml_data_item(base_regulation, self.information_text)
-  end
-
-  base_regulation.tag!("oub:approved.flag") do base_regulation
-    xml_data_item(base_regulation, self.approved_flag)
-  end
+  xml_data_item_v2(base_regulation, "base.regulation.role", self.base_regulation_role)
+  xml_data_item_v2(base_regulation, "base.regulation.id", self.base_regulation_id)
+  xml_data_item_v2(base_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d")
+  xml_data_item_v2(base_regulation, "officialjournal.number", self.officialjournal_number)
+  xml_data_item_v2(base_regulation, "officialjournal.page", self.officialjournal_page)
+  xml_data_item_v2(base_regulation, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(base_regulation, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(base_regulation, "effective.end.date", self.effective_end_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(base_regulation, "community.code", self.community_code)
+  xml_data_item_v2(base_regulation, "regulation.group.id", self.regulation_group_id)
+  xml_data_item_v2(base_regulation, "antidumping.regulation.role", self.antidumping_regulation_role)
+  xml_data_item_v2(base_regulation, "related.antidumping.regulation.id", self.related_antidumping_regulation_id)
+  xml_data_item_v2(base_regulation, "complete.abrogation.regulation.role", self.complete_abrogation_regulation_role)
+  xml_data_item_v2(base_regulation, "complete.abrogation.regulation.id", self.complete_abrogation_regulation_id)
+  xml_data_item_v2(base_regulation, "explicit.abrogation.regulation.role", self.explicit_abrogation_regulation_role)
+  xml_data_item_v2(base_regulation, "explicit.abrogation.regulation.id", self.explicit_abrogation_regulation_id)
+  xml_data_item_v2(base_regulation, "replacement.indicator", self.replacement_indicator)
+  xml_data_item_v2(base_regulation, "stopped.flag", self.stopped_flag)
+  xml_data_item_v2(base_regulation, "information.text", self.information_text)
+  xml_data_item_v2(base_regulation, "approved.flag", self.approved_flag)
 end

--- a/app/views/xml_generation/templates/regulations/base_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/base_regulation.builder
@@ -1,7 +1,7 @@
 xml.tag!("oub:base.regulation") do |base_regulation|
   xml_data_item_v2(base_regulation, "base.regulation.role", self.base_regulation_role)
   xml_data_item_v2(base_regulation, "base.regulation.id", self.base_regulation_id)
-  xml_data_item_v2(base_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d")
+  xml_data_item_v2(base_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d"))
   xml_data_item_v2(base_regulation, "officialjournal.number", self.officialjournal_number)
   xml_data_item_v2(base_regulation, "officialjournal.page", self.officialjournal_page)
   xml_data_item_v2(base_regulation, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))

--- a/app/views/xml_generation/templates/regulations/complete_abrogation_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/complete_abrogation_regulation.builder
@@ -1,33 +1,10 @@
 xml.tag!("oub:complete.abrogation.regulation") do |complete_abrogation_regulation|
-  complete_abrogation_regulation.tag!("oub:complete.abrogation.regulation.role") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.complete_abrogation_regulation_role)
-  end
-
-  complete_abrogation_regulation.tag!("oub:complete.abrogation.regulation.id") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.complete_abrogation_regulation_id)
-  end
-
-  complete_abrogation_regulation.tag!("oub:published.date") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.published_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  complete_abrogation_regulation.tag!("oub:officialjournal.number") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.officialjournal_number)
-  end
-
-  complete_abrogation_regulation.tag!("oub:officialjournal.page") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.officialjournal_page)
-  end
-
-  complete_abrogation_regulation.tag!("oub:replacement.indicator") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.replacement_indicator)
-  end
-
-  complete_abrogation_regulation.tag!("oub:information.text") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.information_text)
-  end
-
-  complete_abrogation_regulation.tag!("oub:approved.flag") do complete_abrogation_regulation
-    xml_data_item(complete_abrogation_regulation, self.approved_flag)
-  end
+  xml_data_item_v2(complete_abrogation_regulation, "complete.abrogation.regulation.role", self.complete_abrogation_regulation_role)
+  xml_data_item_v2(complete_abrogation_regulation, "complete.abrogation.regulation.id", self.complete_abrogation_regulation_id)
+  xml_data_item_v2(complete_abrogation_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(complete_abrogation_regulation, "officialjournal.number", self.officialjournal_number)
+  xml_data_item_v2(complete_abrogation_regulation, "officialjournal.page", self.officialjournal_page)
+  xml_data_item_v2(complete_abrogation_regulation, "replacement.indicator", self.replacement_indicator)
+  xml_data_item_v2(complete_abrogation_regulation, "information.text", self.information_text)
+  xml_data_item_v2(complete_abrogation_regulation, "approved.flag", self.approved_flag)
 end

--- a/app/views/xml_generation/templates/regulations/explicit_abrogation_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/explicit_abrogation_regulation.builder
@@ -1,37 +1,11 @@
 xml.tag!("oub:explicit.abrogation.regulation") do |explicit_abrogation_regulation|
-  explicit_abrogation_regulation.tag!("oub:explicit.abrogation.regulation.role") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.explicit_abrogation_regulation_role)
-  end
-
-  explicit_abrogation_regulation.tag!("oub:explicit.abrogation.regulation.id") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.explicit_abrogation_regulation_id)
-  end
-
-  explicit_abrogation_regulation.tag!("oub:published.date") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.published_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  explicit_abrogation_regulation.tag!("oub:officialjournal.number") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.officialjournal_number)
-  end
-
-  explicit_abrogation_regulation.tag!("oub:officialjournal.page") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.officialjournal_page)
-  end
-
-  explicit_abrogation_regulation.tag!("oub:replacement.indicator") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.replacement_indicator)
-  end
-
-  explicit_abrogation_regulation.tag!("oub:abrogation.date") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.abrogation_date.strftime("%Y-%m-%d"))
-  end
-
-  explicit_abrogation_regulation.tag!("oub:information.text") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.information_text)
-  end
-
-  explicit_abrogation_regulation.tag!("oub:approved.flag") do explicit_abrogation_regulation
-    xml_data_item(explicit_abrogation_regulation, self.approved_flag)
-  end
+  xml_data_item_v2(explicit_abrogation_regulation, "explicit.abrogation.regulation.role", self.explicit_abrogation_regulation_role)
+  xml_data_item_v2(explicit_abrogation_regulation, "explicit.abrogation.regulation.id", self.explicit_abrogation_regulation_id)
+  xml_data_item_v2(explicit_abrogation_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(explicit_abrogation_regulation, "officialjournal.number", self.officialjournal_number)
+  xml_data_item_v2(explicit_abrogation_regulation, "officialjournal.page", self.officialjournal_page)
+  xml_data_item_v2(explicit_abrogation_regulation, "replacement.indicator", self.replacement_indicator)
+  xml_data_item_v2(explicit_abrogation_regulation, "abrogation.date", self.abrogation_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(explicit_abrogation_regulation, "information.text", self.information_text)
+  xml_data_item_v2(explicit_abrogation_regulation, "approved.flag", self.approved_flag)
 end

--- a/app/views/xml_generation/templates/regulations/fts_regulation_action.builder
+++ b/app/views/xml_generation/templates/regulations/fts_regulation_action.builder
@@ -1,17 +1,6 @@
 xml.tag!("oub:fts.regulation.action") do |fts_regulation_action|
-  fts_regulation_action.tag!("oub:fts.regulation.role") do fts_regulation_action
-    xml_data_item(fts_regulation_action, self.fts_regulation_role)
-  end
-
-  fts_regulation_action.tag!("oub:fts.regulation.id") do fts_regulation_action
-    xml_data_item(fts_regulation_action, self.fts_regulation_id)
-  end
-
-  fts_regulation_action.tag!("oub:stopped.regulation.role") do fts_regulation_action
-    xml_data_item(fts_regulation_action, self.stopped_regulation_role)
-  end
-
-  fts_regulation_action.tag!("oub:stopped.regulation.id") do fts_regulation_action
-    xml_data_item(fts_regulation_action, self.stopped_regulation_id)
-  end
+  xml_data_item_v2(fts_regulation_action, "fts.regulation.role", self.fts_regulation_role)
+  xml_data_item_v2(fts_regulation_action, "fts.regulation.id", self.fts_regulation_id)
+  xml_data_item_v2(fts_regulation_action, "stopped.regulation.role", self.stopped_regulation_role)
+  xml_data_item_v2(fts_regulation_action, "stopped.regulation.id", self.stopped_regulation_id)
 end

--- a/app/views/xml_generation/templates/regulations/full_temporary_stop_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/full_temporary_stop_regulation.builder
@@ -1,53 +1,15 @@
 xml.tag!("oub:full.temporary.stop.regulation") do |full_temporary_stop_regulation|
-  full_temporary_stop_regulation.tag!("oub:full.temporary.stop.regulation.role") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.full_temporary_stop_regulation_role)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:full.temporary.stop.regulation.id") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.full_temporary_stop_regulation_id)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:published.date") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.published_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  full_temporary_stop_regulation.tag!("oub:officialjournal.number") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.officialjournal_number)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:officialjournal.page") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.officialjournal_page)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:explicit.abrogation.regulation.role") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.explicit_abrogation_regulation_role)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:explicit.abrogation.regulation.id") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.explicit_abrogation_regulation_id)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:replacement.indicator") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.replacement_indicator)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:information.text") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.information_text)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:approved.flag") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.approved_flag)
-  end
-
-  full_temporary_stop_regulation.tag!("oub:effective.enddate") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.effective_enddate.strftime("%Y-%m-%d"))
-  end
-
-  full_temporary_stop_regulation.tag!("oub:validity.start.date") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  full_temporary_stop_regulation.tag!("oub:validity.end.date") do full_temporary_stop_regulation
-    xml_data_item(full_temporary_stop_regulation, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(full_temporary_stop_regulation, "full.temporary.stop.regulation.role", self.full_temporary_stop_regulation_role)
+  xml_data_item_v2(full_temporary_stop_regulation, "full.temporary.stop.regulation.id", self.full_temporary_stop_regulation_id)
+  xml_data_item_v2(full_temporary_stop_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(full_temporary_stop_regulation, "officialjournal.number", self.officialjournal_number)
+  xml_data_item_v2(full_temporary_stop_regulation, "officialjournal.page", self.officialjournal_page)
+  xml_data_item_v2(full_temporary_stop_regulation, "explicit.abrogation.regulation.role", self.explicit_abrogation_regulation_role)
+  xml_data_item_v2(full_temporary_stop_regulation, "explicit.abrogation.regulation.id", self.explicit_abrogation_regulation_id)
+  xml_data_item_v2(full_temporary_stop_regulation, "replacement.indicator", self.replacement_indicator)
+  xml_data_item_v2(full_temporary_stop_regulation, "information.text", self.information_text)
+  xml_data_item_v2(full_temporary_stop_regulation, "approved.flag", self.approved_flag)
+  xml_data_item_v2(full_temporary_stop_regulation, "effective.enddate", self.effective_enddate.strftime("%Y-%m-%d"))
+  xml_data_item_v2(full_temporary_stop_regulation, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(full_temporary_stop_regulation, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/regulations/modification_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/modification_regulation.builder
@@ -1,73 +1,20 @@
 xml.tag!("oub:modification.regulation") do |modification_regulation|
-  modification_regulation.tag!("oub:modification.regulation.role") do modification_regulation
-    xml_data_item(modification_regulation, self.modification_regulation_role)
-  end
-
-  modification_regulation.tag!("oub:modification.regulation.id") do modification_regulation
-    xml_data_item(modification_regulation, self.modification_regulation_id)
-  end
-
-  modification_regulation.tag!("oub:published.date") do modification_regulation
-    xml_data_item(modification_regulation, self.published_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  modification_regulation.tag!("oub:officialjournal.number") do modification_regulation
-    xml_data_item(modification_regulation, self.officialjournal_number)
-  end
-
-  modification_regulation.tag!("oub:officialjournal.page") do modification_regulation
-    xml_data_item(modification_regulation, self.officialjournal_page)
-  end
-
-  modification_regulation.tag!("oub:validity.start.date") do modification_regulation
-    xml_data_item(modification_regulation, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  modification_regulation.tag!("oub:validity.end.date") do modification_regulation
-    xml_data_item(modification_regulation, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  modification_regulation.tag!("oub:effective.end.date") do modification_regulation
-    xml_data_item(modification_regulation, self.effective_end_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  modification_regulation.tag!("oub:base.regulation.role") do base_regulation
-    xml_data_item(modification_regulation, self.base_regulation_role)
-  end
-
-  modification_regulation.tag!("oub:base.regulation.id") do base_regulation
-    xml_data_item(modification_regulation, self.base_regulation_id)
-  end
-
-  modification_regulation.tag!("oub:complete.abrogation.regulation.role") do modification_regulation
-    xml_data_item(modification_regulation, self.complete_abrogation_regulation_role)
-  end
-
-  modification_regulation.tag!("oub:complete.abrogation.regulation.id") do modification_regulation
-    xml_data_item(modification_regulation, self.complete_abrogation_regulation_id)
-  end
-
-  modification_regulation.tag!("oub:explicit.abrogation.regulation.role") do modification_regulation
-    xml_data_item(modification_regulation, self.explicit_abrogation_regulation_role)
-  end
-
-  modification_regulation.tag!("oub:explicit.abrogation.regulation.id") do modification_regulation
-    xml_data_item(modification_regulation, self.explicit_abrogation_regulation_id)
-  end
-
-  modification_regulation.tag!("oub:replacement.indicator") do modification_regulation
-    xml_data_item(modification_regulation, self.replacement_indicator)
-  end
-
-  modification_regulation.tag!("oub:stopped.flag") do modification_regulation
-    xml_data_item(modification_regulation, self.stopped_flag)
-  end
-
-  modification_regulation.tag!("oub:information.text") do modification_regulation
-    xml_data_item(modification_regulation, self.information_text)
-  end
-
-  modification_regulation.tag!("oub:approved.flag") do modification_regulation
-    xml_data_item(modification_regulation, self.approved_flag)
-  end
+  xml_data_item_v2(modification_regulation, "modification.regulation.role", self.modification_regulation_role)
+  xml_data_item_v2(modification_regulation, "modification.regulation.id", self.modification_regulation_id)
+  xml_data_item_v2(modification_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(modification_regulation, "officialjournal.number", self.officialjournal_number)
+  xml_data_item_v2(modification_regulation, "officialjournal.page", self.officialjournal_page)
+  xml_data_item_v2(modification_regulation, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(modification_regulation, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(modification_regulation, "effective.end.date", self.effective_end_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(modification_regulation, "base.regulation.role", self.base_regulation_role)
+  xml_data_item_v2(modification_regulation, "base.regulation.id", self.base_regulation_id)
+  xml_data_item_v2(modification_regulation, "complete.abrogation.regulation.role", self.complete_abrogation_regulation_role)
+  xml_data_item_v2(modification_regulation, "complete.abrogation.regulation.id", self.complete_abrogation_regulation_id)
+  xml_data_item_v2(modification_regulation, "explicit.abrogation.regulation.role", self.explicit_abrogation_regulation_role)
+  xml_data_item_v2(modification_regulation, "explicit.abrogation.regulation.id", self.explicit_abrogation_regulation_id)
+  xml_data_item_v2(modification_regulation, "replacement.indicator", self.replacement_indicator)
+  xml_data_item_v2(modification_regulation, "stopped.flag", self.stopped_flag)
+  xml_data_item_v2(modification_regulation, "information.text", self.information_text)
+  xml_data_item_v2(modification_regulation, "approved.flag", self.approved_flag)
 end

--- a/app/views/xml_generation/templates/regulations/prorogation_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/prorogation_regulation.builder
@@ -1,33 +1,10 @@
 xml.tag!("oub:prorogation.regulation") do |prorogation_regulation|
-  prorogation_regulation.tag!("oub:prorogation.regulation.role") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.prorogation_regulation_role)
-  end
-
-  prorogation_regulation.tag!("oub:prorogation.regulation.id") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.prorogation_regulation_id)
-  end
-
-  prorogation_regulation.tag!("oub:published.date") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.published_date.try(:strftime, "%Y-%m-%d"))
-  end
-
-  prorogation_regulation.tag!("oub:officialjournal.number") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.officialjournal_number)
-  end
-
-  prorogation_regulation.tag!("oub:officialjournal.page") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.officialjournal_page)
-  end
-
-  prorogation_regulation.tag!("oub:replacement.indicator") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.replacement_indicator)
-  end
-
-  prorogation_regulation.tag!("oub:information.text") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.information_text)
-  end
-
-  prorogation_regulation.tag!("oub:approved.flag") do prorogation_regulation
-    xml_data_item(prorogation_regulation, self.approved_flag)
-  end
+  xml_data_item_v2(prorogation_regulation, "prorogation.regulation.role", self.prorogation_regulation_role)
+  xml_data_item_v2(prorogation_regulation, "prorogation.regulation.id", self.prorogation_regulation_id)
+  xml_data_item_v2(prorogation_regulation, "published.date", self.published_date.try(:strftime, "%Y-%m-%d"))
+  xml_data_item_v2(prorogation_regulation, "officialjournal.number", self.officialjournal_number)
+  xml_data_item_v2(prorogation_regulation, "officialjournal.page", self.officialjournal_page)
+  xml_data_item_v2(prorogation_regulation, "replacement.indicator", self.replacement_indicator)
+  xml_data_item_v2(prorogation_regulation, "information.text", self.information_text)
+  xml_data_item_v2(prorogation_regulation, "approved.flag", self.approved_flag)
 end

--- a/app/views/xml_generation/templates/regulations/prorogation_regulation_action.builder
+++ b/app/views/xml_generation/templates/regulations/prorogation_regulation_action.builder
@@ -1,21 +1,7 @@
 xml.tag!("oub:prorogation.regulation.action") do |prorogation_regulation_action|
-  prorogation_regulation_action.tag!("oub:prorogation.regulation.role") do prorogation_regulation_action
-    xml_data_item(prorogation_regulation_action, self.prorogation_regulation_role)
-  end
-
-  prorogation_regulation_action.tag!("oub:prorogation.regulation.id") do prorogation_regulation_action
-    xml_data_item(prorogation_regulation_action, self.prorogation_regulation_id)
-  end
-
-  prorogation_regulation_action.tag!("oub:prorogated.regulation.role") do prorogation_regulation_action
-    xml_data_item(prorogation_regulation_action, self.prorogated_regulation_role)
-  end
-
-  prorogation_regulation_action.tag!("oub:prorogated.regulation.id") do prorogation_regulation_action
-    xml_data_item(prorogation_regulation_action, self.prorogated_regulation_id)
-  end
-
-  prorogation_regulation_action.tag!("oub:prorogated.date") do prorogation_regulation_action
-    xml_data_item(prorogation_regulation_action, self.prorogated_date.strftime("%Y-%m-%d"))
-  end
+  xml_data_item_v2(prorogation_regulation_action, "prorogation.regulation.role", self.prorogation_regulation_role)
+  xml_data_item_v2(prorogation_regulation_action, "prorogation.regulation.id", self.prorogation_regulation_id)
+  xml_data_item_v2(prorogation_regulation_action, "prorogated.regulation.role", self.prorogated_regulation_role)
+  xml_data_item_v2(prorogation_regulation_action, "prorogated.regulation.id", self.prorogated_regulation_id)
+  xml_data_item_v2(prorogation_regulation_action, "prorogated.date", self.prorogated_date.strftime("%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/regulations/regulation_group.builder
+++ b/app/views/xml_generation/templates/regulations/regulation_group.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:regulation.group") do |regulation_group|
-  regulation_group.tag!("oub:regulation.group.id") do regulation_group
-    xml_data_item(regulation_group, self.regulation_group_id)
-  end
-
-  regulation_group.tag!("oub:validity.start.date") do regulation_group
-    xml_data_item(regulation_group, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  regulation_group.tag!("oub:validity.end.date") do regulation_group
-    xml_data_item(regulation_group, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(regulation_group, "regulation.group.id", self.regulation_group_id)
+  xml_data_item_v2(regulation_group, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(regulation_group, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/regulations/regulation_group_description.builder
+++ b/app/views/xml_generation/templates/regulations/regulation_group_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:regulation.group.description") do |regulation_group_description|
-  regulation_group_description.tag!("oub:regulation.group.id") do regulation_group_description
-    xml_data_item(regulation_group_description, self.regulation_group_id)
-  end
-
-  regulation_group_description.tag!("oub:language.id") do regulation_group_description
-    xml_data_item(regulation_group_description, self.language_id)
-  end
-
-  regulation_group_description.tag!("oub:description") do regulation_group_description
-    xml_data_item(regulation_group_description, self.description)
-  end
+  xml_data_item_v2(regulation_group_description, "regulation.group.id", self.regulation_group_id)
+  xml_data_item_v2(regulation_group_description, "language.id", self.language_id)
+  xml_data_item_v2(regulation_group_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/regulations/regulation_replacement.builder
+++ b/app/views/xml_generation/templates/regulations/regulation_replacement.builder
@@ -1,6 +1,6 @@
 xml.tag!("oub:regulation.replacement") do |regulation_replacement|
   xml_data_item_v2(regulation_replacement, "replacing.regulation.role", self.replacing_regulation_role)
-  xml_data_item_v2(regulation_replacement, "replacing.regulation.id", self.replacing_regulation_id))
+  xml_data_item_v2(regulation_replacement, "replacing.regulation.id", self.replacing_regulation_id)
   xml_data_item_v2(regulation_replacement, "replaced.regulation.role", self.replaced_regulation_role)
   xml_data_item_v2(regulation_replacement, "replaced.regulation.id", self.replaced_regulation_id)
   xml_data_item_v2(regulation_replacement, "measure.type.id", self.measure_type_id)

--- a/app/views/xml_generation/templates/regulations/regulation_replacement.builder
+++ b/app/views/xml_generation/templates/regulations/regulation_replacement.builder
@@ -1,29 +1,9 @@
 xml.tag!("oub:regulation.replacement") do |regulation_replacement|
-  regulation_replacement.tag!("oub:replacing.regulation.role") do regulation_replacement
-    xml_data_item(regulation_replacement, self.replacing_regulation_role)
-  end
-
-  regulation_replacement.tag!("oub:replacing.regulation.id") do regulation_replacement
-    xml_data_item(regulation_replacement, self.replacing_regulation_id)
-  end
-
-  regulation_replacement.tag!("oub:replaced.regulation.role") do regulation_replacement
-    xml_data_item(regulation_replacement, self.replaced_regulation_role)
-  end
-
-  regulation_replacement.tag!("oub:replaced.regulation.id") do regulation_replacement
-    xml_data_item(regulation_replacement, self.replaced_regulation_id)
-  end
-
-  regulation_replacement.tag!("oub:measure.type.id") do regulation_replacement
-    xml_data_item(regulation_replacement, self.measure_type_id)
-  end
-
-  regulation_replacement.tag!("oub:geographical.area.id") do regulation_replacement
-    xml_data_item(regulation_replacement, self.geographical_area_id)
-  end
-
-  regulation_replacement.tag!("oub:chapter.heading") do regulation_replacement
-    xml_data_item(regulation_replacement, self.chapter_heading)
-  end
+  xml_data_item_v2(regulation_replacement, "replacing.regulation.role", self.replacing_regulation_role)
+  xml_data_item_v2(regulation_replacement, "replacing.regulation.id", self.replacing_regulation_id))
+  xml_data_item_v2(regulation_replacement, "replaced.regulation.role", self.replaced_regulation_role)
+  xml_data_item_v2(regulation_replacement, "replaced.regulation.id", self.replaced_regulation_id)
+  xml_data_item_v2(regulation_replacement, "measure.type.id", self.measure_type_id)
+  xml_data_item_v2(regulation_replacement, "geographical.area.id", self.geographical_area_id)
+  xml_data_item_v2(regulation_replacement, "chapter.heading", self.chapter.heading)
 end

--- a/app/views/xml_generation/templates/regulations/regulation_role_type.builder
+++ b/app/views/xml_generation/templates/regulations/regulation_role_type.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:regulation.role.type") do |regulation_role_type|
-  regulation_role_type.tag!("oub:regulation.role.type.id") do regulation_role_type
-    xml_data_item(regulation_role_type, self.regulation_role_type_id)
-  end
-
-  regulation_role_type.tag!("oub:validity.start.date") do regulation_role_type
-    xml_data_item(regulation_role_type, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  regulation_role_type.tag!("oub:validity.end.date") do regulation_role_type
-    xml_data_item(regulation_role_type, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(regulation_role_type, "regulation.role.type.id", self.regulation_role_type_id)
+  xml_data_item_v2(regulation_role_type, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(regulation_role_type, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/regulations/regulation_role_type_description.builder
+++ b/app/views/xml_generation/templates/regulations/regulation_role_type_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:regulation.role.type.description") do |regulation_role_type_description|
-  regulation_role_type_description.tag!("oub:regulation.role.type.id") do regulation_role_type_description
-    xml_data_item(regulation_role_type_description, self.regulation_role_type_id)
-  end
-
-  regulation_role_type_description.tag!("oub:language.id") do regulation_role_type_description
-    xml_data_item(regulation_role_type_description, self.language_id)
-  end
-
-  regulation_role_type_description.tag!("oub:description") do regulation_role_type_description
-    xml_data_item(regulation_role_type_description, self.description)
-  end
+  xml_data_item_v2(regulation_role_type_description, "regulation.role.type.id", self.regulation_role_type_id)
+  xml_data_item_v2(regulation_role_type_description, "language.id", self.language_id)
+  xml_data_item_v2(regulation_role_type_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/system/language.builder
+++ b/app/views/xml_generation/templates/system/language.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:language") do |language|
-  language.tag!("oub:language.id") do language
-    xml_data_item(language, self.language_id)
-  end
-
-  language.tag!("oub:validity.start.date") do language
-    xml_data_item(language, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  language.tag!("oub:validity.end.date") do language
-    xml_data_item(language, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(language, "language.id", self.language_id)
+  xml_data_item_v2(language, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(language, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/system/language_description.builder
+++ b/app/views/xml_generation/templates/system/language_description.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:language.description") do |language_description|
-  language_description.tag!("oub:language.code.id") do language_description
-    xml_data_item(language_description, self.language_code_id)
-  end
-
-  language_description.tag!("oub:language.id") do language_description
-    xml_data_item(language_description, self.language_id)
-  end
-
-  language_description.tag!("oub:description") do language_description
-    xml_data_item(language_description, self.description)
-  end
+  xml_data_item_v2(language_description, "language.code.id", self.language_code_id)
+  xml_data_item_v2(language_description, "language.id", self.language_id)
+  xml_data_item_v2(language_description, "description", self.description)
 end

--- a/app/views/xml_generation/templates/system/publication_sigle.builder
+++ b/app/views/xml_generation/templates/system/publication_sigle.builder
@@ -1,25 +1,8 @@
 xml.tag!("oub:publication.sigle") do |publication_sigle|
-  publication_sigle.tag!("oub:code.type.id") do publication_sigle
-    xml_data_item(publication_sigle, self.code_type_id)
-  end
-
-  publication_sigle.tag!("oub:code") do publication_sigle
-    xml_data_item(publication_sigle, self.code)
-  end
-
-  publication_sigle.tag!("oub:publication.code") do publication_sigle
-    xml_data_item(publication_sigle, self.publication_code)
-  end
-
-  publication_sigle.tag!("oub:publication.sigle") do publication_sigle
-    xml_data_item(publication_sigle, self.publication_sigle)
-  end
-
-  publication_sigle.tag!("oub:validity.start.date") do publication_sigle
-    xml_data_item(publication_sigle, self.validity_start_date.strftime("%Y-%m-%d"))
-  end
-
-  publication_sigle.tag!("oub:validity.end.date") do publication_sigle
-    xml_data_item(publication_sigle, self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  end
+  xml_data_item_v2(publication_sigle, "code.type.id", self.code_type_id)
+  xml_data_item_v2(publication_sigle, "code", self.code)
+  xml_data_item_v2(publication_sigle, "publication.code", self.publication_code)
+  xml_data_item_v2(publication_sigle, "publication.sigle", self.publication_sigle)
+  xml_data_item_v2(publication_sigle, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(publication_sigle, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
 end

--- a/app/views/xml_generation/templates/system/transmission_comment.builder
+++ b/app/views/xml_generation/templates/system/transmission_comment.builder
@@ -1,13 +1,5 @@
 xml.tag!("oub:transmission.comment") do |transmission_comment|
-  transmission_comment.tag!("oub:comment.sid") do transmission_comment
-    xml_data_item(transmission_comment, self.comment_sid)
-  end
-
-  transmission_comment.tag!("oub:language.id") do transmission_comment
-    xml_data_item(transmission_comment, self.language_id)
-  end
-
-  transmission_comment.tag!("oub:comment.text") do transmission_comment
-    xml_data_item(transmission_comment, self.comment_text)
-  end
+  xml_data_item_v2(transmission_comment, "comment.sid", self.comment_sid)
+  xml_data_item_v2(transmission_comment, "language.id", self.language_id)
+  xml_data_item_v2(transmission_comment, "comment.text", self.comment_text)
 end

--- a/db/migrate/20180726104556_add_workbasket_attrs_to_measure_excluded_geographical_areas.rb
+++ b/db/migrate/20180726104556_add_workbasket_attrs_to_measure_excluded_geographical_areas.rb
@@ -1,0 +1,31 @@
+Sequel.migration do
+  change do
+    run "DROP VIEW public.measure_excluded_geographical_areas;"
+
+    alter_table :measure_excluded_geographical_areas_oplog do
+      add_column :status, String
+      add_column :workbasket_id, Integer
+      add_column :workbasket_sequence_number, Integer
+    end
+
+    run %Q{
+      CREATE VIEW public.measure_excluded_geographical_areas AS
+       SELECT measure_excluded_geographical_areas1.measure_sid,
+          measure_excluded_geographical_areas1.excluded_geographical_area,
+          measure_excluded_geographical_areas1.geographical_area_sid,
+          measure_excluded_geographical_areas1.oid,
+          measure_excluded_geographical_areas1.operation,
+          measure_excluded_geographical_areas1.operation_date,
+          measure_excluded_geographical_areas1.added_by_id,
+          measure_excluded_geographical_areas1.added_at,
+          measure_excluded_geographical_areas1."national",
+          measure_excluded_geographical_areas1.status,
+          measure_excluded_geographical_areas1.workbasket_id,
+          measure_excluded_geographical_areas1.workbasket_sequence_number
+         FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas1
+        WHERE ((measure_excluded_geographical_areas1.oid IN ( SELECT max(measure_excluded_geographical_areas2.oid) AS max
+                 FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas2
+                WHERE ((measure_excluded_geographical_areas1.measure_sid = measure_excluded_geographical_areas2.measure_sid) AND (measure_excluded_geographical_areas1.geographical_area_sid = measure_excluded_geographical_areas2.geographical_area_sid)))) AND ((measure_excluded_geographical_areas1.operation)::text <> 'D'::text));
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3712,7 +3712,10 @@ CREATE TABLE public.measure_excluded_geographical_areas_oplog (
     operation_date date,
     added_by_id integer,
     added_at timestamp without time zone,
-    "national" boolean
+    "national" boolean,
+    status text,
+    workbasket_id integer,
+    workbasket_sequence_number integer
 );
 
 
@@ -3729,7 +3732,10 @@ CREATE VIEW public.measure_excluded_geographical_areas AS
     measure_excluded_geographical_areas1.operation_date,
     measure_excluded_geographical_areas1.added_by_id,
     measure_excluded_geographical_areas1.added_at,
-    measure_excluded_geographical_areas1."national"
+    measure_excluded_geographical_areas1."national",
+    measure_excluded_geographical_areas1.status,
+    measure_excluded_geographical_areas1.workbasket_id,
+    measure_excluded_geographical_areas1.workbasket_sequence_number
    FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas1
   WHERE ((measure_excluded_geographical_areas1.oid IN ( SELECT max(measure_excluded_geographical_areas2.oid) AS max
            FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas2
@@ -10845,3 +10851,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180718101124_change_vali
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180718174824_fix_footnote_id_characters_limit_in_associations.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180720100558_add_measure_sids_to_create_measures_workbasket_settings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180722185024_add_workbasket_attributes_to_db_tables.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180726104556_add_workbasket_attrs_to_measure_excluded_geographical_areas.rb');

--- a/lib/sequel/plugins/oplog.rb
+++ b/lib/sequel/plugins/oplog.rb
@@ -82,9 +82,15 @@ module Sequel
         end
 
         def _update_columns(columns)
-          self.operation = :update
+          if manual_add
+            sql = _update_dataset.update_sql(columns)
+            _update_dataset.send(:returning_fetch_rows, sql)
 
-          operation_klass.insert(self.values.except(:oid))
+          else
+            self.operation = :update
+
+            operation_klass.insert(self.values.except(:oid))
+          end
         end
       end
 

--- a/spec/factories/workbasket_code_factory.rb
+++ b/spec/factories/workbasket_code_factory.rb
@@ -1,0 +1,11 @@
+FactoryGirl.define do
+  factory :workbasket, class: ::Workbaskets::Workbasket do
+    title { "Test" }
+    user_id { create(:user).id }
+
+    trait :create_measures do
+      type { :create_measures }
+      status { :submitted_for_cross_check }
+    end
+  end
+end

--- a/spec/support/shared_contexts/xml_generation/base_context.rb
+++ b/spec/support/shared_contexts/xml_generation/base_context.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 shared_context "xml_generation_base_context" do
   let(:xml_node) do
-    ::XmlGeneration::NodeEnvelope.new(Array.wrap(db_record))
+    ::XmlGeneration::NodeEnvelope.new(Array.wrap(workbasket))
   end
 
   let(:xml_builder) do

--- a/spec/support/shared_contexts/xml_generation/record_context.rb
+++ b/spec/support/shared_contexts/xml_generation/record_context.rb
@@ -12,12 +12,28 @@ shared_context "xml_generation_record_context" do
     xml_record[data_namespace]
   end
 
+  let!(:workbasket) do
+    create(:workbasket, :create_measures)
+  end
+
   before do
-    db_record
+    workbasket
+
+    db_record.workbasket_id = workbasket.id
+    db_record.workbasket_sequence_number = 1
+    db_record.status = "submitted_for_cross_check"
+    db_record.save
+
+    db_record.reload
+    workbasket.reload
   end
 
   it "should return valid XML" do
     fields_to_check.map do |_field_name|
+      p ""
+      p "#{_field_name}: #{_field_name}"
+      p ""
+
       expect_proper_xml_at(_field_name)
     end
   end


### PR DESCRIPTION
**THIS PR COVERS:**

**CREATE MEASURES V2:**

1) BACKEND: Disable validation on Step 1
    As user should be able to go ahead even if he didn't specify all necessary data on Step 1

2) BACKEND: Fixed 'NoMethodError (undefined method 'workbasket_id=' for "02":String)'

   Random issue with assigning of system ops to creating DB records:
  'NoMethodError (undefined method 'workbasket_id=' for "02":String)'

  [Related SENTRY issue](https://sentry.io/bit-zesty-client-apps/management/issues/617320003)

3) BACKEND: Added status check
    EG: do not allow to update workbasket settings after submission for cross-check)

4) BUG: Excluded geographical areas are not saving for measure

[TRELLO CARD](https://trello.com/c/IN154EvH/204-dit-create-measures-iteration)

**XML Export V2:**

1) Updated logic on existing exporter class to work with workbaskets

   XML Message node should reproduce one separated event of updates specified by workbasket
   EG: message 1 - create measures, message 2 - add footnotes to measures, message 3 - add duties to 
   measures so on

2) SEQUEL OPLOG PLUGIN: patch 'update' method to do not bump new version on manual mode

3) Generated XML should not include blank nodes 

4) Test coverage: update related Rspec tests

5) Footnotes: fix for 'F04: At least one description record is mandatory.'

   When adding new footnote to the system (not reuse) importing highlights
   conformance rule triggered 'F04: At least one description record is mandatory.'

[TRELLO CARD](https://trello.com/c/35jJMqC9/360-xml-export-v2-improvements-and-bugfixes) 

