### PR TITLE
do not allow user to exclude a region twice

### DIFF
--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -224,12 +224,16 @@ Vue.component('custom-select', {
       }
     },
     value: function (value) {
-      $(this.$el).find("select")[0].selectize.setValue(value, false);
+      this.$emit("change-value");
+      this.applyValueInSelect(value);
     },
     options: function (options) {
       $(this.$el).find("select")[0].selectize.clearOptions();
       $(this.$el).find("select")[0].selectize.addOption(options);
       $(this.$el).find("select")[0].selectize.refreshOptions(false);
+      if (this.value) {
+        this.applyValueInSelect(this.value);
+      }
     },
     drilldownValue: function(newVal, oldVal) {
       if (newVal == oldVal) {
@@ -237,6 +241,11 @@ Vue.component('custom-select', {
       }
 
       this.handleDateSentitivity({}, this.start_date, this.end_date);
+    }
+  },
+  methods: {
+    applyValueInSelect: function(value){
+      $(this.$el).find("select")[0].selectize.setValue(value, false);
     }
   },
   destroyed: function () {

--- a/app/views/shared/vue_templates/_measure_origin.html.slim
+++ b/app/views/shared/vue_templates/_measure_origin.html.slim
@@ -12,9 +12,9 @@ script type="text/x-template" id="measure-origin-template"
         | If you want to exclude countries from this measure, enter them here:
 
       .exclusions-target
-        .exclusion v-for="exclusion in origin.exclusions"
+        .exclusion v-for="exclusion in origin.exclusions" :key="exclusion.uid"
           .exclusion-select
-            = content_tag "custom-select", "", { ":options" => "exclusion.options", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", "placeholder": "― start typing ―", "min-length" => 1, "v-model" => "exclusion.geographical_area_id", class: "origin-select", "code-class-name" => "prefix--country" }
+            = content_tag "custom-select", "", { ":options" => "exclusion.options", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", "placeholder": "― start typing ―", "min-length" => 1, "v-model" => "exclusion.geographical_area_id", class: "origin-select", "code-class-name" => "prefix--country", "@change-value" => "changeExclusion" }
           .exclusion-actions v-if="origin.exclusions.length > 1"
             a.remove-link v-on:click.prevent="removeExclusion(exclusion)"
                | Remove


### PR DESCRIPTION
https://trello.com/c/mdeaxnRH/358-dit-create-measures-form-and-change-origin-popup-which-origin-will-the-measures-apply-to-block-should-not-allow-to-exclude-same