### PR TITLE
- rename effective_enddate column of full_temporary_stop_regulations_…

### DIFF
--- a/app/interactors/regulation_saver.rb
+++ b/app/interactors/regulation_saver.rb
@@ -98,13 +98,7 @@ class RegulationParamsNormalizer
 
   def method_effective_end_date(effective_end_date)
     ops = {}
-
-    if reg_params[:role] == "8"
-      ops[:effective_enddate] = effective_end_date
-    else
-      ops[:effective_end_date] = effective_end_date
-    end
-
+    ops[:effective_end_date] = effective_end_date
     ops
   end
 
@@ -256,7 +250,7 @@ class RegulationSaver
     :officialjournal_page,
     :validity_start_date,
     :validity_end_date,
-    :effective_enddate,
+    :effective_end_date,
     :published_date,
     :operation_date
   ]

--- a/app/models/full_temporary_stop_regulation.rb
+++ b/app/models/full_temporary_stop_regulation.rb
@@ -17,10 +17,6 @@ class FullTemporaryStopRegulation < Sequel::Model
     full_temporary_stop_regulation_id
   end
 
-  def effective_end_date
-    effective_enddate.to_date if effective_enddate.present?
-  end
-
   def effective_start_date
     validity_start_date.to_date
   end

--- a/app/views/xml_generation/templates/regulations/full_temporary_stop_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/full_temporary_stop_regulation.builder
@@ -6,7 +6,7 @@ xml.tag!("oub:full.temporary.stop.regulation") do |full_temporary_stop_regulatio
   xml_data_item_v2(full_temporary_stop_regulation, "officialjournal.page", self.officialjournal_page)
   xml_data_item_v2(full_temporary_stop_regulation, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
   xml_data_item_v2(full_temporary_stop_regulation, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  xml_data_item_v2(full_temporary_stop_regulation, "effective.enddate", self.effective_enddate.strftime("%Y-%m-%d"))
+  xml_data_item_v2(full_temporary_stop_regulation, "effective.end.date", self.effective_end_date.strftime("%Y-%m-%d"))
   xml_data_item_v2(full_temporary_stop_regulation, "complete.abrogation.regulation.role", self.complete_abrogation_regulation_role)
   xml_data_item_v2(full_temporary_stop_regulation, "complete.abrogation.regulation.id", self.complete_abrogation_regulation_id)
   xml_data_item_v2(full_temporary_stop_regulation, "explicit.abrogation.regulation.role", self.explicit_abrogation_regulation_role)

--- a/app/views/xml_generation/templates/regulations/full_temporary_stop_regulation.builder
+++ b/app/views/xml_generation/templates/regulations/full_temporary_stop_regulation.builder
@@ -6,7 +6,7 @@ xml.tag!("oub:full.temporary.stop.regulation") do |full_temporary_stop_regulatio
   xml_data_item_v2(full_temporary_stop_regulation, "officialjournal.page", self.officialjournal_page)
   xml_data_item_v2(full_temporary_stop_regulation, "validity.start.date", self.validity_start_date.strftime("%Y-%m-%d"))
   xml_data_item_v2(full_temporary_stop_regulation, "validity.end.date", self.validity_end_date.try(:strftime, "%Y-%m-%d"))
-  xml_data_item_v2(full_temporary_stop_regulation, "effective.end.date", self.effective_end_date.strftime("%Y-%m-%d"))
+  xml_data_item_v2(full_temporary_stop_regulation, "effective.enddate", self.effective_end_date.strftime("%Y-%m-%d"))
   xml_data_item_v2(full_temporary_stop_regulation, "complete.abrogation.regulation.role", self.complete_abrogation_regulation_role)
   xml_data_item_v2(full_temporary_stop_regulation, "complete.abrogation.regulation.id", self.complete_abrogation_regulation_id)
   xml_data_item_v2(full_temporary_stop_regulation, "explicit.abrogation.regulation.role", self.explicit_abrogation_regulation_role)

--- a/db/migrate/20180828085635_rename_effective_end_date_column.rb
+++ b/db/migrate/20180828085635_rename_effective_end_date_column.rb
@@ -1,0 +1,85 @@
+Sequel.migration do
+  up do
+
+    run 'DROP VIEW public.full_temporary_stop_regulations;'
+
+    alter_table :full_temporary_stop_regulations_oplog do
+      rename_column :effective_enddate, :effective_end_date
+    end
+
+    run %Q{
+CREATE VIEW public.full_temporary_stop_regulations AS
+ SELECT full_temporary_stop_regulations1.full_temporary_stop_regulation_role,
+    full_temporary_stop_regulations1.full_temporary_stop_regulation_id,
+    full_temporary_stop_regulations1.published_date,
+    full_temporary_stop_regulations1.officialjournal_number,
+    full_temporary_stop_regulations1.officialjournal_page,
+    full_temporary_stop_regulations1.validity_start_date,
+    full_temporary_stop_regulations1.validity_end_date,
+    full_temporary_stop_regulations1.effective_end_date,
+    full_temporary_stop_regulations1.explicit_abrogation_regulation_role,
+    full_temporary_stop_regulations1.explicit_abrogation_regulation_id,
+    full_temporary_stop_regulations1.replacement_indicator,
+    full_temporary_stop_regulations1.information_text,
+    full_temporary_stop_regulations1.approved_flag,
+    full_temporary_stop_regulations1.oid,
+    full_temporary_stop_regulations1.operation,
+    full_temporary_stop_regulations1.operation_date,
+    full_temporary_stop_regulations1.added_by_id,
+    full_temporary_stop_regulations1.added_at,
+    full_temporary_stop_regulations1."national",
+    full_temporary_stop_regulations1.status,
+    full_temporary_stop_regulations1.workbasket_id,
+    full_temporary_stop_regulations1.workbasket_sequence_number,
+    full_temporary_stop_regulations1.complete_abrogation_regulation_role,
+    full_temporary_stop_regulations1.complete_abrogation_regulation_id
+   FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations1
+  WHERE ((full_temporary_stop_regulations1.oid IN ( SELECT max(full_temporary_stop_regulations2.oid) AS max
+           FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations2
+          WHERE (((full_temporary_stop_regulations1.full_temporary_stop_regulation_id)::text = (full_temporary_stop_regulations2.full_temporary_stop_regulation_id)::text) AND (full_temporary_stop_regulations1.full_temporary_stop_regulation_role = full_temporary_stop_regulations2.full_temporary_stop_regulation_role)))) AND ((full_temporary_stop_regulations1.operation)::text <> 'D'::text));
+    }
+
+  end
+
+  down do
+
+    run 'DROP VIEW public.full_temporary_stop_regulations;'
+
+    alter_table :full_temporary_stop_regulations_oplog do
+      rename_column :effective_end_date, :effective_enddate
+    end
+
+    run %Q{
+CREATE VIEW public.full_temporary_stop_regulations AS
+ SELECT full_temporary_stop_regulations1.full_temporary_stop_regulation_role,
+    full_temporary_stop_regulations1.full_temporary_stop_regulation_id,
+    full_temporary_stop_regulations1.published_date,
+    full_temporary_stop_regulations1.officialjournal_number,
+    full_temporary_stop_regulations1.officialjournal_page,
+    full_temporary_stop_regulations1.validity_start_date,
+    full_temporary_stop_regulations1.validity_end_date,
+    full_temporary_stop_regulations1.effective_enddate,
+    full_temporary_stop_regulations1.explicit_abrogation_regulation_role,
+    full_temporary_stop_regulations1.explicit_abrogation_regulation_id,
+    full_temporary_stop_regulations1.replacement_indicator,
+    full_temporary_stop_regulations1.information_text,
+    full_temporary_stop_regulations1.approved_flag,
+    full_temporary_stop_regulations1.oid,
+    full_temporary_stop_regulations1.operation,
+    full_temporary_stop_regulations1.operation_date,
+    full_temporary_stop_regulations1.added_by_id,
+    full_temporary_stop_regulations1.added_at,
+    full_temporary_stop_regulations1."national",
+    full_temporary_stop_regulations1.status,
+    full_temporary_stop_regulations1.workbasket_id,
+    full_temporary_stop_regulations1.workbasket_sequence_number,
+    full_temporary_stop_regulations1.complete_abrogation_regulation_role,
+    full_temporary_stop_regulations1.complete_abrogation_regulation_id
+   FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations1
+  WHERE ((full_temporary_stop_regulations1.oid IN ( SELECT max(full_temporary_stop_regulations2.oid) AS max
+           FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations2
+          WHERE (((full_temporary_stop_regulations1.full_temporary_stop_regulation_id)::text = (full_temporary_stop_regulations2.full_temporary_stop_regulation_id)::text) AND (full_temporary_stop_regulations1.full_temporary_stop_regulation_role = full_temporary_stop_regulations2.full_temporary_stop_regulation_role)))) AND ((full_temporary_stop_regulations1.operation)::text <> 'D'::text));
+    }
+
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2626,7 +2626,7 @@ CREATE TABLE public.full_temporary_stop_regulations_oplog (
     officialjournal_page integer,
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
-    effective_enddate date,
+    effective_end_date date,
     explicit_abrogation_regulation_role integer,
     explicit_abrogation_regulation_id character varying(8),
     replacement_indicator integer,
@@ -2659,7 +2659,7 @@ CREATE VIEW public.full_temporary_stop_regulations AS
     full_temporary_stop_regulations1.officialjournal_page,
     full_temporary_stop_regulations1.validity_start_date,
     full_temporary_stop_regulations1.validity_end_date,
-    full_temporary_stop_regulations1.effective_enddate,
+    full_temporary_stop_regulations1.effective_end_date,
     full_temporary_stop_regulations1.explicit_abrogation_regulation_role,
     full_temporary_stop_regulations1.explicit_abrogation_regulation_id,
     full_temporary_stop_regulations1.replacement_indicator,
@@ -11468,3 +11468,4 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180802084730_add_fields_
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180807180500_add_initial_search_results_code_to_workbaskets.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180820092723_add_internal_fields_to_duty_expressions.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180823124148_add_workbasket_type_of_quota_to_quota_definitions.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180828085635_rename_effective_end_date_column.rb');

--- a/spec/factories/full_temporary_stop_regulation_factory.rb
+++ b/spec/factories/full_temporary_stop_regulation_factory.rb
@@ -4,7 +4,7 @@ FactoryGirl.define do
     full_temporary_stop_regulation_id     { Forgery(:basic).text(exactly: 8) }
     validity_start_date                   { Time.now.ago(2.years) }
     validity_end_date                     { nil }
-    effective_enddate                     { nil }
+    effective_end_date                    { nil }
 
     trait :xml do
       officialjournal_number              "L 120"
@@ -17,7 +17,7 @@ FactoryGirl.define do
       explicit_abrogation_regulation_id   { Forgery(:basic).text(exactly: 8) }
 
       published_date                       { Date.today.ago(14.months) }
-      effective_enddate                    { Date.today.ago(1.years) }
+      effective_end_date                   { Date.today.ago(1.years) }
       validity_end_date                    { Date.today.ago(3.months) }
     end
   end

--- a/spec/models/full_temporary_stop_regulation_spec.rb
+++ b/spec/models/full_temporary_stop_regulation_spec.rb
@@ -1,17 +1,11 @@
 require 'rails_helper'
 
 describe FullTemporaryStopRegulation do
-  let(:fts_regulation) { build :fts_regulation, effective_enddate: Date.today }
+  let(:fts_regulation) { build :fts_regulation, effective_end_date: Date.today }
 
   describe '#regulation_id' do
     it 'is an alias for full temporary stop regulation id' do
       expect(fts_regulation.regulation_id).to eq fts_regulation.full_temporary_stop_regulation_id
-    end
-  end
-
-  describe '#effective_end_date' do
-    it 'is an alias for effective_enddate' do
-      expect(fts_regulation.effective_end_date).to eq fts_regulation.effective_enddate.to_date
     end
   end
 

--- a/spec/xml_generation/regulations/full_temporary_stop_regulation_spec.rb
+++ b/spec/xml_generation/regulations/full_temporary_stop_regulation_spec.rb
@@ -21,7 +21,7 @@ describe "FullTemporaryStopRegulation XML generation" do
       :explicit_abrogation_regulation_id,
       :replacement_indicator,
       :information_text,
-      :effective_end_date,
+      { effective_end_date: :effective_enddate },
       :validity_start_date,
       :validity_end_date
     ]

--- a/spec/xml_generation/regulations/full_temporary_stop_regulation_spec.rb
+++ b/spec/xml_generation/regulations/full_temporary_stop_regulation_spec.rb
@@ -21,7 +21,7 @@ describe "FullTemporaryStopRegulation XML generation" do
       :explicit_abrogation_regulation_id,
       :replacement_indicator,
       :information_text,
-      :effective_enddate,
+      :effective_end_date,
       :validity_start_date,
       :validity_end_date
     ]


### PR DESCRIPTION
I changed xml generator, rspec test are passed, but I think what it would be nice to pay attention on it during the code review.

- rename effective_enddate column of full_temporary_stop_regulations_oplog table to effective_end_date.
- recreate related db view.
- delete useless alias from FullTemporaryStopRegulation model.
- fix all rspec test.
- fix xml data generation.
- fix regulation saver.