### PR TITLE
[ROLLBACKS] updated to work with workbaskets

### DIFF
--- a/app/models/db/rollback_process.rb
+++ b/app/models/db/rollback_process.rb
@@ -23,9 +23,8 @@ module Db
       end
 
       def delete_target_db_records!
-        data.map do |item|
-          item.manual_add = true
-          item.delete
+        data.map do |workbasket|
+          workbasket.clean_up_workbasket!
         end
       end
 

--- a/app/models/workbaskets/workbasket.rb
+++ b/app/models/workbaskets/workbasket.rb
@@ -184,6 +184,17 @@ module Workbaskets
       end
     end
 
+    def clean_up_workbasket!
+      if settings.present?
+        settings.collection
+                .map(&:destroy)
+
+        settings.destroy
+      end
+
+      destroy
+    end
+
     class << self
       def buld_new_workbasket!(type, current_user)
         workbasket = Workbaskets::Workbasket.new(
@@ -222,13 +233,9 @@ module Workbaskets
           create_quota
         ).map do |type_name|
           by_type(type_name).map do |w|
-            w.settings
-             .collection
-             .map(&:destroy)
+            w.clean_up_workbasket!
           end
         end
-
-        all.map(&:destroy)
       end
     end
 


### PR DESCRIPTION
Previously we got the issue reported by sentry:

```
undefined method `manual_add=' for #<Workbaskets::Workbasket:0x00007f95ae9b5ac8>
```

This PR fixes that.

[SENTRY ISSUE](https://sentry.io/bit-zesty-client-apps/management/issues/648363976/?referrer=slack)
[TRELLO CARD](https://trello.com/c/gKHXVPgX/412-dit-rollbacks-functionality-issue-nomethoderror-undefined-method-manualadd-for-workbasket)