### PR TITLE
[FIND MEASURES] Fix 'Conditions' filters

### DIFF
--- a/app/searches/measures/search_filters/conditions.rb
+++ b/app/searches/measures/search_filters/conditions.rb
@@ -37,7 +37,7 @@ module Measures
 
       def initialize(operator, conditions_list)
         @operator = operator
-        @conditions_list = filtered_collection_params(conditions_list)
+        @conditions_list = filtered_collection_params(conditions_list) if conditions_list.present?
       end
 
       def sql_rules

--- a/app/searches/measures/search_filters/duties.rb
+++ b/app/searches/measures/search_filters/duties.rb
@@ -30,7 +30,7 @@ module Measures
 
       def initialize(operator, duties_list)
         @operator = operator
-        @duties_list = filtered_hash_collection_params(duties_list)
+        @duties_list = filtered_hash_collection_params(duties_list) if duties_list.present?
       end
 
       def sql_rules


### PR DESCRIPTION
Selecting Conditions are not unspecified or specified breaks search.

[TRELLO STORY](https://trello.com/c/LlkiDd09/377-dit-selecting-conditions-are-not-unspecified-or-specified-breaks-search)