### PR TITLE
[FIND MEASURES] End date filter: logic improvements

### DIFF
--- a/app/searches/measures/search_filters/date_universal.rb
+++ b/app/searches/measures/search_filters/date_universal.rb
@@ -98,6 +98,21 @@ module Measures
         def is_not_unspecified_clause
           "#{field_name} IS NOT NULL"
         end
+
+        def is_before_clause
+          compare_sql("<")
+        end
+
+        def is_after_clause
+          compare_sql(">")
+        end
+
+        def compare_sql(compare_operator)
+          res = "#{field_name}::date #{compare_operator} ?"
+          res += " OR #{is_not_specified_clause}" if field_name == "validity_end_date"
+
+          res
+        end
     end
   end
 end

--- a/spec/unit/searches/measures/valid_to_filter_spec.rb
+++ b/spec/unit/searches/measures/valid_to_filter_spec.rb
@@ -35,7 +35,7 @@ describe "Measure search: valid_to filter" do
         value: 3.days.ago.strftime('%d/%m/%Y')
       )
 
-      expect(res.count).to be_eql(2)
+      expect(res.count).to be_eql(3)
       measure_sids = res.map(&:measure_sid)
       expect(measure_sids).not_to include(a_measure.measure_sid)
 
@@ -45,8 +45,9 @@ describe "Measure search: valid_to filter" do
         value: 2.days.ago.strftime('%d/%m/%Y')
       )
 
-      expect(res.count).to be_eql(1)
-      expect(res[0].measure_sid).to be_eql(a_measure.measure_sid)
+      expect(res.count).to be_eql(2)
+      expect(res[0].measure_sid).to be_eql(d_measure.measure_sid)
+      expect(res[1].measure_sid).to be_eql(a_measure.measure_sid)
 
       res = search_results(
         enabled: true,


### PR DESCRIPTION
Search: end date filters for before/after should also include undefined
So you can search for measures in the future and ones without an end date at the same time.

```
end date before X and nil
end date after X and nil 
```

[TRELLO CARD](https://trello.com/c/ksibeV56/372-dit-search-end-date-filters-for-before-after-should-also-include-undefined)