### PR TITLE
[Measures] re-index of searchable data need to be regular

### DIFF
--- a/app/models/measure.rb
+++ b/app/models/measure.rb
@@ -328,6 +328,7 @@ class Measure < Sequel::Model
       ops[:footnotes_count] = footnotes.count
     end
 
+    self.manual_add = true
     self.searchable_data = ops.to_json
     self.searchable_data_updated_at = Time.now.utc
 

--- a/app/searches/measures/search_filters/find_measures_collection.rb
+++ b/app/searches/measures/search_filters/find_measures_collection.rb
@@ -9,7 +9,10 @@ module Measures
       end
 
       def searchable_data_not_indexed
-        where("searchable_data_updated_at IS NULL")
+        where(
+          "searchable_data_updated_at IS NULL OR searchable_data_updated_at::date < ?",
+          Date.today.strftime("%Y-%m-%d")
+        )
       end
 
       def operation_search_jsonb_default

--- a/app/searches/measures/search_filters/find_measures_collection.rb
+++ b/app/searches/measures/search_filters/find_measures_collection.rb
@@ -11,7 +11,7 @@ module Measures
       def searchable_data_not_indexed
         where(
           "searchable_data_updated_at IS NULL OR searchable_data_updated_at::date < ?",
-          Date.today.strftime("%Y-%m-%d")
+          Date.today.midnight.strftime("%Y-%m-%d")
         )
       end
 

--- a/app/tasks/measures/reindex_searchable_data.rb
+++ b/app/tasks/measures/reindex_searchable_data.rb
@@ -1,30 +1,30 @@
 module Measures
   class ReindexSearchableData
 
+    LIMIT = 2500
+
     attr_accessor :total,
-                  :offset,
-                  :limit
+                  :offset
 
     def initialize(offset_start=nil)
       @total = Measure.searchable_data_not_indexed.count
       @offset = offset_start || 1
-      @limit = 5000
     end
 
     def run
       while offset < total do
         query
-        @offset += limit
+        @offset += LIMIT
       end
     end
 
     def query
       records = Measure.searchable_data_not_indexed
                        .offset(offset)
-                       .limit(limit)
+                       .limit(LIMIT)
 
       records.map do |record|
-        reindex_measure!(record)
+        record.set_searchable_data!
       end
 
       log_it(records.sql)
@@ -33,11 +33,6 @@ module Measures
     end
 
     private
-
-      def reindex_measure!(record)
-        record.set_searchable_data!
-        record.save
-      end
 
       def log_it(sql)
         p ""

--- a/app/workers/searchable_data_reindex_worker.rb
+++ b/app/workers/searchable_data_reindex_worker.rb
@@ -6,6 +6,6 @@ class SearchableDataReindexWorker
   sidekiq_options queue: :default, retry: 5
 
   def perform
-    ::Measures::ReindexSearchableData.run
+    ::Measures::ReindexSearchableData.new.run
   end
 end

--- a/app/workers/searchable_data_reindex_worker.rb
+++ b/app/workers/searchable_data_reindex_worker.rb
@@ -1,0 +1,11 @@
+require 'measures/refresh_cache'
+
+class SearchableDataReindexWorker
+  include Sidekiq::Worker
+
+  sidekiq_options queue: :default, retry: 5
+
+  def perform
+    ::Measures::ReindexSearchableData.run
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -20,9 +20,13 @@
   # Online converter: https://crontab.guru/#0_22_*_*_*
   #
   UpdatesSynchronizerWorker:
-    cron: "0 22 * * *" # 10 PM every day
+    cron: "0 22 * * *" #
     description: "UpdatesSynchronizerWorker will run at 10 PM every day"
 
   RefreshCacheWorker:
-    cron: "0 5 * * *" # 5 AM every day
+    cron: "0 5 * * *"
     description: "RefreshCacheWorker will run at 5 AM every day"
+
+  SearchableDataReindexWorker:
+    cron: "5 0 * * *"
+    description: "SearchableDataReindexWorker will run at 00:05 every day"


### PR DESCRIPTION
For measures we are using separated JSONB field.

**Example:**

```
{"footnotes"=>[{"footnote_id"=>"136", "footnote_type_id"=>"CD"}, {"footnote_id"=>"001", "footnote_type_id"=>"EU"}],
 "additional_code"=>"2550",
 "footnotes_count"=>2,
 "regulation_code"=>"R0316/18",
 "duty_expressions"=>[{"duty_amount"=>"0.0", "duty_expression_id"=>"01", "monetary_unit_code"=>"EUR", "measurement_unit_code"=>"TNE"}],
 "measure_conditions"=>"_B_",
 "duty_expressions_count"=>1,
 "measure_conditions_count"=>1}
```

Currently, we are setting it on add / update measure via `set_searchable_data!` callback.

But, there is another case which is not handled by current logic - 'time travel' feature (validity periods - start / end dates).

**For example:**

Today measure having footnotes which are having `validity_end_date` tomorrow. 
So, that means that tomorrow we need to re-index related measures again - otherwise tomorrow this measure would still have footnotes for search functionality (eg: 'Find Measures' section).

Same situation if today measure have duty expressions - but validity_start_date of them is tomorrow. In this case tomorrow index would still not have info about duties which will apply tomorrow.

**POSSIBLE SOLUTION:**

We already having `::Measures::ReindexSearchableData` re-index script 

https://github.com/bitzesty/trade-tariff-management/blob/master/lib/tasks/measures/reindex_searchable_data.rake

Previously, we were running it manually after applying of Postgresql dumps from LIVE to server.

**Now 'sidekiq cron' will run it automatically at 00:05 every day**

[TRELLO STORY](https://trello.com/c/dPABBUCL/392-dit-measures-re-index-of-searchable-data-need-to-be-regular)