### PR TITLE
[FIND MEASURES] add new options for 'Additional code' filter

### DIFF
--- a/app/assets/javascripts/components/find-measures.js
+++ b/app/assets/javascripts/components/find-measures.js
@@ -65,7 +65,7 @@ $(document).ready(function() {
         conditionsForValidityStartDate: [ conditions.is, conditions.is_after, conditions.is_before, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified ],
         conditionsForValidityEndDate: [ conditions.is, conditions.is_after, conditions.is_before, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified ],
         conditionsForCommodityCode: [ conditions.is, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified, conditions.starts_with ],
-        conditionsForAdditionalCode: [ conditions.is, conditions.is_not, conditions.starts_with ],
+        conditionsForAdditionalCode: [ conditions.is, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified, conditions.starts_with ],
         conditionsForOrigin: [ conditions.is, conditions.is_not ],
         conditionsForOriginExclusions: [ conditions.are_not_specified, conditions.are_not_unspecified, conditions.include, conditions.do_not_include ],
         conditionsForDuties: [ conditions.are, conditions.include ],

--- a/spec/support/shared_contexts/searches/measures/is_or_is_not_context.rb
+++ b/spec/support/shared_contexts/searches/measures/is_or_is_not_context.rb
@@ -4,6 +4,8 @@ shared_context "measures_search_is_or_is_not_context" do
 
   include_context "measures_search_base_context"
 
+  let(:is_not_context_number_of_measures) { 3 }
+
   describe "Invalid Search" do
     it "should not filter with 'is' if value blank" do
       res = search_results(
@@ -11,7 +13,7 @@ shared_context "measures_search_is_or_is_not_context" do
         operator: 'is'
       )
 
-      expect(res.count).to be_eql(3)
+      expect(res.count).to be_eql(is_not_context_number_of_measures)
     end
 
     it "should not filter with 'is_not' if value blank" do
@@ -20,13 +22,13 @@ shared_context "measures_search_is_or_is_not_context" do
         operator: 'is_not'
       )
 
-      expect(res.count).to be_eql(3)
+      expect(res.count).to be_eql(is_not_context_number_of_measures)
     end
 
     it "should not filter with blank ops provided" do
       res = search_results({})
 
-      expect(res.count).to be_eql(3)
+      expect(res.count).to be_eql(is_not_context_number_of_measures)
     end
   end
 end

--- a/spec/unit/searches/measures/additional_code_filter_spec.rb
+++ b/spec/unit/searches/measures/additional_code_filter_spec.rb
@@ -4,6 +4,8 @@ describe "Measure search: additional code filter" do
 
   include_context "measures_search_is_or_is_not_context"
 
+  let(:is_not_context_number_of_measures) { 4 }
+
   let(:search_key) { "additional_code" }
 
   let(:a_measure) do
@@ -24,10 +26,17 @@ describe "Measure search: additional code filter" do
     )
   end
 
+  let(:d_measure) do
+    set_searchable_data!(
+      create(:measure)
+    )
+  end
+
   before do
     a_measure
     b_measure
     c_measure
+    d_measure
   end
 
   describe "Valid Search" do
@@ -55,7 +64,7 @@ describe "Measure search: additional code filter" do
         value: "B334"
       )
 
-      expect(res.count).to be_eql(2)
+      expect(res.count).to be_eql(3)
       measure_sids = res.map(&:measure_sid)
       expect(measure_sids).not_to include(b_measure.measure_sid)
 
@@ -71,6 +80,30 @@ describe "Measure search: additional code filter" do
 
       expect(res.count).to be_eql(1)
       expect(res[0].measure_sid).to be_eql(b_measure.measure_sid)
+
+
+      #
+      # 'is_not_unspecified' filter
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'is_not_specified'
+      )
+
+      expect(res.count).to be_eql(1)
+      expect(res[0].measure_sid).to be_eql(d_measure.measure_sid)
+
+      #
+      # 'is_not_unspecified' filter
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'is_not_unspecified'
+      )
+
+      expect(res.count).to be_eql(3)
     end
   end
 


### PR DESCRIPTION
Add 'is not specified' and 'is not unspecified' to additional codes search options

[TRELLO STORY](https://trello.com/c/OzFhKj0F/376-dit-add-is-not-specified-and-is-not-unspecified-to-additional-codes-search-options)