### PR TITLE
use govuk elements in bulk edit modals

### DIFF
--- a/app/assets/stylesheets/components/modal.scss
+++ b/app/assets/stylesheets/components/modal.scss
@@ -85,3 +85,28 @@
     font-weight: bold;
   }
 }
+
+.measure-change-additional-code-input {
+  .remove-additional-code-checkbox {
+
+  }
+
+  .multiple-choice-wrapper {
+    .multiple-choice {
+      width: 38px;
+      height: 38px;
+      display: inline-block;
+      padding: 0;
+    }
+
+    .or {
+      display: inline-block;
+      padding: 0 10px;
+    }
+
+    .text-input-wrapper {
+      display: inline-block;
+      width: calc(100% - 80px);
+    }
+  }
+}

--- a/app/views/shared/vue_templates/_change_additional_code.html.slim
+++ b/app/views/shared/vue_templates/_change_additional_code.html.slim
@@ -1,13 +1,17 @@
 script type="text/x-template" id="measure-change-additional-code-input-template"
-  .row
+  .row.measure-change-additional-code-input
     .col-xs-4
       p
         | {{additionalCode || "-"}}
     .col-xs-8
-      p
-        input type="checkbox" v-model="removeAdditionalCode"
-        '  or
-        input type="text" v-model="newAdditionalCode" :disabled="removeAdditionalCode"
+      .multiple-choice-wrapper
+        .multiple-choice
+          input type="checkbox" v-model="removeAdditionalCode" class="remove-additional-code-checkbox"
+          label
+        .or or
+        .text-input-wrapper
+          input type="text" v-model="newAdditionalCode" class="form-control" :disabled="removeAdditionalCode"
+        p
 
 script type="text/x-template" id="measure-additional-code-previewer-template"
   div

--- a/app/views/shared/vue_templates/_change_footnotes.html.slim
+++ b/app/views/shared/vue_templates/_change_footnotes.html.slim
@@ -14,10 +14,12 @@ script type="text/x-template" id="change-footnotes-popup-template"
       div.footnote v-for="(footnote, index) in measuresFootnotes"
         = content_tag "foot-note", "", { ":footnote" => "footnote", ":index" => "index", ":only-one-measure" => "onlyOneMeasure" }
 
-        p v-if="footnote.footnote_type_id"
-          input type="checkbox" v-model="footnote.remove"
-          label
+        .multiple-choice v-if="footnote.footnote_type_id"
+          input type="checkbox" v-model="footnote.remove" :id=="'remove_footnote_checkbox_' + index"
+          label :for=="'remove_footnote_checkbox_' + index"
             | Remove this footnote from the selection
+        p.clearfix
+
     div
       a href="#" v-on:click.prevent="addFootnote"
         | Add another footnote
@@ -26,20 +28,26 @@ script type="text/x-template" id="change-footnotes-popup-template"
       div v-if="!onlyOneMeasure && !hideUpdateMode"
         .row
           .col-xs-1
-            input type="radio" v-model="updateMode" value="add"
+            .multiple-choice
+              input type="radio" v-model="updateMode" value="add" id="add-to-any-existing"
+              label
           .col-xs-11
-            div
-              strong Add to any existing footnotes in the selection
-            .form-hint
-              | Existing footnotes will be retained. Footnotes specified here will not be added to any measures in which the exact same footnote already exists.
+            label for="add-to-any-existing"
+              div
+                strong Add to any existing footnotes in the selection
+              .form-hint
+                | Existing footnotes will be retained. Footnotes specified here will not be added to any measures in which the exact same footnote already exists.
         .row
           .col-xs-1
-            input type="radio" v-model="updateMode" value="replace"
+            .multiple-choice
+              input type="radio" v-model="updateMode" value="replace" id="replace-any-existing"
+              label
           .col-xs-11
-            div
-              strong Replace any existing footnotes in the selection
-            .form-hint
-              | Select this option and leave the footnotes field above empty to remove all existing footnotes in the selection.
+            label for="replace-any-existing"
+              div
+                strong Replace any existing footnotes in the selection
+              .form-hint
+                | Select this option and leave the footnotes field above empty to remove all existing footnotes in the selection.
 
       button.button @click.prevent="confirmChanges" :disabled="confirmBtnDisabled" Update
       a.secondary-button href="#" @click.prevent="onClose" Cancel


### PR DESCRIPTION
replace default browser elements with custom govuk radio buttons & checkboxes

for change footnotes and change additional codes actions