### PR TITLE
[NEW CONDITIONS MECHANIC] added internal columns for related database tables

### DIFF
--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -59,6 +59,7 @@ class MeasureComponent < Sequel::Model
 
   def to_json(options = {})
     {
+      original_duty_expression_id: original_duty_expression_id,
       duty_expression: duty_expression.try(:to_json),
       measurement_unit: measurement_unit.try(:to_json),
       monetary_unit: monetary_unit.try(:to_json),

--- a/app/models/measure_condition.rb
+++ b/app/models/measure_condition.rb
@@ -140,6 +140,7 @@ class MeasureCondition < Sequel::Model
 
   def to_json(options = {})
     {
+      original_measure_condition_code: original_measure_condition_code,
       measure_action: measure_action.to_json,
       certificate: certificate.try(:to_json),
       certificate_type: certificate_type.try(:to_json),

--- a/app/models/measure_condition_component.rb
+++ b/app/models/measure_condition_component.rb
@@ -60,6 +60,7 @@ class MeasureConditionComponent < Sequel::Model
 
   def to_json(options = {})
     {
+      original_duty_expression_id: original_duty_expression_id,
       duty_amount: duty_amount,
       duty_expression: duty_expression.to_json,
       measurement_unit: measurement_unit.to_json,

--- a/db/migrate/20180820092723_add_internal_fields_to_duty_expressions.rb
+++ b/db/migrate/20180820092723_add_internal_fields_to_duty_expressions.rb
@@ -1,0 +1,100 @@
+Sequel.migration do
+  change do
+    alter_table :measure_components_oplog do
+      add_column :original_duty_expression_id, String
+    end
+
+    alter_table :measure_condition_components_oplog do
+      add_column :original_duty_expression_id, String
+    end
+
+    alter_table :measure_conditions_oplog do
+      add_column :original_measure_condition_code, String
+    end
+
+    [
+      :measure_components,
+      :measure_condition_components,
+      :measure_conditions
+    ].map do |view_name|
+      run "DROP VIEW public.#{view_name};"
+    end
+
+    run %Q{
+      CREATE VIEW public.measure_components AS
+       SELECT measure_components1.measure_sid,
+          measure_components1.duty_expression_id,
+          measure_components1.duty_amount,
+          measure_components1.monetary_unit_code,
+          measure_components1.measurement_unit_code,
+          measure_components1.measurement_unit_qualifier_code,
+          measure_components1.oid,
+          measure_components1.operation,
+          measure_components1.operation_date,
+          measure_components1.added_by_id,
+          measure_components1.added_at,
+          measure_components1."national",
+          measure_components1.status,
+          measure_components1.workbasket_id,
+          measure_components1.workbasket_sequence_number,
+          measure_components1.original_duty_expression_id
+         FROM public.measure_components_oplog measure_components1
+        WHERE ((measure_components1.oid IN ( SELECT max(measure_components2.oid) AS max
+                 FROM public.measure_components_oplog measure_components2
+                WHERE ((measure_components1.measure_sid = measure_components2.measure_sid) AND ((measure_components1.duty_expression_id)::text = (measure_components2.duty_expression_id)::text)))) AND ((measure_components1.operation)::text <> 'D'::text));
+    }
+
+    run %Q{
+      CREATE VIEW public.measure_condition_components AS
+       SELECT measure_condition_components1.measure_condition_sid,
+          measure_condition_components1.duty_expression_id,
+          measure_condition_components1.duty_amount,
+          measure_condition_components1.monetary_unit_code,
+          measure_condition_components1.measurement_unit_code,
+          measure_condition_components1.measurement_unit_qualifier_code,
+          measure_condition_components1.oid,
+          measure_condition_components1.operation,
+          measure_condition_components1.operation_date,
+          measure_condition_components1.added_by_id,
+          measure_condition_components1.added_at,
+          measure_condition_components1."national",
+          measure_condition_components1.status,
+          measure_condition_components1.workbasket_id,
+          measure_condition_components1.workbasket_sequence_number,
+          measure_condition_components1.original_duty_expression_id
+         FROM public.measure_condition_components_oplog measure_condition_components1
+        WHERE ((measure_condition_components1.oid IN ( SELECT max(measure_condition_components2.oid) AS max
+                 FROM public.measure_condition_components_oplog measure_condition_components2
+                WHERE ((measure_condition_components1.measure_condition_sid = measure_condition_components2.measure_condition_sid) AND ((measure_condition_components1.duty_expression_id)::text = (measure_condition_components2.duty_expression_id)::text)))) AND ((measure_condition_components1.operation)::text <> 'D'::text));
+    }
+
+    run %Q{
+      CREATE VIEW public.measure_conditions AS
+       SELECT measure_conditions1.measure_condition_sid,
+          measure_conditions1.measure_sid,
+          measure_conditions1.condition_code,
+          measure_conditions1.component_sequence_number,
+          measure_conditions1.condition_duty_amount,
+          measure_conditions1.condition_monetary_unit_code,
+          measure_conditions1.condition_measurement_unit_code,
+          measure_conditions1.condition_measurement_unit_qualifier_code,
+          measure_conditions1.action_code,
+          measure_conditions1.certificate_type_code,
+          measure_conditions1.certificate_code,
+          measure_conditions1.oid,
+          measure_conditions1.operation,
+          measure_conditions1.operation_date,
+          measure_conditions1.added_by_id,
+          measure_conditions1.added_at,
+          measure_conditions1."national",
+          measure_conditions1.status,
+          measure_conditions1.workbasket_id,
+          measure_conditions1.workbasket_sequence_number,
+          measure_conditions1.original_measure_condition_code
+         FROM public.measure_conditions_oplog measure_conditions1
+        WHERE ((measure_conditions1.oid IN ( SELECT max(measure_conditions2.oid) AS max
+                 FROM public.measure_conditions_oplog measure_conditions2
+                WHERE (measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid))) AND ((measure_conditions1.operation)::text <> 'D'::text));
+    }
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -3707,7 +3707,8 @@ CREATE TABLE public.measure_components_oplog (
     "national" boolean,
     status text,
     workbasket_id integer,
-    workbasket_sequence_number integer
+    workbasket_sequence_number integer,
+    original_duty_expression_id text
 );
 
 
@@ -3730,7 +3731,8 @@ CREATE VIEW public.measure_components AS
     measure_components1."national",
     measure_components1.status,
     measure_components1.workbasket_id,
-    measure_components1.workbasket_sequence_number
+    measure_components1.workbasket_sequence_number,
+    measure_components1.original_duty_expression_id
    FROM public.measure_components_oplog measure_components1
   WHERE ((measure_components1.oid IN ( SELECT max(measure_components2.oid) AS max
            FROM public.measure_components_oplog measure_components2
@@ -3890,7 +3892,8 @@ CREATE TABLE public.measure_condition_components_oplog (
     "national" boolean,
     status text,
     workbasket_id integer,
-    workbasket_sequence_number integer
+    workbasket_sequence_number integer,
+    original_duty_expression_id text
 );
 
 
@@ -3913,7 +3916,8 @@ CREATE VIEW public.measure_condition_components AS
     measure_condition_components1."national",
     measure_condition_components1.status,
     measure_condition_components1.workbasket_id,
-    measure_condition_components1.workbasket_sequence_number
+    measure_condition_components1.workbasket_sequence_number,
+    measure_condition_components1.original_duty_expression_id
    FROM public.measure_condition_components_oplog measure_condition_components1
   WHERE ((measure_condition_components1.oid IN ( SELECT max(measure_condition_components2.oid) AS max
            FROM public.measure_condition_components_oplog measure_condition_components2
@@ -3964,7 +3968,8 @@ CREATE TABLE public.measure_conditions_oplog (
     "national" boolean,
     status text,
     workbasket_id integer,
-    workbasket_sequence_number integer
+    workbasket_sequence_number integer,
+    original_measure_condition_code text
 );
 
 
@@ -3992,7 +3997,8 @@ CREATE VIEW public.measure_conditions AS
     measure_conditions1."national",
     measure_conditions1.status,
     measure_conditions1.workbasket_id,
-    measure_conditions1.workbasket_sequence_number
+    measure_conditions1.workbasket_sequence_number,
+    measure_conditions1.original_measure_condition_code
    FROM public.measure_conditions_oplog measure_conditions1
   WHERE ((measure_conditions1.oid IN ( SELECT max(measure_conditions2.oid) AS max
            FROM public.measure_conditions_oplog measure_conditions2
@@ -11458,3 +11464,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180727173036_add_more_fi
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180730134551_add_more_fields_to_create_quota_settings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180802084730_add_fields_to_full_temporary_stop_regulations.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180807180500_add_initial_search_results_code_to_workbaskets.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180820092723_add_internal_fields_to_duty_expressions.rb');


### PR DESCRIPTION
Standart DutyExpressions are living in `MeasureComponent` DB model
And DutyExpressions which belongs to Conditions are living in `MeasureConditionComponent` DB model
Conditions are living in `MeasureCondition`  DB model

So we are adding following internal columns:

`MeasureComponent` <- `original_duty_expression_id`
`MeasureConditionComponent` <- `original_duty_expression_id`
`MeasureCondition` <- `original_measure_condition_code`

They would be used as internal triggers for UI building and on saving mechanism.

[TRELLO CARD](https://trello.com/c/l1ou2EW6/406-dit-new-complexity-for-the-conditions-mechanic-in-create-measures-etc-10)