### PR TITLE
Create measures prepopulation

### DIFF
--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -63,32 +63,70 @@ $(document).ready(function() {
         errors: []
       };
 
+      var default_measure = {
+        operation_date: null,
+        regulation_id: null,
+        measure_type_series_id: null,
+        measure_type_id: null,
+        quota_ordernumber: null,
+        quota_status: "open",
+        quota_criticality_threshold: null,
+        quota_description: null,
+        geographical_area_id: null,
+        excluded_geographical_areas: [],
+        conditions: [],
+        quota_periods: [],
+        measure_components: [],
+        footnotes: [],
+        workbasket_name: null,
+        reduction_indicator: null,
+        commodity_codes: null,
+        commodity_codes_exclusions: null,
+        additional_codes: null,
+
+        existing_quota: null
+      };
+
       if (window.__measure) {
         this.parseMeasure(window.__measure);
-      } else {
-        data.measure = {
-          operation_date: null,
-          regulation_id: null,
-          measure_type_series_id: null,
-          measure_type_id: null,
-          quota_ordernumber: null,
-          quota_status: "open",
-          quota_criticality_threshold: null,
-          quota_description: null,
-          geographical_area_id: null,
-          excluded_geographical_areas: [],
-          conditions: [],
-          quota_periods: [],
-          measure_components: [],
-          footnotes: [],
-          workbasket_name: null,
-          reduction_indicator: null,
-          commodity_codes: null,
-          commodity_codes_exclusions: null,
-          additional_codes: null,
+      } else if (window.all_settings) {
+        data.measure = jQuery.extend({}, default_measure, this.unwrapPayload(window.all_settings));
 
-          existing_quota: null
-        };
+        if (window.all_settings.geographical_area_id) {
+          if (window.all_settings.geographical_area_id == '1011') {
+            data.origins.erga_omnes.selected = true;
+            data.origins.erga_omnes.geographical_area_id = window.all_settings.geographical_area_id;
+
+            if (window.all_settings.excluded_geographical_areas) {
+              window.all_settings.excluded_geographical_areas.forEach(function(e) {
+                data.origins.erga_omnes.exclusions.push({
+                  geographical_area_id: e,
+                  options: window.all_geographical_countries
+                });
+              });
+            }
+          } else {
+            // country
+            if (window.geographical_areas_json[window.all_settings.geographical_area_id].length === 0) {
+              data.origins.country.selected = true;
+              data.origins.country.geographical_area_id = window.all_settings.geographical_area_id;
+            } else {
+              data.origins.group.selected = true;
+              data.origins.group.geographical_area_id = window.all_settings.geographical_area_id;
+
+              if (window.all_settings.excluded_geographical_areas) {
+                window.all_settings.excluded_geographical_areas.forEach(function(e) {
+                  data.origins.group.exclusions.push({
+                    geographical_area_id: e,
+                    options: window.geographical_areas_json[window.all_settings.geographical_area_id]
+                  });
+                });
+              }
+            }
+          }
+        }
+      } else {
+        data.measure = default_measure;
       }
 
       return data;
@@ -374,6 +412,32 @@ $(document).ready(function() {
           self.measure[code] = null;
         }
       },
+      unwrapPayload: function(payload) {
+        var self = this;
+
+        var measure = {
+          operation_date: payload.operation_date,
+          validity_start_date: payload.start_date,
+          validity_end_date: payload.end_date,
+          regulation_id: payload.regulation_id,
+          measure_type_id: payload.measure_type_id,
+          workbasket_name: payload.workbasket_name,
+          reduction_indicator: payload.reduction_indicator,
+          additional_codes: payload.additional_codes,
+          commodity_codes: payload.commodity_codes,
+          commodity_codes_exclusions: payload.commodity_codes_exclusions
+        };
+
+        if (window.measure_types_json) {
+          window.measure_types_json.forEach(function(mt) {
+            if (mt.measure_type_id == payload.measure_type_id) {
+              measure.measure_type_series_id = mt.measure_type_series_id;
+            }
+          });
+        }
+
+        return measure;
+      },
       prepareV2Step1Payload: function() {
         var payload = {
           operation_date: this.measure.operation_date,
@@ -385,7 +449,9 @@ $(document).ready(function() {
           reduction_indicator: this.measure.reduction_indicator,
           additional_codes: this.measure.additional_codes,
           commodity_codes: this.measure.commodity_codes,
-          commodity_codes_exclusions: this.measure.commodity_codes_exclusions
+          commodity_codes_exclusions: this.measure.commodity_codes_exclusions,
+          footnotes: this.measure.footnotes
+
         };
 
         if (this.origins.country.selected) {

--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -83,6 +83,8 @@ $(document).ready(function() {
         commodity_codes: null,
         commodity_codes_exclusions: null,
         additional_codes: null,
+        validity_start_date: null,
+        validity_end_date: null,
 
         existing_quota: null
       };

--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -425,8 +425,69 @@ $(document).ready(function() {
           reduction_indicator: payload.reduction_indicator,
           additional_codes: payload.additional_codes,
           commodity_codes: payload.commodity_codes,
-          commodity_codes_exclusions: payload.commodity_codes_exclusions
+          commodity_codes_exclusions: payload.commodity_codes_exclusions,
+          footnotes: [],
+          measure_components: [],
+          conditions: []
         };
+
+        if (payload.footnotes) {
+          for (var k in payload.footnotes) {
+            if (!payload.footnotes.hasOwnProperty(k)) {
+              continue;
+            }
+
+            measure.footnotes.push(clone(payload.footnotes[k]));
+          }
+        }
+
+        if (payload.measure_components) {
+          for (var k in payload.measure_components) {
+            if (!payload.measure_components.hasOwnProperty(k)) {
+              continue;
+            }
+
+              var component = clone(payload.measure_components[k]);
+
+              if (component.duty_expression_id) {
+                component.duty_expression_id = self.getDutyExpressionId(component);
+              }
+
+              measure.measure_components.push(component);
+          };
+        }
+
+        if (payload.conditions) {
+          for (var k in payload.conditions) {
+            if (!payload.conditions.hasOwnProperty(k)) {
+              continue;
+            }
+
+            var condition = clone(payload.conditions[k]);
+
+            if (condition.measure_condition_components) {
+              var mcc = [];
+
+              for (var kk in condition.measure_condition_components) {
+                if (!condition.measure_condition_components.hasOwnProperty(kk)) {
+                  continue;
+                }
+
+                var component = clone(condition.measure_condition_components[kk]);
+
+                if (component.duty_expression_id) {
+                  component.duty_expression_id = self.getDutyExpressionId(component);
+                }
+
+                mcc.push(component);
+              }
+
+              condition.measure_condition_components = mcc;
+            }
+
+            measure.conditions.push(condition);
+          }
+        }
 
         if (window.measure_types_json) {
           window.measure_types_json.forEach(function(mt) {
@@ -670,6 +731,20 @@ $(document).ready(function() {
         }
 
         this.measure.conditions.splice(index, 1);
+      },
+      getDutyExpressionId: function(component) {
+        var ids = ["01","02","04","19","20"];
+        var id = component.duty_expression.duty_expression_id;
+
+        if (ids.indexOf(component.duty_expression.duty_expression_id) === -1) {
+          return id;
+        }
+
+        if (component.monetary_unit) {
+          return id + "B";
+        }
+
+        return id + "A";
       }
     },
     computed: {

--- a/app/assets/javascripts/vendors/selectize.js
+++ b/app/assets/javascripts/vendors/selectize.js
@@ -1279,6 +1279,7 @@
       }
 
       if (self.settings.allowClear) {
+        $control.addClass("allow-clear");
         $wrapper.append($remove);
       }
 

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -70,6 +70,7 @@ Vue.component('custom-select', {
         var self = this;
         var fn = self.settings.load;
         self.isInitialLoad = true;
+
         self.load(function(callback) {
           fn.apply(self, ["", callback]);
         });
@@ -77,7 +78,8 @@ Vue.component('custom-select', {
 
       options.onLoad = function(data) {
         if (vm.url && vm.value && !vm.firstLoadSelected) {
-          $(vm.$el).find("select")[0].selectize.setValue(vm.value.toString());
+          $(vm.$el).find("select")[0].selectize.setValue(vm.value);
+
           vm.firstLoadSelected = true;
         }
       };
@@ -92,6 +94,10 @@ Vue.component('custom-select', {
         $(vm.$el).find("select")[0].selectize.refreshOptions();
         $(vm.$el).find("select")[0].selectize.renderCache['option'] = {};
         $(vm.$el).find("select")[0].selectize.renderCache['item'] = {};
+
+        if (!vm.firstLoadSelected && vm.value) {
+          query = vm.value;
+        }
 
         if (!this.isInitialLoad && vm.minLength && query.length < vm.minLength) return callback();
         if (vm.drilldownRequired === "true" && !vm.drilldownValue) return callback();

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -89,21 +89,23 @@ Vue.component('custom-select', {
       options["load"] = function(query, callback) {
         var self = this;
 
+        var q = query.toString();
+
         $(vm.$el).find("select")[0].selectize.clearOptions();
         $(vm.$el).find("select")[0].selectize.clearCache();
         $(vm.$el).find("select")[0].selectize.refreshOptions();
         $(vm.$el).find("select")[0].selectize.renderCache['option'] = {};
         $(vm.$el).find("select")[0].selectize.renderCache['item'] = {};
 
-        if (!vm.firstLoadSelected && vm.value) {
-          query = vm.value;
+        if (!vm.firstLoadSelected && vm.value && vm.minLength) {
+          q = vm.value;
         }
 
-        if (!this.isInitialLoad && vm.minLength && query.length < vm.minLength) return callback();
+        if (!this.isInitialLoad && vm.minLength && q.length < vm.minLength) return callback();
         if (vm.drilldownRequired === "true" && !vm.drilldownValue) return callback();
 
         var data = {
-          q: query,
+          q: q,
           start_date: vm.start_date,
           end_date: vm.end_date
         };

--- a/app/assets/javascripts/vue_components/date-select.js
+++ b/app/assets/javascripts/vue_components/date-select.js
@@ -1,27 +1,84 @@
 Vue.component('date-select', {
   template: "#date-select-template",
-  props: ["value", "disabled"],
+  props: ["value", "disabled", "minYear"],
   data: function() {
-    return {
-      vproxy: this.value
+    var data = {
+      day: "",
+      month: "",
+      year: ""
+    };
+
+    var valueMoment = moment(this.value, "DD/MM/YYYY", true);
+
+    if (valueMoment.isValid()) {
+      data.day = valueMoment.format("DD");
+      data.month = valueMoment.format("MM");
+      data.year = valueMoment.year();
+    } else {
+      this.year = moment().year();
+    }
+
+    return data;
+  },
+  computed: {
+    days: function() {
+      var days = [];
+      for (var i = 1; i <= 31; i++) {
+        var v = this.leftPad(i + "", 2, "0");
+         days.push({ value: v, label: v });
+      }
+       return days;
+    },
+    months: function() {
+      return [
+        { value: "01", label: "January" },
+        { value: "02", label: "February" },
+        { value: "03", label: "March" },
+        { value: "04", label: "April" },
+        { value: "05", label: "May" },
+        { value: "06", label: "June" },
+        { value: "07", label: "July" },
+        { value: "08", label: "August" },
+        { value: "09", label: "September" },
+        { value: "10", label: "October" },
+        { value: "11", label: "November" },
+        { value: "12", label: "December" }
+      ];
+    },
+    years: function() {
+      var minYear = this.minYear || (new Date()).getFullYear() - 100;
+      var maxYear = (new Date()).getFullYear() + 100;
+      var years = [];
+       for (var i = minYear; i <= maxYear; i++) {
+        years.push({ value: i, label: i });
+      }
+
+      return years;
     }
   },
-  mounted: function() {
-    var self = this;
+  methods: {
+    leftPad: function(val, length, pad) {
+      while (val.length < length) {
+        val = pad + val;
+      }
 
-    new Pikaday({
-      field: $(this.$el)[0],
-      format: "DD/MM/YYYY",
-      blurFieldOnSelect: true
-    });
-
-    $(this.$el).on("change", function() {
-      self.vproxy = $(self.$el).val();
-    });
+      return val;
+    },
+    updateValue: function() {
+      if (this.day && this.month && this.year) {
+        this.$emit("update:value", this.day + "/" + this.month + "/" + this.year);
+      }
+    }
   },
   watch: {
-    vproxy: function() {
-      this.$emit("update:value", this.vproxy);
+    year: function() {
+      this.updateValue();
+    },
+    day: function() {
+      this.updateValue();
+    },
+    month: function() {
+      this.updateValue();
     }
   }
 });

--- a/app/assets/stylesheets/components/find-measures.scss
+++ b/app/assets/stylesheets/components/find-measures.scss
@@ -28,6 +28,12 @@ $find-measure-gutter: 5px;
   padding: $find-measure-gutter $find-measure-gutter $find-measure-gutter 0;
 }
 
+.find-measure__date {
+  flex: 0 0 500px;
+  max-width: 500px;
+  padding: $find-measure-gutter $find-measure-gutter $find-measure-gutter 0;
+}
+
 .origin-exclusion + .origin-exclusion {
   margin-top: 5px;
 }
@@ -73,7 +79,7 @@ $find-measure-gutter: 5px;
     width: 100px !important;
     display: inline-block;
     vertical-align: top;
-    margin-left: 10px;
+    margin-left: 2px;
   }
 }
 

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -61,6 +61,7 @@ label abbr {
 
 .form-hint {
   margin: 1em 0 1em;
+  max-width: 800px;
 }
 
 .selectize-control.form-control {
@@ -355,4 +356,12 @@ label abbr {
 
 .bulk-edit-measures {
   margin-bottom: 100px;
+}
+
+fieldset + fieldset {
+  margin-top: -30px;
+}
+
+.single-digit-field {
+  width: 50px !important;
 }

--- a/app/assets/stylesheets/components/measure-components.scss
+++ b/app/assets/stylesheets/components/measure-components.scss
@@ -1,0 +1,5 @@
+.measure-component {
+  .form-group {
+    margin-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/components/measure-condition-component.scss
+++ b/app/assets/stylesheets/components/measure-condition-component.scss
@@ -1,0 +1,11 @@
+.condition-components-wrapper {
+  padding: 0;
+}
+
+.measure-condition-component {
+  margin-top: 20px;
+
+  &:last-child {
+    margin-bottom: 20px;
+  }
+}

--- a/app/assets/stylesheets/components/measure-condition.scss
+++ b/app/assets/stylesheets/components/measure-condition.scss
@@ -1,0 +1,17 @@
+.condition {
+  border-bottom: 1px solid $border-colour;
+  padding-bottom: 10px;
+
+  .form-group {
+    margin-bottom: 0;
+  }
+
+  & + & {
+    padding-top: 10px;
+  }
+
+  &:last-of-type {
+    margin-bottom: 10px;
+    border-bottom: 0;
+  }
+}

--- a/app/assets/stylesheets/components/measure-origin.scss
+++ b/app/assets/stylesheets/components/measure-origin.scss
@@ -1,0 +1,31 @@
+.measure-origin {
+  .multiple-choice {
+    float: none !important;
+
+    &:after {
+      content: " ";
+      display: table;
+      clear: both;
+      zoom: 1;
+    }
+  }
+
+  label {
+    padding-top: 0;
+    padding-bottom: 0;
+  }
+
+  .origin-select {
+    position: relative;
+    top: 0;
+  }
+
+  #measure-origin-erga_omnes + label {
+    padding-top: 7px;
+    padding-bottom: 7px;
+  }
+
+  & + .measure-origin {
+    margin-top: 12px;
+  }
+}

--- a/app/assets/stylesheets/components/remove-row.scss
+++ b/app/assets/stylesheets/components/remove-row.scss
@@ -1,0 +1,4 @@
+.remove-row {
+  position: relative;
+  top: -6px;
+}

--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -172,8 +172,12 @@
 .selectize-input {
   border-radius: 0 !important;
   border: 2px solid #000 !important;
-  padding-right: 65px !important;
   line-height: 22px !important;
+  padding-right: 35px !important;
+
+  &.allow-clear {
+    padding-right: 65px !important;
+  }
 
   &.focus {
     box-shadow: none !important;

--- a/app/assets/stylesheets/simple-grid.scss
+++ b/app/assets/stylesheets/simple-grid.scss
@@ -1,6 +1,8 @@
+$gutter: 6px;
+
 .row {
   position: relative;
-  margin: 0 -15px;
+  margin: 0 $gutter/-2;
 
   @media (min-width: 992px) {
     display: flex;
@@ -9,17 +11,17 @@
 
 [class^="col"] {
   float: left;
-  padding: 0 15px;
+  padding: 0 $gutter/2;
   min-height: 0.125rem;
   width: 100%;
-  width: calc(100% - 30px);
+  width: calc(100% - #{$gutter});
 
   @media (min-width: 992px) {
     width: auto;
     display: flex;
     flex-direction: column;
     max-width: 100%;
-    flex: 0 0 calc(100% - 30px);
+    flex: 0 0 calc(100% - #{$gutter});
 
     .modal & {
       justify-content: flex-start;
@@ -41,14 +43,14 @@ $maxcol: $site-width / 12;
 @each $col in $cols {
   .col-#{$col} {
     max-width: $maxcol * $col;
-    width: calc(#{$single * $col} - 30px);
-    flex: 0 0 calc(#{$single * $col} - 30px);
+    width: calc(#{$single * $col} - #{$gutter});
+    flex: 0 0 calc(#{$single * $col} - #{$gutter});
   }
 
   .col-xs-#{$col} {
     max-width: $maxcol * $col;
-    width: calc(#{$single * $col} - 30px);
-    flex: 0 0 calc(#{$single * $col} - 30px);
+    width: calc(#{$single * $col} - #{$gutter});
+    flex: 0 0 calc(#{$single * $col} - #{$gutter});
   }
 }
 
@@ -56,8 +58,8 @@ $maxcol: $site-width / 12;
   @each $col in $cols {
     .col-sm-#{$col} {
       max-width: $maxcol * $col;
-      width: calc(#{$single * $col} - 30px);
-      flex: 0 0 calc(#{$single * $col} - 30px);
+      width: calc(#{$single * $col} - #{$gutter});
+      flex: 0 0 calc(#{$single * $col} - #{$gutter});
     }
   }
 }
@@ -66,8 +68,8 @@ $maxcol: $site-width / 12;
   @each $col in $cols {
     .col-md-#{$col} {
       max-width: $maxcol * $col;
-      width: calc(#{$single * $col} - 30px);
-      flex: 0 0 calc(#{$single * $col} - 30px);
+      width: calc(#{$single * $col} - #{$gutter});
+      flex: 0 0 calc(#{$single * $col} - #{$gutter});
     }
   }
 }
@@ -76,8 +78,8 @@ $maxcol: $site-width / 12;
   @each $col in $cols {
     .col-lg-#{$col} {
       max-width: $maxcol * $col;
-      width: calc(#{$single * $col} - 30px);
-      flex: 0 0 calc(#{$single * $col} - 30px);
+      width: calc(#{$single * $col} - #{$gutter});
+      flex: 0 0 calc(#{$single * $col} - #{$gutter});
     }
   }
 }
@@ -86,8 +88,8 @@ $maxcol: $site-width / 12;
   @each $col in $cols {
     .col-xl-#{$col} {
       max-width: $maxcol * $col;
-      width: calc(#{$single * $col} - 30px);
-      flex: 0 0 calc(#{$single * $col} - 30px);
+      width: calc(#{$single * $col} - #{$gutter});
+      flex: 0 0 calc(#{$single * $col} - #{$gutter});
     }
   }
 }

--- a/app/views/measures/measures/_search_form.html.erb
+++ b/app/views/measures/measures/_search_form.html.erb
@@ -65,7 +65,7 @@
     <div class="find-measures__is">
       <custom-select :options="conditionsForValidityStartDate" label-field="label" value-field="value"  v-model="validity_start_date.operator" v-bind:disabled="validityStartDateDisabled" name="search[valid_from][operator]"></custom-select>
     </div>
-    <div class="find-measure__long">
+    <div class="find-measure__date">
       <date-select v-model="validity_start_date.value" name="search[valid_from][value]" v-bind:disabled="validityStartDateValueDisabled" />
     </div>
   </div>
@@ -82,7 +82,7 @@
     <div class="find-measures__is">
       <custom-select :options="conditionsForValidityEndDate" label-field="label" value-field="value"  v-model="validity_end_date.operator" v-bind:disabled="validityEndDateDisabled" name="search[valid_to][operator]"></custom-select>
     </div>
-    <div class="find-measure__long">
+    <div class="find-measure__date">
       <date-select v-model="validity_end_date.value" name="search[valid_to][value]" v-bind:disabled="validityEndDateValueDisabled" />
     </div>
   </div>
@@ -283,7 +283,7 @@
     <div class="find-measures__is">
       <custom-select :options="conditionsForDate" label-field="label" value-field="value"  v-model="date_of.operator" v-bind:disabled="dateDisabled" name="search[date_of][operator]"></custom-select>
     </div>
-    <div class="find-measure__long">
+    <div class="find-measure__date">
       <date-select v-model="date_of.value" name="search[date_of][value]" v-bind:disabled="dateDisabled" />
     </div>
   </div>

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -8,7 +8,7 @@ script type="text/x-template" id="condition-template"
               | Condition
 
             span.form-hint v-if="hideHelp !== true"
-              | This specifies a requirement the import mush meet and determines the customs treatment of the goods concerned.
+              | This specifies a requirement the import must meet and determines the customs treatment of the goods concerned.
           = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select condition ―", "code-class-name" => "prefix--condition", ":on-change" => "onConditionCodeSelected", ":allow-clear" => "true" }
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "showMinimumPrice" do

--- a/app/views/shared/vue_templates/_date_select.html.slim
+++ b/app/views/shared/vue_templates/_date_select.html.slim
@@ -1,2 +1,8 @@
 script type="text/x-template" id="date-select-template"
-  input.date-picker.form-control v-model="vproxy" v-bind:disabled="disabled"
+  .row
+    .col-xs-12.col-sm-3.date-part
+      custom-select v-model="day" placeholder="― day ―" labelField="label" valueField="value" :options="days" v-bind:disabled="disabled"
+    .col-xs-12.col-sm-4.date-part
+      custom-select v-model="month" placeholder="― month ―" labelField="label" valueField="value" :options="months" v-bind:disabled="disabled"
+    .col-xs-12.col-sm-3.date-part
+      custom-select v-model="year" placeholder="― year ―" labelField="label" valueField="value" :options="years" v-bind:disabled="disabled"

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -2,37 +2,37 @@ script type="text/x-template" id="measure-component-template"
   .row
     .col-md-4
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Duty expression
         = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected" }
 
     .col-md-3 v-if="showDutyAmountOrPercentage"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Duty amount (% or €)
         input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountPercentage"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Duty amount (%)
         input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountNegativePercentage"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Duty amount (-%)
         input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountNumber"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Duty amount (€)
         input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showDutyAmountMinimum"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Duty amount (at least €)
         input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
@@ -44,25 +44,25 @@ script type="text/x-template" id="measure-component-template"
 
     .col-md-3 v-if="showDutyRefundAmount"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Refund amount (€)
         input.form-control v-model="measureComponent.amount" type="number" min="0" step="0.0001"
 
     .col-md-3 v-if="showMonetaryUnit"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Monetary unit
         = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Measurement unit
         = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected" }
 
     .col-md-3 v-if="showMeasurementUnit"
       .form-group
-        label.form-label v-if="index === 0"
+        label.form-label
           | Measurement unit qualifier
         = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected" }
     slot

--- a/app/views/shared/vue_templates/_measure_origin.html.slim
+++ b/app/views/shared/vue_templates/_measure_origin.html.slim
@@ -5,7 +5,7 @@ script type="text/x-template" id="measure-origin-template"
       label v-if="notErgaOmnes"
         = content_tag "custom-select", "", { ":options" => "optionsForSelect", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", ":placeholder": "placeholder", "v-model" => "origin.geographical_area_id", class: "origin-select", "code-class-name" => "prefix--region", ":on-change" => "geographicalAreaChanged" }
       label :for="radioID" v-else=""
-        | ERGA OMNES (all origins)
+        | Erga Omnes (all origins)
 
     .panel.panel-border-narrow v-if="showExclusions"
       label.form-label

--- a/app/views/shared/vue_templates/_selectize.html.slim
+++ b/app/views/shared/vue_templates/_selectize.html.slim
@@ -1,4 +1,4 @@
 script type="text/x-template" id="selectize-template"
   div
     slot
-      select v-model="value" :name="name"
+      select v-model="value" :name="name" :class="{ allowClear: allowClear }"

--- a/app/views/workbaskets/create_measures/steps/duties_conditions_footnotes/_duty_expression.html.slim
+++ b/app/views/workbaskets/create_measures/steps/duties_conditions_footnotes/_duty_expression.html.slim
@@ -18,10 +18,9 @@ fieldset
   .measure-components
     div.measure-component v-for="(measureComponent, index) in measure.measure_components"
       = content_tag "measure-component", "", { ":measure-component" => "measureComponent", ":index" => "index" }
-
-      div v-if="canRemoveMeasureComponent"
-        a.text-danger href="#" v-on:click.prevent="removeMeasureComponent(measureComponent)"
-          | Remove
+        div.col-md-3 v-if="canRemoveMeasureComponent"
+          a.text-danger.remove-row href="#" v-on:click.prevent="removeMeasureComponent(measureComponent)"
+            | Remove
 
   p.add-another-wrapper
     a href="#" v-on:click.prevent="addMeasureComponent"

--- a/app/views/workbaskets/create_measures/steps/main/_start_end_dates.html.slim
+++ b/app/views/workbaskets/create_measures/steps/main/_start_end_dates.html.slim
@@ -5,9 +5,7 @@ fieldset
   .form-group
     label.form-label
       span.form-hint
-        | This is the start of the measures' validity period. This will be delayed for any measures that are
-        br
-        | not approved in time, or if the generating regulation has not come into force by the date specified here.
+        | This is the start of the measures' validity period. This will be delayed for any measures that are not approved in time, or if the generating regulation has not come into force by the date specified here.
 
     .row
       .col-md-6
@@ -20,9 +18,7 @@ fieldset
   .form-group
     label.form-label
       span.form-hint
-        | This is the end of the measures' validity period. By default, this will inherit from the generating
-        br
-        | regulation, and may be open-ended. You can optionally specify an earlier date.
+        | This is the end of the measures' validity period. By default, this will inherit from the generating regulation, and may be open-ended. You can optionally specify an earlier date.
 
     .row
       .col-md-6

--- a/app/views/workbaskets/create_measures/steps/main/_workbasket_name.html.slim
+++ b/app/views/workbaskets/create_measures/steps/main/_workbasket_name.html.slim
@@ -5,9 +5,7 @@ fieldset
   .form-group
     label.form-label
       span.form-hint
-        | This is needed for saving progress and can be returned to from the main menu.
-        br
-        | Measures created here will be submitted to workflow as a single batch.
+        | This is needed for saving progress and can be returned to from the main menu. Measures created here will be submitted to workflow as a single batch.
 
     .row
       .col-md-5

--- a/app/views/workbaskets/shared/steps/duties_conditions_footnotes/_conditions.html.slim
+++ b/app/views/workbaskets/shared/steps/duties_conditions_footnotes/_conditions.html.slim
@@ -6,9 +6,9 @@ fieldset
     .condition v-for='condition in measure.conditions'
       = content_tag "measure-condition", "", ":condition" => "condition"
 
-      div v-if="canRemoveCondition"
-        a.text-danger href="#" v-on:click.prevent="removeCondition(condition)"
-          | Remove
+        div.col-md-3 v-if="canRemoveCondition"
+          a.text-danger.remove-row href="#" v-on:click.prevent="removeCondition(condition)"
+            | Remove
 
     p.add-another-wrapper
       a href="#" v-on:click.prevent="addCondition" v-if="atLeastOneCondition"

--- a/app/views/workbaskets/shared/steps/main/_additional_codes.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_additional_codes.html.slim
@@ -8,11 +8,7 @@ fieldset.js-workbasket-check-code-parent-container
         | Additional codes
 
       span.form-hint
-        | You can optionally specify one or more additional codes.
-        br
-        | If you do not provide a commodity code above, then you must provide at least one Meursing code here.
-        br
-        | Separate individual codes with comma. Separate measures will be created for every combination of commodity code and addition code.
+        | You can optionally specify one or more additional codes. If you do not provide a commodity code above, then you must provide at least one Meursing code here. Separate individual codes with comma. Separate measures will be created for every combination of commodity code and additional code.
         br
 
     .row

--- a/app/views/workbaskets/shared/steps/main/_commodity_codes_exceptions.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_commodity_codes_exceptions.html.slim
@@ -3,13 +3,7 @@ label.form-label
     | Exceptions
 
   span.form-hint
-    | If you have specified at least of one commodity code above, you can optionally specify commodity codes here to exclude.
-    br
-
-    | Separate individual codes with line break. There must be children of codes entered above.
-    br
-
-    | This will cause a separate measure to be created for every child code under the parent(s) you enter above, aside from the exclusions you specify here.
+    | If you have specified at least of one commodity code above, you can optionally specify commodity codes here to exclude. These must be children of codes entered above. This will cause a separate measure to be created for every child code under the parent(s) you enter above, aside from the exclusions you specify here.
 
 .row
   .col-xs-12.col-md-11.col-lg-9

--- a/app/views/workbaskets/shared/steps/main/_geographical_area.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_geographical_area.html.slim
@@ -14,6 +14,6 @@ fieldset
     |.
 
   .controls.origins-region
-    = content_tag "measure-origin", "", { kind: "country", placeholder: "― select a country or region ―", ":origin" => "origins.country" }
-    = content_tag "measure-origin", "", { kind: "group", placeholder: "― select a group of countries ―", ":origin" => "origins.group" }
     = content_tag "measure-origin", "", { kind: "erga_omnes", placeholder: "― select a country or region ―", ":origin" => "origins.erga_omnes" }
+    = content_tag "measure-origin", "", { kind: "group", placeholder: "― select a group of countries ―", ":origin" => "origins.group" }
+    = content_tag "measure-origin", "", { kind: "country", placeholder: "― select a country or region ―", ":origin" => "origins.country" }

--- a/app/views/workbaskets/shared/steps/main/_reduction_indicator.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_reduction_indicator.html.slim
@@ -8,5 +8,5 @@ fieldset
         | This is optional, but if specified, must be 1, 2 or 3.
 
     .row
-      .col-md-3
-        input.form-control*{ "v-model" => "measure.reduction_indicator" }
+      .col-md-1
+        input.form-control.single-digit-field v-model="measure.reduction_indicator" min="1" max="3" step="1" maxlength="1" size="1" pattern="[1-3]?"

--- a/app/views/workbaskets/shared/steps/main/_regulation.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_regulation.html.slim
@@ -11,13 +11,13 @@ fieldset
         | If the regulation you need is not in the list, you can&nbsp;
 
         = link_to "add it from here", new_regulation_url, target: "_blank"
-        |&nbsp;.
+        |.
         br
 
         | If you're not sure of the regulation name or ID, you can&nbsp;
 
         = link_to "search here", regulations_url, target: "_blank"
-        |&nbsp;.
+        |.
 
     .row
       .col-md-5


### PR DESCRIPTION
This PR does the following:

- Implements re-population of fields in create measures form, for steps 1 and 2
- Changes datepickers for 3-select components as requested by Jon in a meeting
- Fixes some typos and removes some unnecessary line breaks in form hints
- Improves styling of conditions, duty expressions
- Fixes ordering and styling of measure origins
- Puts form hints and labels on top of every field on conditions in step 2, due to the fact that it is very rare for both conditions to have the same sequence of fields
- Reduction indicator, reduced size and allowed only one character

Couple screenshots from work done:

![screen shot 2018-08-06 at 10 40 13](https://user-images.githubusercontent.com/758001/43729915-274aee14-9980-11e8-89df-47466f0d1d6a.png)
![screen shot 2018-08-06 at 13 50 52](https://user-images.githubusercontent.com/758001/43729916-27774716-9980-11e8-96e9-f57d549b6c5b.png)
![screen shot 2018-08-06 at 13 51 13](https://user-images.githubusercontent.com/758001/43729917-279e5f36-9980-11e8-988d-f89beb74b848.png)
![screen shot 2018-08-06 at 13 51 21](https://user-images.githubusercontent.com/758001/43729918-27c13588-9980-11e8-9095-034749b90023.png)
