### PR TITLE
[Find Regulation] fix [measures] link search

### DIFF
--- a/app/controllers/measures/measures_controller.rb
+++ b/app/controllers/measures/measures_controller.rb
@@ -57,11 +57,19 @@ module Measures
       end
     end
 
-    def search
-      code = search_code
-      ::MeasureService::TrackMeasureSids.new(code).run
+    def quick_search
+      #
+      # This is a GET version of same search.
+      # We need it in order to perform one parametr searches via links.
+      #
+      # For example: when you click on [measures] link in regulation
+      # found in 'Find Regulation' section
+      #
+      perform_search
+    end
 
-      redirect_to measures_url(search_code: code)
+    def search
+      perform_search
     end
 
     def create
@@ -96,6 +104,13 @@ module Measures
         end
 
         ops
+      end
+
+      def perform_search
+        code = search_code
+        ::MeasureService::TrackMeasureSids.new(code).run
+
+        redirect_to measures_url(search_code: code)
       end
   end
 end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -24,4 +24,16 @@ module MeasuresHelper
       "Review and submit"
     end
   end
+
+  def search_in_measures_by_regulation_rule(item)
+    {
+      search: {
+        regulation: {
+          enabled: "1",
+          operator: "is",
+          value: item.regulation_id
+        }
+      }
+    }
+  end
 end

--- a/app/views/regulations/search/_results.html.slim
+++ b/app/views/regulations/search/_results.html.slim
@@ -42,5 +42,4 @@
           td
             = item.officialjournal_page
           td
-            = link_to "[measures]", measures_path(search: { regulation: {enabled: "1", operator: "is", value: item.regulation_id } })
-
+            = link_to "[measures]", quick_search_measures_url(search_in_measures_by_regulation_rule(item))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
     resources :measures, only: [:new, :create, :index] do
       collection do
         post :search
+
+        get :quick_search
         get :all_measures_data
       end
     end


### PR DESCRIPTION
The searching link on regulations listing does not pre fill the measure search with the regulation id

[TRELLO CARD](https://trello.com/c/2s6f7Ipj/341-dit-the-searching-link-on-regulations-listing-does-not-pre-fill-the-measure-search-with-the-regulation-id-1)