### PR TITLE
[SHOW STOPPER BUGS] Fixes

### DIFF
--- a/app/searches/measures/search_filters/conditions.rb
+++ b/app/searches/measures/search_filters/conditions.rb
@@ -37,7 +37,12 @@ module Measures
 
       def initialize(operator, conditions_list)
         @operator = operator
-        @conditions_list = filtered_collection_params(conditions_list) if conditions_list.present?
+
+        @conditions_list = if conditions_list.present?
+          filtered_collection_params(conditions_list)
+        else
+          []
+        end
       end
 
       def sql_rules

--- a/app/searches/measures/search_filters/duties.rb
+++ b/app/searches/measures/search_filters/duties.rb
@@ -30,7 +30,12 @@ module Measures
 
       def initialize(operator, duties_list)
         @operator = operator
-        @duties_list = filtered_hash_collection_params(duties_list) if duties_list.present?
+
+        @duties_list = if duties_list.present?
+          filtered_hash_collection_params(duties_list)
+        else
+          []
+        end
       end
 
       def sql_rules

--- a/app/searches/measures/search_filters/footnotes.rb
+++ b/app/searches/measures/search_filters/footnotes.rb
@@ -38,7 +38,12 @@ module Measures
 
       def initialize(operator, footnotes_list)
         @operator = operator
-        @footnotes_list = filtered_hash_collection_params(footnotes_list) if footnotes_list.present?
+
+        @footnotes_list = if footnotes_list.present?
+          filtered_hash_collection_params(footnotes_list)
+        else
+          []
+        end
       end
 
       def sql_rules

--- a/app/searches/measures/search_filters/origin_exclusions.rb
+++ b/app/searches/measures/search_filters/origin_exclusions.rb
@@ -37,7 +37,12 @@ module Measures
 
       def initialize(operator, exclusions_list)
         @operator = operator
-        @exclusions_list = filtered_collection_params(exclusions_list)
+
+        @exclusions_list = if exclusions_list.present?
+          filtered_collection_params(exclusions_list)
+        else
+          []
+        end
       end
 
       def sql_rules

--- a/lib/measures/refresh_cache.rb
+++ b/lib/measures/refresh_cache.rb
@@ -26,13 +26,15 @@ module Measures
       end
 
       def recache_keys!
-        form = MeasureForm.new(Measure.last)
+        TimeMachine.at(Date.current) do
+          form = MeasureForm.new(Measure.last)
 
-        form.geographical_areas_json
-        form.all_geographical_areas
-        form.all_geographical_countries
-        form.geographical_groups_except_erga_omnes
-        form.geographical_area_erga_omnes
+          form.geographical_areas_json
+          form.all_geographical_areas
+          form.all_geographical_countries
+          form.geographical_groups_except_erga_omnes
+          form.geographical_area_erga_omnes
+        end
       end
 
       def notify_via_sentry!(message)


### PR DESCRIPTION
**THIS PR COVERS:**

**1) [SEARCH IN MEASURES] fix for collection search filters**

[SENTRY ISSUE](https://sentry.io/bit-zesty-client-apps/management/issues/634019078)

Fix applying to:

- footnotes
- conditions
- duties
- origin exclusions

[TRELLO CARD](https://trello.com/c/HJnvX9WL/407-errorwere-sorry-but-something-went-wrong-3)

**2) [CREATE MEASURES] fixed issue with wrong geographical areas list**

So issue was happened when we are selecting:

```
 Origin - XD-Mayotte
```

Because `XD-Mayotte` is not longer actual geographical area.

DB record for `XD-Mayotte`:

```
 :geographical_area_sid=>329,
 :parent_geographical_area_group_sid=>nil,
 :validity_start_date=>"1984-01-01T00:00:00.000Z",
 :validity_end_date=>"1994-12-31T00:00:00.000Z",
 :geographical_code=>"2",
 :geographical_area_id=>"XD",
}>
```

So record for this area was expired at `1994-12-31T00:00:00.000Z`.

I fixed rechaching script for geographical areas - now it would allow to select only actual areas.

[TRELLO STORY](https://trello.com/c/SZpxy72p/404-creating-tariff-preference-142-measure-is-stuck-with-checking-data-when-all-the-data-entered-and-clicked-on-next-on-second-page)