### PR TITLE
[FIND MEASURES] Bugfixes + New features

### DIFF
--- a/app/assets/javascripts/components/find-measures.js
+++ b/app/assets/javascripts/components/find-measures.js
@@ -55,6 +55,7 @@ $(document).ready(function() {
           { value: "last_status_change", label: "last status change" }
         ],
 
+        conditionsForMeasureSid: [ conditions.is, conditions.starts_with, conditions.contains ],
         conditionsForGroupName: [ conditions.is, conditions.starts_with, conditions.contains ],
         conditionsForStatus: [ conditions.is, conditions.is_not ],
         conditionsForAuthor: [ conditions.is, conditions.is_not ],
@@ -107,6 +108,11 @@ $(document).ready(function() {
       };
 
       var default_params = {
+        measure_sid: {
+          enabled: true,
+          operator: "is",
+          value: null
+        },
         group_name: {
           enabled: true,
           operator: "is",
@@ -198,6 +204,7 @@ $(document).ready(function() {
       };
 
       var fields = [
+        "measure_sid",
         "group_name",
         "status",
         "author",
@@ -231,6 +238,7 @@ $(document).ready(function() {
         var params = window.__search_params;
 
         var mapping = {
+          measure_sid: "measure_sid",
           group_name: "group_name",
           status: "status",
           author: "author",
@@ -372,6 +380,9 @@ $(document).ready(function() {
       return data;
     },
     computed: {
+      measureSidDisabled: function() {
+        return !this.measure_sid.enabled;
+      },
       groupNameDisabled: function() {
         return !this.group_name.enabled;
       },

--- a/app/assets/javascripts/components/find-measures.js
+++ b/app/assets/javascripts/components/find-measures.js
@@ -65,7 +65,7 @@ $(document).ready(function() {
         conditionsForValidityStartDate: [ conditions.is, conditions.is_after, conditions.is_before, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified ],
         conditionsForValidityEndDate: [ conditions.is, conditions.is_after, conditions.is_before, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified ],
         conditionsForCommodityCode: [ conditions.is, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified, conditions.starts_with ],
-        conditionsForAdditionalCode: [ conditions.is, conditions.is_not, conditions.starts_with ],
+        conditionsForAdditionalCode: [ conditions.is, conditions.is_not, conditions.is_not_specified, conditions.is_not_unspecified, conditions.starts_with ],
         conditionsForOrigin: [ conditions.is, conditions.is_not ],
         conditionsForOriginExclusions: [ conditions.are_not_specified, conditions.are_not_unspecified, conditions.include, conditions.do_not_include ],
         conditionsForDuties: [ conditions.are, conditions.include ],

--- a/app/controllers/measures/measures_controller.rb
+++ b/app/controllers/measures/measures_controller.rb
@@ -57,11 +57,19 @@ module Measures
       end
     end
 
-    def search
-      code = search_code
-      ::MeasureService::TrackMeasureSids.new(code).run
+    def quick_search
+      #
+      # This is a GET version of same search.
+      # We need it in order to perform one parametr searches via links.
+      #
+      # For example: when you click on [measures] link in regulation
+      # found in 'Find Regulation' section
+      #
+      perform_search
+    end
 
-      redirect_to measures_url(search_code: code)
+    def search
+      perform_search
     end
 
     def create
@@ -96,6 +104,13 @@ module Measures
         end
 
         ops
+      end
+
+      def perform_search
+        code = search_code
+        ::MeasureService::TrackMeasureSids.new(code).run
+
+        redirect_to measures_url(search_code: code)
       end
   end
 end

--- a/app/helpers/measures_helper.rb
+++ b/app/helpers/measures_helper.rb
@@ -24,4 +24,16 @@ module MeasuresHelper
       "Review and submit"
     end
   end
+
+  def search_in_measures_by_regulation_rule(item)
+    {
+      search: {
+        regulation: {
+          enabled: "1",
+          operator: "is",
+          value: item.regulation_id
+        }
+      }
+    }
+  end
 end

--- a/app/searches/measures/search.rb
+++ b/app/searches/measures/search.rb
@@ -2,6 +2,7 @@ module Measures
   class Search
 
     ALLOWED_FILTERS = %w(
+      measure_sid
       group_name
       status
       author
@@ -80,6 +81,12 @@ module Measures
         duties ||
         conditions ||
         footnotes
+      end
+
+      def apply_measure_sid_filter
+        @relation = relation.operator_search_by_measure_sid(
+          *query_ops(measure_sid)
+        )
       end
 
       def apply_group_name_filter

--- a/app/searches/measures/search_filters/conditions.rb
+++ b/app/searches/measures/search_filters/conditions.rb
@@ -37,7 +37,7 @@ module Measures
 
       def initialize(operator, conditions_list)
         @operator = operator
-        @conditions_list = filtered_collection_params(conditions_list)
+        @conditions_list = filtered_collection_params(conditions_list) if conditions_list.present?
       end
 
       def sql_rules

--- a/app/searches/measures/search_filters/duties.rb
+++ b/app/searches/measures/search_filters/duties.rb
@@ -30,7 +30,7 @@ module Measures
 
       def initialize(operator, duties_list)
         @operator = operator
-        @duties_list = filtered_hash_collection_params(duties_list)
+        @duties_list = filtered_hash_collection_params(duties_list) if duties_list.present?
       end
 
       def sql_rules

--- a/app/searches/measures/search_filters/find_measures_collection.rb
+++ b/app/searches/measures/search_filters/find_measures_collection.rb
@@ -61,6 +61,10 @@ module Measures
         operator_search_where_clause("Regulation", operator, regulation_id)
       end
 
+      def operator_search_by_measure_sid(operator, measure_sid=nil)
+        operator_search_where_clause("MeasureSid", operator, measure_sid)
+      end
+
       def operator_search_by_group_name(operator, group_name=nil)
         operator_search_where_clause("GroupName", operator, group_name)
       end

--- a/app/searches/measures/search_filters/footnotes.rb
+++ b/app/searches/measures/search_filters/footnotes.rb
@@ -38,7 +38,7 @@ module Measures
 
       def initialize(operator, footnotes_list)
         @operator = operator
-        @footnotes_list = filtered_hash_collection_params(footnotes_list)
+        @footnotes_list = filtered_hash_collection_params(footnotes_list) if footnotes_list.present?
       end
 
       def sql_rules

--- a/app/searches/measures/search_filters/measure_sid.rb
+++ b/app/searches/measures/search_filters/measure_sid.rb
@@ -1,0 +1,71 @@
+#
+# Form parameters:
+#
+# {
+#   operator: 'is',
+#   value: 'user input'
+# }
+#
+# Operator possible options:
+#
+# - is
+# - starts_with
+# - contains
+#
+# Example:
+#
+# ::Measures::SearchFilters::MeasureSid.new(
+#   "is", "3632261"
+# ).sql_rules
+#
+
+module Measures
+  module SearchFilters
+    class MeasureSid
+
+      attr_accessor :operator,
+                    :measure_sid
+
+      def initialize(operator, measure_sid)
+        @operator = operator
+        @measure_sid = measure_sid.to_s.strip
+      end
+
+      def sql_rules
+        return nil if measure_sid.blank?
+
+        case operator
+        when "is"
+
+          [ is_clause, measure_sid ]
+        when "starts_with", "contains"
+
+          [ equal_clause, equal_value ]
+        end
+      end
+
+      private
+
+        def is_clause
+          <<-eos
+            measure_sid::text = ?
+          eos
+        end
+
+        def equal_clause
+          <<-eos
+            measure_sid::text ilike ?
+          eos
+        end
+
+        def equal_value
+          case operator
+          when "starts_with"
+            "#{measure_sid}%"
+          when "contains"
+            "%#{measure_sid}%"
+          end
+        end
+    end
+  end
+end

--- a/app/views/measures/measures/_search_form.html.erb
+++ b/app/views/measures/measures/_search_form.html.erb
@@ -4,6 +4,9 @@
       Find measures where:
     </strong>
   </p>
+
+  <%= render "measures/measures/search_form_parts/measure_sid_filter" %>
+
   <div class="find-measures__row">
     <div class="find-measures__checkbox-column">
       <div class="multiple-choice">

--- a/app/views/measures/measures/search_form_parts/_measure_sid_filter.html.erb
+++ b/app/views/measures/measures/search_form_parts/_measure_sid_filter.html.erb
@@ -1,0 +1,18 @@
+<div class="find-measures__row">
+  <div class="find-measures__checkbox-column">
+    <div class="multiple-choice">
+      <input name="search[measure_sid][enabled]" id="toggle-measure-sid" type="checkbox" value="1" v-model="measure_sid.enabled" />
+      <label for="toggle-measure-sid">
+        Measure SID
+      </label>
+    </div>
+  </div>
+
+  <div class="find-measures__is">
+    <custom-select :options="conditionsForMeasureSid" label-field="label" value-field="value"  v-model="measure_sid.operator" v-bind:disabled="measureSidDisabled" name="search[measure_sid][operator]"></custom-select>
+  </div>
+
+  <div class="find-measure__long">
+    <input name="search[measure_sid][value]" class="form-control" v-model="measure_sid.value" v-bind:disabled="measureSidDisabled" />
+  </div>
+</div>

--- a/app/views/regulations/search/_results.html.slim
+++ b/app/views/regulations/search/_results.html.slim
@@ -42,5 +42,4 @@
           td
             = item.officialjournal_page
           td
-            = link_to "[measures]", measures_path(search: { regulation: {enabled: "1", operator: "is", value: item.regulation_id } })
-
+            = link_to "[measures]", quick_search_measures_url(search_in_measures_by_regulation_rule(item))

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,8 @@ Rails.application.routes.draw do
     resources :measures, only: [:new, :create, :index] do
       collection do
         post :search
+
+        get :quick_search
         get :all_measures_data
       end
     end

--- a/spec/support/shared_contexts/searches/measures/is_or_is_not_context.rb
+++ b/spec/support/shared_contexts/searches/measures/is_or_is_not_context.rb
@@ -4,6 +4,8 @@ shared_context "measures_search_is_or_is_not_context" do
 
   include_context "measures_search_base_context"
 
+  let(:is_not_context_number_of_measures) { 3 }
+
   describe "Invalid Search" do
     it "should not filter with 'is' if value blank" do
       res = search_results(
@@ -11,7 +13,7 @@ shared_context "measures_search_is_or_is_not_context" do
         operator: 'is'
       )
 
-      expect(res.count).to be_eql(3)
+      expect(res.count).to be_eql(is_not_context_number_of_measures)
     end
 
     it "should not filter with 'is_not' if value blank" do
@@ -20,13 +22,13 @@ shared_context "measures_search_is_or_is_not_context" do
         operator: 'is_not'
       )
 
-      expect(res.count).to be_eql(3)
+      expect(res.count).to be_eql(is_not_context_number_of_measures)
     end
 
     it "should not filter with blank ops provided" do
       res = search_results({})
 
-      expect(res.count).to be_eql(3)
+      expect(res.count).to be_eql(is_not_context_number_of_measures)
     end
   end
 end

--- a/spec/unit/searches/measures/additional_code_filter_spec.rb
+++ b/spec/unit/searches/measures/additional_code_filter_spec.rb
@@ -4,6 +4,8 @@ describe "Measure search: additional code filter" do
 
   include_context "measures_search_is_or_is_not_context"
 
+  let(:is_not_context_number_of_measures) { 4 }
+
   let(:search_key) { "additional_code" }
 
   let(:a_measure) do
@@ -24,10 +26,17 @@ describe "Measure search: additional code filter" do
     )
   end
 
+  let(:d_measure) do
+    set_searchable_data!(
+      create(:measure)
+    )
+  end
+
   before do
     a_measure
     b_measure
     c_measure
+    d_measure
   end
 
   describe "Valid Search" do
@@ -55,7 +64,7 @@ describe "Measure search: additional code filter" do
         value: "B334"
       )
 
-      expect(res.count).to be_eql(2)
+      expect(res.count).to be_eql(3)
       measure_sids = res.map(&:measure_sid)
       expect(measure_sids).not_to include(b_measure.measure_sid)
 
@@ -71,6 +80,30 @@ describe "Measure search: additional code filter" do
 
       expect(res.count).to be_eql(1)
       expect(res[0].measure_sid).to be_eql(b_measure.measure_sid)
+
+
+      #
+      # 'is_not_unspecified' filter
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'is_not_specified'
+      )
+
+      expect(res.count).to be_eql(1)
+      expect(res[0].measure_sid).to be_eql(d_measure.measure_sid)
+
+      #
+      # 'is_not_unspecified' filter
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'is_not_unspecified'
+      )
+
+      expect(res.count).to be_eql(3)
     end
   end
 

--- a/spec/unit/searches/measures/measure_sid_filter_spec.rb
+++ b/spec/unit/searches/measures/measure_sid_filter_spec.rb
@@ -1,0 +1,84 @@
+require "rails_helper"
+
+describe "Measure search: measure_sid filter" do
+
+  include_context "measures_search_is_or_is_not_context"
+
+  let(:search_key) { "measure_sid" }
+
+  let(:a_measure_sid) { 3632261 }
+
+  let(:a_measure) do
+    generate_measure(a_measure_sid)
+  end
+
+  let(:b_measure_sid) { 4556446 }
+
+  let(:b_measure) do
+    generate_measure(b_measure_sid)
+  end
+
+  let(:c_measure_sid) { 6445435 }
+
+  let(:c_measure) do
+    generate_measure(c_measure_sid)
+  end
+
+  before do
+    a_measure
+    b_measure
+    c_measure
+  end
+
+  describe "Valid Search" do
+    it "should filter by additional_code_id with operator" do
+      #
+      # 'is' filter
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'is',
+        value: b_measure_sid
+      )
+
+      expect(res.count).to be_eql(1)
+      expect(res[0].measure_sid).to be_eql(b_measure_sid)
+
+      #
+      # 'starts_with' filter
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'starts_with',
+        value: c_measure_sid.to_s[0..3]
+      )
+
+      expect(res.count).to be_eql(1)
+      expect(res[0].measure_sid).to be_eql(c_measure_sid)
+
+
+      #
+      # 'contains' filter
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'contains',
+        value: a_measure_sid.to_s[1..2]
+      )
+
+      expect(res.count).to be_eql(1)
+      expect(res[0].measure_sid).to be_eql(a_measure_sid)
+    end
+  end
+
+  def generate_measure(measure_sid)
+    record = build(:measure)
+    record.measure_sid = measure_sid
+    record.save
+
+    record
+  end
+end


### PR DESCRIPTION
**THIS PR COVERS:**

**1) The searching link on regulations listing does not pre fill the measure search with the regulation id**

[TRELLO CARD](https://trello.com/c/2s6f7Ipj/341-dit-the-searching-link-on-regulations-listing-does-not-pre-fill-the-measure-search-with-the-regulation-id-1)

**2) Selecting Footnotes are not unspecified or specified breaks search**

[TRELLO CARD](https://trello.com/c/6IMJLeIg/378-dit-selecting-footnotes-are-not-unspecified-or-specified-breaks-search)

**3) Selecting Conditions are not unspecified or specified breaks search**

[TRELLO CARD](https://trello.com/c/LlkiDd09/377-dit-selecting-conditions-are-not-unspecified-or-specified-breaks-search)

**4) Add ‘is not specified’ and ‘is not unspecified’ to additional codes search options**

[TRELLO CARD](https://trello.com/c/OzFhKj0F/376-dit-add-is-not-specified-and-is-not-unspecified-to-additional-codes-search-options)

**5) Add search by measure id to measure search**

[TRELLO CARD](https://trello.com/c/85mPlhUX/375-dit-add-search-by-measure-id-to-measure-search)