### PR TITLE
[FIND MEASURES] Fix 'Footnotes' filters

### DIFF
--- a/app/searches/measures/search_filters/footnotes.rb
+++ b/app/searches/measures/search_filters/footnotes.rb
@@ -38,7 +38,7 @@ module Measures
 
       def initialize(operator, footnotes_list)
         @operator = operator
-        @footnotes_list = filtered_hash_collection_params(footnotes_list)
+        @footnotes_list = filtered_hash_collection_params(footnotes_list) if footnotes_list.present?
       end
 
       def sql_rules


### PR DESCRIPTION
Selecting Footnotes are not unspecified or specified breaks search

[TRELLO STORY](https://trello.com/c/6IMJLeIg/378-dit-selecting-footnotes-are-not-unspecified-or-specified-breaks-search)