### PR TITLE
fixes on change footnotes popup

### DIFF
--- a/app/assets/javascripts/vue_components/change-footnotes-popup.js
+++ b/app/assets/javascripts/vue_components/change-footnotes-popup.js
@@ -66,6 +66,18 @@ Vue.component("change-footnotes-popup", {
   watch: {
     updateMode: function(){
       this.confirmBtnDisabled = false;
+    },
+    measuresFootnotes: {
+      handler: function(){
+        if (!this.confirmBtnDisabled) { return; }
+        var anyFootnote = this.measuresFootnotes.some(function(footnote){
+          return footnote.footnote_type_id && footnote.description;
+        });
+        if (anyFootnote) {
+          this.confirmBtnDisabled = false;
+        }
+      },
+      deep: true
     }
   },
   mounted: function(){

--- a/app/assets/stylesheets/components/tables.scss
+++ b/app/assets/stylesheets/components/tables.scss
@@ -23,7 +23,7 @@ table {
   }
 
   .table__column--highlight {
-    background: $panel-colour;
+    background: transparentize($panel-colour, 0.4);
   }
 
   .select-all-column {


### PR DESCRIPTION
addresses

- a. When you try to bulk edit Footnotes, there are missing lines on the highlights
- e. After you remove all the footnotes, select Edit Footnotes again,then select any footnotes, the "Update Selected Measures" seems to be disabled permanently.

https://trello.com/c/XOvqXITQ/314-dit-bulk-edit-popups-footnotes-5