### PR TITLE
New conditions & duty expressions mechanics

### DIFF
--- a/app/assets/javascripts/components/conditions-parser.js
+++ b/app/assets/javascripts/components/conditions-parser.js
@@ -1,0 +1,83 @@
+window.ConditionsParser = {
+  parse: function(options) {
+    var newOptions = [];
+    var mappings = {
+      "E": [
+        {
+          condition_code: "E1",
+          description: "The quantity declared is equal or less than the specified maximum"
+        },
+        {
+          condition_code: "E2",
+          description: "The price per unit declared is equal or less than the specified maximum"
+        },
+        {
+          condition_code: "E3",
+          description: "Presentation of the required document"
+        }
+      ],
+      "I": [
+        {
+          condition_code: "I1",
+          description: "The quantity  declared is equal or less than the specified maximum"
+        },
+        {
+          condition_code: "I2",
+          description: "The price per unit declared is equal or less than the specified maximum"
+        },
+        {
+          condition_code: "I3",
+          description: "Presentation of the required document"
+        }
+      ],
+      "M": [
+        {
+          condition_code: "M1",
+          description: "Declared price must be equal to or greater than the minimum price (see components)"
+        },
+        {
+          condition_code: "M2",
+          description: "Declared price must be equal to or greater than the reference price (see components)"
+        }
+      ]
+    };
+
+    options.forEach(function (option) {
+      var newOption = null;
+
+      if (mappings[option.condition_code] !== undefined) {
+        mappings[option.condition_code].forEach(function(newOption) {
+          newOptions.push(newOption);
+        });
+      } else {
+        newOptions.push(option);
+      }
+    });
+
+    return newOptions;
+  },
+  getConditionCode: function(condition) {
+    if (condition.condition_code == "E") {
+      if (condition.certificate_type_code) {
+        return "E3";
+      } else if (condition.monetary_unit_code) {
+        return "E2";
+      } else {
+        return "E1";
+      }
+    } else if (condition.condition_code == "I") {
+      if (condition.certificate_type_code) {
+        return "I3";
+      } else if (condition.monetary_unit_code) {
+        return "I2";
+      } else {
+        return "I1";
+      }
+    } else if (condition.condition_code == "M") {
+      return "M1";
+      // there's no seemingly possible way to determine if it's M2
+    } else {
+      return condition.condition_code;
+    }
+  }
+};

--- a/app/assets/javascripts/components/conditions-parser.js
+++ b/app/assets/javascripts/components/conditions-parser.js
@@ -57,6 +57,10 @@ window.ConditionsParser = {
     return newOptions;
   },
   getConditionCode: function(condition) {
+    if (condition.original_measure_condition_code) {
+      return condition.original_measure_condition_code;
+    }
+
     if (condition.condition_code == "E") {
       if (condition.certificate_type_code) {
         return "E3";

--- a/app/assets/javascripts/components/duty-expressions-parser.js
+++ b/app/assets/javascripts/components/duty-expressions-parser.js
@@ -9,58 +9,95 @@ window.DutyExpressionsParser = {
       if (option.duty_expression_id === "01") {
         option.duty_expression_id = "01A";
         option.description = "% (ad valorem)";
-        option.abbreviation = "+ %";
+        option.abbreviation = "%";
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "01B",
-          description: "Specific duty rate",
-          abbreviation: "+ €"
+          description: "Amount €",
+          abbreviation: "€"
         };
       } else if (option.duty_expression_id === "02") {
         option.duty_expression_id = "02A";
         option.description = "Minus %";
-        option.abbreviation = "- %";
+        option.abbreviation = "-%";
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "02B",
-          description: "Minus amount",
-          abbreviation: "- €"
+          description: "Minus amount €",
+          abbreviation: "-€"
         };
       } else if (option.duty_expression_id === "04") {
         option.duty_expression_id = "04A";
         option.description = "Plus %";
-        option.abbreviation = "+ %";
+        option.abbreviation = "+%";
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "04B",
-          description: "Plus amount",
-          abbreviation: "+ €"
+          description: "Plus amount €",
+          abbreviation: "+€"
+        };
+      } else if (option.duty_expression_id === "15") {
+        option.duty_expression_id = "15A";
+        option.description = "Minimum %";
+        option.abbreviation = "≥%";
+
+        newOption = {
+          duty_expression_code: option.duty_expression_code,
+          duty_expression_id: "15B",
+          description: "Minimum amount €",
+          abbreviation: "≥€"
+        };
+      } else if (option.duty_expression_id === "17") {
+        option.duty_expression_id = "17A";
+        option.description = "Maximum %";
+        option.abbreviation = "≤%";
+
+        newOption = {
+          duty_expression_code: option.duty_expression_code,
+          duty_expression_id: "17B",
+          description: "Maximum amount €",
+          abbreviation: "≤€"
         };
       } else if (option.duty_expression_id === "19") {
         option.duty_expression_id = "19A";
         option.description = "Plus %";
-        option.abbreviation = "+ %";
+        option.abbreviation = "%";
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "19B",
-          description: "Plus amount",
-          abbreviation: "+ €"
+          description: "Plus amount €",
+          abbreviation: "€"
         };
       } else if (option.duty_expression_id === "20") {
         option.duty_expression_id = "20A";
         option.description = "Plus %";
-        option.abbreviation = "+ %";
+        option.abbreviation = "%";
 
         newOption = {
           duty_expression_code: option.duty_expression_code,
           duty_expression_id: "20B",
-          description: "Plus amount",
-          abbreviation: "+ €"
+          description: "Plus amount €",
+          abbreviation: "€"
         };
+      } else if (option.duty_expression_id === "35") {
+        option.duty_expression_id = "35A";
+        option.description = "Maximum %";
+        option.abbreviation = "≤%";
+
+        newOption = {
+          duty_expression_code: option.duty_expression_code,
+          duty_expression_id: "35B",
+          description: "Maximum amount €",
+          abbreviation: "≤€"
+        };
+      } else if (option.duty_expression_id === "36") {
+        option.abbreviation = "-%";
+      } else {
+        option.abbreviation = undefined;
       }
 
       newOptions.push(option);

--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -197,198 +197,45 @@ $(document).ready(function() {
     mounted: function() {
       var self = this;
 
-      $(document).ready(function(){
-        $(document).on('click', ".js-create-measures-v1-submit-button, .js-workbasket-base-submit-button", function(e) {
-          e.preventDefault();
-          e.stopPropagation();
-
-          submit_button = $(this);
-
-          if ( window.save_url == "/measures" ) {
-            // Create measures V1 version
-            //
-
-            var button = $("input[type='submit']");
-            button.attr("data-text", button.val());
-            button.val("Saving...");
-            button.prop("disabled", true);
-
-            var http_method = "POST";
-            var data_ops = { measure: self.preparePayload() };
-
-          } else {
-            // Create measures V2 version
-            //
-
-            WorkbasketBaseSaveActions.hideSuccessMessage();
-            WorkbasketBaseSaveActions.toogleSaveSpinner($(this).attr('name'));
-            var http_method = "PUT";
-
-            if ( window.save_url.indexOf('create_measures') == -1 ) {
-              // Create Quota
-              //
-
-              if (window.current_step == 'main') {
-                var payload = self.createQuotaMainStepPayload();
-              } else if (window.current_step == 'configure_quota') {
-                var payload = self.createQuotaConfigureQuotaStepPayload();
-              } else if (window.current_step == 'conditions_footnotes') {
-                var payload = self.createQuotaConditionsFootnotesStepPayload();
-              }
-            } else {
-              // Create measures V2
-              //
-
-              if (window.current_step == 'main') {
-                var payload = self.prepareV2Step1Payload();
-              } else if (window.current_step == 'duties_conditions_footnotes') {
-                var payload = self.prepareV2Step2Payload();
-              }
-            }
-
-            var data_ops = {
-              step: window.current_step,
-              mode: submit_button.attr('name'),
-              start_date: window.create_measures_start_date,
-              end_date: window.create_measures_end_date,
-              settings: payload
-            };
-          }
-
-          self.errors = [];
-
-          $.ajax({
-            url: window.save_url,
-            type: http_method,
-            data: data_ops,
-            success: function(response) {
-              if ( window.save_url == "/measures" ) {
-                // Create measures V1 version
-                //
-                $(".js-workbasket-errors-container").empty().addClass("hidden");
-                window.location = window.save_url + "?code=" + response.goods_nomenclature_item_id;
-              } else {
-                // Create measures V2 version
-                //
-                WorkbasketBaseSaveActions.handleSuccessResponse(response, submit_button.attr('name'));
-              }
-            },
-            error: function(response) {
-
-              if ( window.save_url == "/measures" ) {
-                // Create measures V1 version
-                //
-                button.val(button.attr("data-text"));
-                button.prop("disabled", false);
-
-                $.each( response.responseJSON.errors, function( key, value ) {
-                  if (value.constructor === Array) {
-                    value.forEach(function(innerError) {
-                      self.errors.push(innerError);
-                    });
-                  } else {
-                    self.errors.push(value);
-                  }
-                });
-
-              } else {
-                // Create measures V2 version
-                //
-                WorkbasketBaseValidationErrorsHandler.handleErrorsResponse(response, self);
-              }
-            }
-          });
-        });
-      });
-
-      if (this.measure.quota_periods.length === 0) {
-        this.addQuotaPeriod(true);
-      }
-
-      if (this.measure.conditions.length === 0) {
-        this.addCondition();
-      }
-
-      if (this.measure.footnotes.length === 0) {
-        this.measure.footnotes.push({
-          footnote_type_id: null,
-          description: null
-        });
-      }
-
-      if (this.measure.measure_components.length === 0) {
-        this.measure.measure_components.push({
-          duty_expression_id: null,
-          duty_amount: null,
-          measurement_unit_code: null,
-          measurement_unit_qualifier_code: null
-        });
-      }
-
-      this.fetchNomenclatureCode("/goods_nomenclatures", 10, "goods_nomenclature_code", "goods_nomenclature_code_description");
-      this.fetchAdditionalCode("/additional_codes/preview", 4, "additional_code_preview", "additional_code_preview_description");
-
-      $(document).on('click', ".js-create-measures-v1-submit-button, .js-workbasket-base-submit-button", function(e) {
+      var saveFunction = function(e) {
         e.preventDefault();
         e.stopPropagation();
 
         submit_button = $(this);
 
-        if ( window.save_url == "/measures" ) {
-          // Create measures V1 version
+        WorkbasketBaseSaveActions.hideSuccessMessage();
+        WorkbasketBaseSaveActions.toogleSaveSpinner($(this).attr('name'));
+        var http_method = "PUT";
+
+        if ( window.save_url.indexOf('create_measures') == -1 ) {
+          // Create Quota
           //
 
-          var button = $("input[type='submit']");
-          button.attr("data-text", button.val());
-          button.val("Saving...");
-          button.prop("disabled", true);
-
-          var http_method = "POST";
-          var data_ops = { measure: self.preparePayload() };
-
-        } else {
-          // Create measures V2 version
-          //
-
-          WorkbasketBaseSaveActions.hideSuccessMessage();
-          WorkbasketBaseSaveActions.toogleSaveSpinner($(this).attr('name'));
-          var http_method = "PUT";
-
-          if ( window.save_url.indexOf('create_measures') == -1 ) {
-            // Create Quota
-            //
-
-            if (window.current_step == 'main') {
-              var payload = self.createQuotaMainStepPayload();
-
-            } else if (window.current_step == 'configure_quota') {
-              var payload = self.createQuotaConfigureQuotaStepPayload();
-
-            } else if (window.current_step == 'conditions_footnotes') {
-              var payload = self.createQuotaConditionsFootnotesStepPayload();
-
-            }
-          } else {
-            // Create measures V2
-            //
-
-            if (window.current_step == 'main') {
-              var payload = self.prepareV2Step1Payload();
-
-            } else if (window.current_step == 'duties_conditions_footnotes') {
-              var payload = self.prepareV2Step2Payload();
-
-            }
+          if (window.current_step == 'main') {
+            var payload = self.createQuotaMainStepPayload();
+          } else if (window.current_step == 'configure_quota') {
+            var payload = self.createQuotaConfigureQuotaStepPayload();
+          } else if (window.current_step == 'conditions_footnotes') {
+            var payload = self.createQuotaConditionsFootnotesStepPayload();
           }
+        } else {
+          // Create measures V2
+          //
 
-          var data_ops = {
-            step: window.current_step,
-            mode: submit_button.attr('name'),
-            start_date: window.create_measures_start_date,
-            end_date: window.create_measures_end_date,
-            settings: payload
-          };
+          if (window.current_step == 'main') {
+            var payload = self.prepareV2Step1Payload();
+          } else if (window.current_step == 'duties_conditions_footnotes') {
+            var payload = self.prepareV2Step2Payload();
+          }
         }
+
+        var data_ops = {
+          step: window.current_step,
+          mode: submit_button.attr('name'),
+          start_date: window.create_measures_start_date,
+          end_date: window.create_measures_end_date,
+          settings: payload
+        };
 
         self.errors = [];
 
@@ -433,7 +280,36 @@ $(document).ready(function() {
             }
           }
         });
-      });
+      };
+
+      $(document).on('click', ".js-create-measures-v1-submit-button, .js-workbasket-base-submit-button", debounce(saveFunction, 100, true));
+
+      if (this.measure.quota_periods.length === 0) {
+        this.addQuotaPeriod(true);
+      }
+
+      if (this.measure.conditions.length === 0) {
+        this.addCondition();
+      }
+
+      if (this.measure.footnotes.length === 0) {
+        this.measure.footnotes.push({
+          footnote_type_id: null,
+          description: null
+        });
+      }
+
+      if (this.measure.measure_components.length === 0) {
+        this.measure.measure_components.push({
+          duty_expression_id: null,
+          duty_amount: null,
+          measurement_unit_code: null,
+          measurement_unit_qualifier_code: null
+        });
+      }
+
+      this.fetchNomenclatureCode("/goods_nomenclatures", 10, "goods_nomenclature_code", "goods_nomenclature_code_description");
+      this.fetchAdditionalCode("/additional_codes/preview", 4, "additional_code_preview", "additional_code_preview_description");
 
       $(".measure-form").on("geoarea:changed", function(e, id) {
         self.measure.geographical_area_id = id;

--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -736,6 +736,7 @@ $(document).ready(function() {
             var section = clone(_section);
 
             section.duty_expressions.forEach(function(e) {
+              e.original_duty_expression_id = e.duty_expression_id.slice(0);
               e.duty_expression_id = e.duty_expression_id.substring(0,2);
             });
 
@@ -751,6 +752,7 @@ $(document).ready(function() {
 
               section.periods.forEach(function(period) {
                 period.duty_expressions.forEach(function(e) {
+                  e.original_duty_expression_id = e.duty_expression_id.slice(0);
                   e.duty_expression_id = e.duty_expression_id.substring(0,2);
                 });
               });
@@ -761,6 +763,7 @@ $(document).ready(function() {
               section.opening_balances.forEach(function(balance) {
                 if (section.type == "annual") {
                   balance.duty_expressions.forEach(function(e) {
+                    e.original_duty_expression_id = e.duty_expression_id.slice(0);
                     e.duty_expression_id = e.duty_expression_id.substring(0,2);
                   });
                 } else {
@@ -772,6 +775,7 @@ $(document).ready(function() {
 
                   ks[section.type].forEach(function(k) {
                     balance[k].duty_expressions.forEach(function(e) {
+                      e.original_duty_expression_id = e.duty_expression_id.slice(0);
                       e.duty_expression_id = e.duty_expression_id.substring(0,2);
                     });
                   });
@@ -794,11 +798,13 @@ $(document).ready(function() {
           payload.conditions = this.measure.conditions.map(function(condition) {
             var c = clone(condition);
 
+            c.original_measure_condition_code = c.condition_code.slice(0);
             c.condition_code = c.condition_code.substring(0, 1);
 
             c.measure_condition_components = c.measure_condition_components.map(function(component) {
               var c = clone(component);
               if (c.duty_expression_id) {
+                c.original_duty_expression_id = c.duty_expression_id.slice(0);
                 // to ignore A and B
                 c.duty_expression_id = c.duty_expression_id.substring(0, 2);
               }
@@ -859,6 +865,8 @@ $(document).ready(function() {
             var c = clone(component);
 
             if (c.duty_expression_id) {
+              c.original_duty_expression_id = c.duty_expression_id.slice(0);
+
               // to ignore A and B
               c.duty_expression_id = c.duty_expression_id.substring(0, 2);
             }
@@ -873,11 +881,13 @@ $(document).ready(function() {
           payload.conditions = this.measure.conditions.map(function(condition) {
             var c = clone(condition);
 
+            c.original_measure_condition_code = c.condition_code.slice(0);
             c.condition_code = c.condition_code.substring(0, 1);
 
             c.measure_condition_components = c.measure_condition_components.map(function(component) {
               var c = clone(component);
               if (c.duty_expression_id) {
+                c.original_duty_expression_id = c.duty_expression_id.slice(0);
                 // to ignore A and B
                 c.duty_expression_id = c.duty_expression_id.substring(0, 2);
               }
@@ -928,6 +938,7 @@ $(document).ready(function() {
               var c = clone(component);
 
               if (c.duty_expression_id) {
+                c.original_duty_expression_id = c.duty_expression_id.slice(0);
                 // to ignore A and B
                 c.duty_expression_id = c.duty_expression_id.substring(0, 2);
               }
@@ -943,11 +954,13 @@ $(document).ready(function() {
           payload.conditions = this.measure.conditions.map(function(condition) {
             var c = clone(condition);
 
+            c.original_measure_condition_code = c.condition_code.slice(0);
             c.condition_code = c.condition_code.substring(0, 1);
 
             c.measure_condition_components = c.measure_condition_components.map(function(component) {
               var c = clone(component);
               if (c.duty_expression_id) {
+                c.original_duty_expression_id = c.duty_expression_id.slice(0);
                 // to ignore A and B
                 c.duty_expression_id = c.duty_expression_id.substring(0, 2);
               }
@@ -1052,7 +1065,22 @@ $(document).ready(function() {
         this.measure.conditions.splice(index, 1);
       },
       getDutyExpressionId: function(component) {
-        var ids = ["01","02","04","19","20"];
+        var ids = [
+          "01",
+          "02",
+          "04",
+          "15",
+          "17",
+          "19",
+          "20",
+          "35",
+          "36"
+        ];
+
+        if (component.original_duty_expression_id) {
+          return component.original_duty_expression_id;
+        }
+
         var id = component.duty_expression ? component.duty_expression.duty_expression_id : component.duty_expression_id;
 
         if (ids.indexOf(id) === -1) {

--- a/app/assets/javascripts/components/workbaskets/save-actions.js.coffee
+++ b/app/assets/javascripts/components/workbaskets/save-actions.js.coffee
@@ -3,40 +3,31 @@ window.WorkbasketBaseSaveActions =
   toogleSaveSpinner: (mode) ->
     WorkbasketBaseSaveActions.disable_other_buttons(mode)
 
-    if mode == "save_progress"
-      link = $(".js-workbasket-base-save-progress-button")
-      spinner = $(".js-workbasket-base-save-progress-spinner")
-    else
-      link = $(".js-workbasket-base-continue-button")
-      spinner = $(".js-workbasket-base-continue-spinner")
-
-    if link.hasClass('hidden')
-      spinner.addClass('hidden')
-      link.addClass('secondary-button')
-      link.removeClass('hidden')
-    else
-      link.removeClass('secondary-button')
-      link.addClass('hidden')
-      spinner.removeClass('hidden')
-
   disable_other_buttons: (mode) ->
     save_link = $(".js-workbasket-base-save-progress-button")
     submit_link = $(".js-workbasket-base-continue-button")
     exit_link = $(".js-workbasket-base-exit-button")
     previous_link = $(".js-workbasket-base-previous-step-link")
+    submit_link.prop('disabled', true)
+    save_link.prop('disabled', true)
 
-    if mode == "save_progress"
-      submit_link.addClass('disabled')
-    else
-      save_link.addClass('disabled')
+    save_link.attr("data-original-text", save_link.val())
+    submit_link.attr("data-original-text", submit_link.val())
+
+    save_link.val("Saving...")
+    submit_link.val("Saving...")
 
     exit_link.addClass('disabled')
     previous_link.addClass('disabled')
 
   unlockButtonsAndHideSpinner: ->
-    $(".spinner_block").addClass('hidden')
-    $(".js-workbasket-base-submit-button, .js-workbasket-base-exit-button, .js-workbasket-base-previous-step-link").removeClass('disabled')
-                                                                                                                      .removeClass('hidden')
+    save_link = $(".js-workbasket-base-save-progress-button")
+    submit_link = $(".js-workbasket-base-continue-button")
+
+    save_link.val(save_link.data("original-text"))
+    submit_link.val(submit_link.data("original-text"))
+
+    $(".js-workbasket-base-submit-button, .js-workbasket-base-exit-button, .js-workbasket-base-previous-step-link").removeClass("disabled").prop('disabled', false)
 
   handleSuccessResponse: (resp, submit_mode) ->
     WorkbasketBaseValidationErrorsHandler.hideCustomErrorsBlock()

--- a/app/assets/javascripts/components/workbaskets/validation_errors_handler.js.coffee
+++ b/app/assets/javascripts/components/workbaskets/validation_errors_handler.js.coffee
@@ -3,13 +3,15 @@ window.WorkbasketBaseValidationErrorsHandler =
   handleErrorsResponse: (response, workbasket_form) ->
     WorkbasketBaseValidationErrorsHandler.hideCustomErrorsBlock()
     WorkbasketBaseSaveActions.hideSuccessMessage()
-
-    if response.responseJSON.step == "main"
-      WorkbasketBaseValidationErrorsHandler.setFormErrors(response, workbasket_form)
-    else
-      WorkbasketBaseValidationErrorsHandler.renderErrorsBlock(response, workbasket_form)
-
     WorkbasketBaseSaveActions.unlockButtonsAndHideSpinner()
+
+    try
+      if response.responseJSON.step == "main"
+        WorkbasketBaseValidationErrorsHandler.setFormErrors(response, workbasket_form)
+      else
+        WorkbasketBaseValidationErrorsHandler.renderErrorsBlock(response, workbasket_form)
+    catch e
+      console.error(e)
 
   setFormErrors: (response, workbasket_form) ->
     errors_list = response.responseJSON.errors

--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -1,7 +1,7 @@
 var template = [
   '<div>',
     '<div :class="classes" v-for="(component, idx) in components">',
-      '<measure-condition-component v-if="isMeasureConditionComponent" :measure-condition-component="component" :index="Math.max(idx,index)" :room-duty-amount-or-percentage="showDutyAmountOrPercentage" :room-duty-amount-percentage="showDutyAmountPercentage" :room-duty-amount-negative-percentage="showDutyAmountNegativePercentage" :room-duty-amount-number="showDutyAmountNumber" :room-duty-amount-minimum="showDutyAmountMinimum" :room-duty-amount-maximum="showDutyAmountMaximum" :room-duty-amount-negative-number="showDutyAmountNegativeNumber" :room-duty-refund-amount="showDutyRefundAmount" :room-monetary-unit="showMonetaryUnit" :room-measurement-unit="showMeasurementUnit">',
+      '<measure-condition-component v-if="isMeasureConditionComponent" :measure-condition-component="component" :index="Math.max(idx,index)" :room-monetary-unit="showMonetaryUnit">',
         '<div class="col-md-1 align-bottom" v-if="canRemoveComponent">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0 && idx == 0">&nbsp;</label>',
@@ -11,7 +11,7 @@ var template = [
           '</div>',
         '</div>',
       '</measure-condition-component>',
-      '<measure-component v-if="isMeasureComponent" :measure-component="component" :index="Math.max(idx,index)" :room-duty-amount-or-percentage="showDutyAmountOrPercentage" :room-duty-amount-percentage="showDutyAmountPercentage" :room-duty-amount-negative-percentage="showDutyAmountNegativePercentage" :room-duty-amount-number="showDutyAmountNumber" :room-duty-amount-minimum="showDutyAmountMinimum" :room-duty-amount-maximum="showDutyAmountMaximum" :room-duty-amount-negative-number="showDutyAmountNegativeNumber" :room-duty-refund-amount="showDutyRefundAmount" :room-monetary-unit="showMonetaryUnit" :room-measurement-unit="showMeasurementUnit">',
+      '<measure-component v-if="isMeasureComponent" :measure-component="component" :index="Math.max(idx,index)" :room-monetary-unit="showMonetaryUnit">',
         '<div class="col-md-1 align-bottom" v-if="canRemoveComponent">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0 && idx == 0">&nbsp;</label>',
@@ -65,75 +65,8 @@ Vue.component("components-coordinator", {
     isMeasureComponent: function() {
       return this.type == "measure_component";
     },
-    showDutyAmountOrPercentage: function() {
-      var ids = ["01", "02", "04", "19", "20"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
-    showDutyAmountPercentage: function() {
-      var ids = ["23", "01A", "04A", "19A", "20A"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
-    showDutyAmountNegativePercentage: function() {
-      var ids = ["36", "02A"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
-    showDutyAmountNumber: function() {
-      var ids = ["01B", "04B", "19B", "20B", "06", "07", "09", "11", "12", "13", "14", "21", "25", "27", "29", "31"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
-    showDutyAmountMinimum: function() {
-      var ids = ["15"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
-    showDutyAmountMaximum: function() {
-      var ids = ["17", "35"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
-    showDutyAmountNegativeNumber: function() {
-      var ids = ["02B"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
-    showDutyRefundAmount: function() {
-      var ids = ["40", "41", "42", "43", "44"];
-
-      return this.any(this.components, function(component) {
-        return ids.indexOf(component.duty_expression_id) > -1;
-      });
-    },
     showMonetaryUnit: function() {
-      return this.showDutyAmountOrPercentage ||
-             this.showDutyAmountNumber ||
-             this.showDutyAmountMinimum ||
-             this.showDutyAmountMaximum ||
-             this.showDutyRefundAmount;
-    },
-    showMeasurementUnit: function() {
-      var ids = ["23", "36", "37", "01A", "04A", "19A", "20A", "02A"];
-
-      return this.any(this.components, function(component) {
-        return component.duty_expression_id && ids.indexOf(component.duty_expression_id) === -1;
-      });
+      return false;
     }
   }
 });

--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -1,7 +1,7 @@
 var template = [
   '<div>',
     '<div :class="classes" v-for="(component, idx) in components">',
-      '<measure-condition-component v-if="isMeasureConditionComponent" :measure-condition-component="component" :index="Math.max(idx,index)" :room-monetary-unit="showMonetaryUnit">',
+      '<measure-condition-component v-if="isMeasureConditionComponent" :measure-condition-component="component" :index="Math.max(idx,index)" :room-duty-amount="showDutyAmount" :room-measurement-unit="showMeasurementUnit" :room-monetary-unit="showMonetaryUnit">',
         '<div class="col-md-1 align-bottom" v-if="canRemoveComponent">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0 && idx == 0">&nbsp;</label>',
@@ -11,7 +11,7 @@ var template = [
           '</div>',
         '</div>',
       '</measure-condition-component>',
-      '<measure-component v-if="isMeasureComponent" :measure-component="component" :index="Math.max(idx,index)" :room-monetary-unit="showMonetaryUnit">',
+      '<measure-component v-if="isMeasureComponent" :measure-component="component" :index="Math.max(idx,index)" :room-monetary-unit="showMonetaryUnit" :room-duty-amount="showDutyAmount" :room-measurement-unit="showMeasurementUnit">',
         '<div class="col-md-1 align-bottom" v-if="canRemoveComponent">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0 && idx == 0">&nbsp;</label>',
@@ -22,10 +22,8 @@ var template = [
         '</div>',
       '</measure-component>',
     '</div>',
-    '<p>',
-      '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureConditionComponent">Add another component</a>',
-      '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureComponent">Add another duty expression</a>',
-    '</p>',
+    '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureConditionComponent">Add another component</a>',
+    '<a href="#" v-on:click.prevent="addComponent" v-if="isMeasureComponent">Add another duty expression</a>',
   '</div>'
 ].join("");
 
@@ -67,6 +65,20 @@ Vue.component("components-coordinator", {
     },
     showMonetaryUnit: function() {
       return false;
-    }
+    },
+    showDutyAmount: function() {
+      var ids = ["12", "14", "21", "25", "27", "29", "37", "99"];
+
+      return this.any(this.components, function(component) {
+        return component.duty_expression_id && ids.indexOf(component.duty_expression_id) === -1;
+      });
+    },
+    showMeasurementUnit: function() {
+      var ids = ["12", "14", "21", "23", "25", "27", "29", "36", "37", "01A", "02A", "04A", "15A", "17A", "19A", "20A", "35A"];
+
+      return this.any(this.components, function(component) {
+        return component.duty_expression_id && ids.indexOf(component.duty_expression_id) === -1;
+      });
+    },
   }
 });

--- a/app/assets/javascripts/vue_components/components-coordinator.js
+++ b/app/assets/javascripts/vue_components/components-coordinator.js
@@ -29,7 +29,14 @@ var template = [
 
 Vue.component("components-coordinator", {
   template: template,
-  props: ["components", "type", "classes", "index"],
+  props: [
+    "components",
+    "type",
+    "classes",
+    "index",
+    "showConditionsDutyAmount",
+    "showConditionsMeasurementUnit"
+  ],
   data: function() {
     return {
 
@@ -69,12 +76,20 @@ Vue.component("components-coordinator", {
     showDutyAmount: function() {
       var ids = ["12", "14", "21", "25", "27", "29", "37", "99"];
 
+      if (this.showConditionsDutyAmount === true) {
+        return true;
+      }
+
       return this.any(this.components, function(component) {
         return component.duty_expression_id && ids.indexOf(component.duty_expression_id) === -1;
       });
     },
     showMeasurementUnit: function() {
       var ids = ["12", "14", "21", "23", "25", "27", "29", "36", "37", "01A", "02A", "04A", "15A", "17A", "19A", "20A", "35A"];
+
+      if (this.showConditionsMeasurementUnit === true) {
+        return true;
+      }
 
       return this.any(this.components, function(component) {
         return component.duty_expression_id && ids.indexOf(component.duty_expression_id) === -1;

--- a/app/assets/javascripts/vue_components/conditions-coordinator.js
+++ b/app/assets/javascripts/vue_components/conditions-coordinator.js
@@ -1,7 +1,7 @@
 var template = [
   '<div>',
     '<div class="measure-condition" v-for="(measureCondition, index) in conditions">',
-      '<measure-condition :condition="measureCondition" :index="index" :hide-help="hideHelp" :room-action="showAction" :room-condition-components="showConditionComponents" :room-minimum-price="showMinimumPrice" :room-ratio="showRatio" :room-entry-price="showEntryPrice" :room-amount="showAmount" :room-certificate-type="showCertificateType" :room-certificate="showCertificate">',
+      '<measure-condition :condition="measureCondition" :index="index" :hide-help="hideHelp" :room-action="showAction" :room-condition-components="showConditionComponents" :room-minimum-price="showMinimumPrice" :room-ratio="showRatio" :room-entry-price="showEntryPrice" :room-amount="showAmount" :room-certificate-type="showCertificateType" :room-certificate="showCertificate" :room-maximum-price-per-unit="showMaximumPricePerUnit" :room-maximum-quantity="showMaximumQuantity" :room-monetary-unit="showMonetaryUnit" :room-measurement-unit="showMeasurementUnit">',
         '<div class="col-md-2">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0">&nbsp;<span class="form-hint-3-line">&nbsp;</span></label>',
@@ -66,6 +66,34 @@ Vue.component("conditions-coordinator", {
     canRemoveMeasureCondition: function() {
       return this.conditions.length > 1;
     },
+    showMaximumQuantity: function() {
+      var codes = ["E1", "I1"];
+
+      return this.any(this.conditions, function(condition) {
+        return condition.condition_code && codes.indexOf(condition.condition_code) > -1;
+      });
+    },
+    showMaximumPricePerUnit: function() {
+      var codes = ["E2", "I2"];
+
+      return this.any(this.conditions, function(condition) {
+        return condition.condition_code && codes.indexOf(condition.condition_code) > -1;
+      });
+    },
+    showMonetaryUnit: function() {
+      var codes = ["E2", "I2", "M1", "M2"];
+
+      return this.any(this.conditions, function(condition) {
+        return condition.condition_code && codes.indexOf(condition.condition_code) > -1;
+      });
+    },
+    showMeasurementUnit: function() {
+      var codes = ["E2", "I2", "M1", "M2"];
+
+      return this.any(this.conditions, function(condition) {
+        return condition.condition_code && codes.indexOf(condition.condition_code) > -1;
+      });
+    },
     showAction: function() {
       var codes = ["K", "P", "S", "W", "Y"];
 
@@ -109,14 +137,14 @@ Vue.component("conditions-coordinator", {
       });
     },
     showCertificateType: function() {
-      var codes = ["B", "C", "E", "I", "H", "Q", "Z", "V", "E"];
+      var codes = ["B", "C", "E3", "I3", "H", "Q", "Z", "V", "E"];
 
       return this.any(this.conditions, function(condition) {
         return codes.indexOf(condition.condition_code) > -1;
       });
     },
     showCertificate: function() {
-      var codes = ["A", "B", "C", "E", "I", "H", "Q", "Z", "V", "E"];
+      var codes = ["A", "B", "C", "E3", "I3", "H", "Q", "Z", "V", "E"];
 
       return this.any(this.conditions, function(condition) {
         return codes.indexOf(condition.condition_code) > -1;

--- a/app/assets/javascripts/vue_components/conditions-coordinator.js
+++ b/app/assets/javascripts/vue_components/conditions-coordinator.js
@@ -1,7 +1,7 @@
 var template = [
   '<div>',
     '<div class="measure-condition" v-for="(measureCondition, index) in conditions">',
-      '<measure-condition :condition="measureCondition" :index="index" :hide-help="hideHelp" :room-action="showAction" :room-condition-components="showConditionComponents" :room-minimum-price="showMinimumPrice" :room-ratio="showRatio" :room-entry-price="showEntryPrice" :room-amount="showAmount" :room-certificate-type="showCertificateType" :room-certificate="showCertificate" :room-maximum-price-per-unit="showMaximumPricePerUnit" :room-maximum-quantity="showMaximumQuantity" :room-monetary-unit="showMonetaryUnit" :room-measurement-unit="showMeasurementUnit">',
+      '<measure-condition :condition="measureCondition" :index="index" :hide-help="hideHelp" :room-referenced-value="showReferencedValue" :room-certificate-type="showCertificateType" :room-certificate="showCertificate" :room-monetary-unit="showMonetaryUnit" :room-measurement-unit="showMeasurementUnit">',
         '<div class="col-md-2">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0">&nbsp;<span class="form-hint-3-line">&nbsp;</span></label>',
@@ -66,15 +66,8 @@ Vue.component("conditions-coordinator", {
     canRemoveMeasureCondition: function() {
       return this.conditions.length > 1;
     },
-    showMaximumQuantity: function() {
-      var codes = ["E1", "I1"];
-
-      return this.any(this.conditions, function(condition) {
-        return condition.condition_code && codes.indexOf(condition.condition_code) > -1;
-      });
-    },
-    showMaximumPricePerUnit: function() {
-      var codes = ["E2", "I2"];
+    showReferencedValue: function() {
+      var codes = ["E1", "E2", "F", "G", "I1", "I2", "L", "M1", "M2", "N", "R", "S", "U", "V"];
 
       return this.any(this.conditions, function(condition) {
         return condition.condition_code && codes.indexOf(condition.condition_code) > -1;
@@ -88,63 +81,21 @@ Vue.component("conditions-coordinator", {
       });
     },
     showMeasurementUnit: function() {
-      var codes = ["E2", "I2", "M1", "M2"];
+      var codes = ["E1", "E2", "F", "G", "I1", "I2", "L", "M1", "M2", "N", "S", "V"];
 
       return this.any(this.conditions, function(condition) {
         return condition.condition_code && codes.indexOf(condition.condition_code) > -1;
       });
     },
-    showAction: function() {
-      var codes = ["K", "P", "S", "W", "Y"];
-
-      return this.any(this.conditions, function(condition) {
-        return condition.condition_code && codes.indexOf(condition.condition_code) === -1;
-      });
-    },
-    showConditionComponents: function() {
-      var codes = ["01", "02", "03", "11", "12", "13", "15", "27", "34", "36"];
-
-      return this.any(this.conditions, function(condition) {
-        return codes.indexOf(condition.action_code) > -1;
-      });
-    },
-    showMinimumPrice: function() {
-      var codes = ["F", "G", "L", "N"];
-
-      return this.any(this.conditions, function(condition) {
-        return codes.indexOf(condition.condition_code) > -1;
-      });
-    },
-    showRatio: function() {
-      var codes = ["R", "U"];
-
-      return this.any(this.conditions, function(condition) {
-        return codes.indexOf(condition.condition_code) > -1;
-      });
-    },
-    showEntryPrice: function() {
-      var codes = ["V"];
-
-      return this.any(this.conditions, function(condition) {
-        return codes.indexOf(condition.condition_code) > -1;
-      });
-    },
-    showAmount: function() {
-      var codes = ["E", "I", "M"];
-
-      return this.any(this.conditions, function(condition) {
-        return codes.indexOf(condition.condition_code) > -1;
-      });
-    },
     showCertificateType: function() {
-      var codes = ["B", "C", "E3", "I3", "H", "Q", "Z", "V", "E"];
+      var codes = ["B", "C", "E3", "I3", "H", "K", "P", "Q", "R", "Y", "Z"];
 
       return this.any(this.conditions, function(condition) {
         return codes.indexOf(condition.condition_code) > -1;
       });
     },
     showCertificate: function() {
-      var codes = ["A", "B", "C", "E3", "I3", "H", "Q", "Z", "V", "E"];
+      var codes = ["A", "B", "C", "E3", "I3", "H", "K", "P", "Q", "R", "Y", "Z"];
 
       return this.any(this.conditions, function(condition) {
         return codes.indexOf(condition.condition_code) > -1;

--- a/app/assets/javascripts/vue_components/conditions-coordinator.js
+++ b/app/assets/javascripts/vue_components/conditions-coordinator.js
@@ -1,7 +1,7 @@
 var template = [
   '<div>',
     '<div class="measure-condition" v-for="(measureCondition, index) in conditions">',
-      '<measure-condition :condition="measureCondition" :index="index" :hide-help="hideHelp" :room-referenced-value="showReferencedValue" :room-certificate-type="showCertificateType" :room-certificate="showCertificate" :room-monetary-unit="showMonetaryUnit" :room-measurement-unit="showMeasurementUnit">',
+      '<measure-condition :condition="measureCondition" :index="index" :hide-help="hideHelp" :room-referenced-value="showReferencedValue" :room-certificate-type="showCertificateType" :room-certificate="showCertificate" :room-monetary-unit="showMonetaryUnit" :room-measurement-unit="showMeasurementUnit" :show-conditions-duty-amount="showConditionsDutyAmount" :show-conditions-measurement-unit="showConditionsMeasurementUnit">',
         '<div class="col-md-2">',
           '<div class="form-group">',
             '<label for="" class="form-label" v-if="index == 0">&nbsp;<span class="form-hint-3-line">&nbsp;</span></label>',
@@ -99,6 +99,27 @@ Vue.component("conditions-coordinator", {
 
       return this.any(this.conditions, function(condition) {
         return codes.indexOf(condition.condition_code) > -1;
+      });
+    },
+    showConditionsDutyAmount: function() {
+      var ids = ["12", "14", "21", "25", "27", "29", "37", "99"];
+      var any = this.any;
+
+      return any(this.conditions, function(condition) {
+        return any(condition.measure_condition_components, function(component) {
+          return component.duty_expression_id && ids.indexOf(component.duty_expression_id) === -1;
+        });
+      });
+    },
+    showConditionsMeasurementUnit: function() {
+      var ids = ["12", "14", "21", "23", "25", "27", "29", "36", "37", "01A", "02A", "04A", "15A", "17A", "19A", "20A", "35A"];
+
+      var any = this.any;
+
+      return any(this.conditions, function(condition) {
+        return any(condition.measure_condition_components, function(component) {
+          return component.duty_expression_id && ids.indexOf(component.duty_expression_id) === -1;
+        });
       });
     }
   }

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -19,7 +19,8 @@ Vue.component('custom-select', {
     "codeClassName",
     "abbreviationClassName",
     "optionsFilter",
-    "disabled"
+    "disabled",
+    "compact"
   ],
   data: function() {
     return {
@@ -156,7 +157,7 @@ Vue.component('custom-select', {
             abbreviation = data.abbreviation + " - ";
           }
 
-          return "<div class='item'>" + data[codeField] + " - " + abbreviation + data[options.labelField] + "</div>";
+          return "<div class='item'>" + data[codeField] + (vm.compact !== true ? (" - " + abbreviation + data[options.labelField]) : "") + "</div>";
         }
       };
     }

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -20,7 +20,8 @@ Vue.component('custom-select', {
     "abbreviationClassName",
     "optionsFilter",
     "disabled",
-    "compact"
+    "compact",
+    "showCompactAbbreviation"
   ],
   data: function() {
     return {
@@ -46,6 +47,10 @@ Vue.component('custom-select', {
     if (this.onChange) {
       options.onChange = function(value) {
         var item = this.options[value];
+
+        if (item) {
+          item = clone(item);
+        }
 
         try {
           vm.onChange(item);
@@ -154,10 +159,18 @@ Vue.component('custom-select', {
           var abbreviation = "";
 
           if (abbreviationClassName && data.abbreviation) {
-            abbreviation = data.abbreviation + " - ";
+            abbreviation = data.abbreviation;
           }
 
-          return "<div class='item'>" + data[codeField] + (vm.compact !== true ? (" - " + abbreviation + data[options.labelField]) : "") + "</div>";
+          var complement = " - " + abbreviation + data[options.labelField] + " - ";
+
+          if (vm.compact === true && vm.showCompactAbbreviation === true) {
+            complement = " " + abbreviation;
+          } else if (vm.compact === true) {
+            complement = "";
+          }
+
+          return "<div class='item'>" + data[codeField] + complement + "</div>";
         }
       };
     }

--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -32,202 +32,7 @@ Vue.component('custom-select', {
   },
   template: "#selectize-template",
   mounted: function () {
-    var vm = this;
-
-    var options = {
-      create: false,
-      items: [this.value],
-      placeholder: this.placeholder,
-      valueField: this.valueField,
-      labelField: this.labelField,
-      allowClear: this.allowClear || false,
-      searchField: [this.valueField, this.codeField, "abbreviation", this.labelField]
-    };
-
-    if (this.onChange) {
-      options.onChange = function(value) {
-        var item = this.options[value];
-
-        if (item) {
-          item = clone(item);
-        }
-
-        try {
-          vm.onChange(item);
-        } catch (e) {
-        }
-      }
-    }
-
-    if (this.codeField) {
-      options.sortField = this.codeField;
-    }
-
-    if (this.options) {
-      try {
-        options["options"] = this.optionsFilter(this.options);
-      } catch (e) {
-        options["options"] = this.options;
-      }
-    }
-
-    if (this.url && (this.value || !this.minLength)) {
-      options["onInitialize"] = function() {
-        var self = this;
-        var fn = self.settings.load;
-        self.isInitialLoad = true;
-
-        self.load(function(callback) {
-          fn.apply(self, ["", callback]);
-        });
-      };
-
-      options.onLoad = function(data) {
-        if (vm.url && vm.value && !vm.firstLoadSelected) {
-          $(vm.$el).find("select")[0].selectize.setValue(vm.value);
-
-          vm.firstLoadSelected = true;
-        }
-      };
-    }
-
-    if (this.url) {
-      options["load"] = function(query, callback) {
-        var self = this;
-
-        var q = query.toString();
-
-        $(vm.$el).find("select")[0].selectize.clearOptions();
-        $(vm.$el).find("select")[0].selectize.clearCache();
-        $(vm.$el).find("select")[0].selectize.refreshOptions();
-        $(vm.$el).find("select")[0].selectize.renderCache['option'] = {};
-        $(vm.$el).find("select")[0].selectize.renderCache['item'] = {};
-
-        if (!vm.firstLoadSelected && vm.value && vm.minLength) {
-          q = vm.value;
-        }
-
-        if (!this.isInitialLoad && vm.minLength && q.length < vm.minLength) return callback();
-        if (vm.drilldownRequired === "true" && !vm.drilldownValue) return callback();
-
-        var data = {
-          q: q,
-          start_date: vm.start_date,
-          end_date: vm.end_date
-        };
-
-        if (vm.drilldownName && vm.drilldownValue) {
-          data[vm.drilldownName] = vm.drilldownValue;
-        }
-
-        $.ajax({
-          url: vm.url,
-          data: data,
-          type: 'GET',
-          error: function() {
-            callback();
-          },
-          success: function(res) {
-            try {
-              callback(vm.optionsFilter(res));
-            } catch (e) {
-              callback(res);
-            }
-
-            self.isInitialLoad = false;
-          }
-        });
-      }
-    }
-
-    var codeField = this.codeField;
-    var codeClassName = this.codeClassName || "";
-    var abbreviationClassName = this.abbreviationClassName || "";
-
-    if (codeField) {
-      options["render"] = {
-        option: function(data) {
-          var abbreviationSpan = "";
-
-          if (abbreviationClassName) {
-            abbreviationSpan = "<span class='abbreviation " + abbreviationClassName + "'>" + (data.abbreviation || "&nbsp;") + "</span>";
-          }
-
-          return "<span class='selection'><span class='option-prefix " + codeClassName + "'>" + data[codeField] + "</span>" + abbreviationSpan + "<span>" + data[options.labelField] + "</span></span>";
-        },
-        item: function(data) {
-          var abbreviation = "";
-
-          if (abbreviationClassName && data.abbreviation) {
-            abbreviation = data.abbreviation;
-          }
-
-          var complement = " - " + abbreviation + data[options.labelField] + " - ";
-
-          if (vm.compact === true && vm.showCompactAbbreviation === true) {
-            complement = " " + abbreviation;
-          } else if (vm.compact === true) {
-            complement = "";
-          }
-
-          return "<div class='item'>" + data[codeField] + complement + "</div>";
-        }
-      };
-    }
-
-    $(this.$el).find("select").selectize(options).val(this.value).trigger('change').on('change', function () {
-      vm.$emit('input', this.value);
-    });
-
-    if (this.disabled) {
-      $(this.$el).find("select")[0].selectize.disable();
-    }
-
-    this.handleDateSentitivity = function(event, start_date, end_date) {
-      vm.start_date = start_date;
-      vm.end_date = end_date;
-
-      var data = {
-        q: $(vm.$el).find("select")[0].selectize.query,
-        start_date: start_date,
-        end_date: end_date
-      };
-
-      if (vm.drilldownName && vm.drilldownValue) {
-        data[vm.drilldownName] = vm.drilldownValue;
-      }
-
-      $(vm.$el).find("select")[0].selectize.clear(true);
-      $(vm.$el).find("select")[0].selectize.clearOptions();
-      $(vm.$el).find("select")[0].selectize.clearCache();
-      $(vm.$el).find("select")[0].selectize.refreshOptions();
-      $(vm.$el).find("select")[0].selectize.renderCache['option'] = {};
-      $(vm.$el).find("select")[0].selectize.renderCache['item'] = {};
-
-      if (!vm.minLength || vm.value) {
-        $(vm.$el).find("select")[0].selectize.load(function(callback) {
-          $.ajax({
-            url: vm.url,
-            data: data,
-            type: 'GET',
-            error: function() {
-              callback();
-            },
-            success: function(res) {
-              try {
-                callback(vm.optionsFilter(res));
-              } catch (e) {
-                callback(res);
-              }
-            }
-          });
-        });
-      }
-    };
-
-    if (this.dateSensitive) {
-      $(".measure-form").on("dates:changed", this.handleDateSentitivity);
-    }
+    this.initializeSelect();
   },
   watch: {
     disabled: function(value) {
@@ -255,19 +60,228 @@ Vue.component('custom-select', {
       }
 
       this.handleDateSentitivity({}, this.start_date, this.end_date);
+    },
+    url: function(newVal, oldVal) {
+      var self = this;
+
+      Vue.nextTick(function() {
+        self.destroySelect();
+        self.initializeSelect();
+      });
     }
   },
   methods: {
     applyValueInSelect: function(value){
       $(this.$el).find("select")[0].selectize.setValue(value, false);
+    },
+    initializeSelect: function() {
+      var vm = this;
+
+      var options = {
+        create: false,
+        items: [this.value],
+        placeholder: this.placeholder,
+        valueField: this.valueField,
+        labelField: this.labelField,
+        allowClear: this.allowClear || false,
+        searchField: [this.valueField, this.codeField, "abbreviation", this.labelField]
+      };
+
+      if (this.onChange) {
+        options.onChange = function(value) {
+          var item = this.options[value];
+
+          if (item) {
+            item = clone(item);
+          }
+
+          try {
+            vm.onChange(item);
+          } catch (e) {
+          }
+        }
+      }
+
+      if (this.codeField) {
+        options.sortField = this.codeField;
+      }
+
+      if (this.options) {
+        try {
+          options["options"] = this.optionsFilter(this.options);
+        } catch (e) {
+          options["options"] = this.options;
+        }
+      }
+
+      if (this.url && (this.value || !this.minLength)) {
+        options["onInitialize"] = function() {
+          var self = this;
+          var fn = self.settings.load;
+          self.isInitialLoad = true;
+
+          self.load(function(callback) {
+            fn.apply(self, ["", callback]);
+          });
+        };
+
+        options.onLoad = function(data) {
+          if (vm.url && vm.value && !vm.firstLoadSelected) {
+            $(vm.$el).find("select")[0].selectize.setValue(vm.value);
+
+            vm.firstLoadSelected = true;
+          }
+        };
+      }
+
+      if (this.url) {
+        options["load"] = function(query, callback) {
+          var self = this;
+
+          var q = query.toString();
+
+          $(vm.$el).find("select")[0].selectize.clearOptions();
+          $(vm.$el).find("select")[0].selectize.clearCache();
+          $(vm.$el).find("select")[0].selectize.refreshOptions();
+          $(vm.$el).find("select")[0].selectize.renderCache['option'] = {};
+          $(vm.$el).find("select")[0].selectize.renderCache['item'] = {};
+
+          if (!vm.firstLoadSelected && vm.value && vm.minLength) {
+            q = vm.value;
+          }
+
+          if (!vm.isInitialLoad && vm.minLength && q.length < vm.minLength) return callback();
+          if (vm.drilldownRequired === "true" && !vm.drilldownValue) return callback();
+
+          var data = {
+            q: q,
+            start_date: vm.start_date,
+            end_date: vm.end_date
+          };
+
+          if (vm.drilldownName && vm.drilldownValue) {
+            data[vm.drilldownName] = vm.drilldownValue;
+          }
+
+          $.ajax({
+            url: vm.url,
+            data: data,
+            type: 'GET',
+            error: function() {
+              callback();
+            },
+            success: function(res) {
+              try {
+                callback(vm.optionsFilter(res));
+              } catch (e) {
+                callback(res);
+              }
+
+              vm.isInitialLoad = false;
+            }
+          });
+        }
+      }
+
+      var codeField = this.codeField;
+      var codeClassName = this.codeClassName || "";
+      var abbreviationClassName = this.abbreviationClassName || "";
+
+      if (codeField) {
+        options["render"] = {
+          option: function(data) {
+            var abbreviationSpan = "";
+
+            if (abbreviationClassName) {
+              abbreviationSpan = "<span class='abbreviation " + abbreviationClassName + "'>" + (data.abbreviation || "&nbsp;") + "</span>";
+            }
+
+            return "<span class='selection'><span class='option-prefix " + codeClassName + "'>" + data[codeField] + "</span>" + abbreviationSpan + "<span>" + data[options.labelField] + "</span></span>";
+          },
+          item: function(data) {
+            var abbreviation = "";
+
+            if (abbreviationClassName && data.abbreviation) {
+              abbreviation = data.abbreviation;
+            }
+
+            var complement = " - " + abbreviation + data[options.labelField] + " - ";
+
+            if (vm.compact === true && vm.showCompactAbbreviation === true) {
+              complement = " " + abbreviation;
+            } else if (vm.compact === true) {
+              complement = "";
+            }
+
+            return "<div class='item'>" + data[codeField] + complement + "</div>";
+          }
+        };
+      }
+
+      $(this.$el).find("select").selectize(options).val(this.value).trigger('change').on('change', function () {
+        vm.$emit('input', this.value);
+      });
+
+      if (this.disabled) {
+        $(this.$el).find("select")[0].selectize.disable();
+      }
+
+      this.handleDateSentitivity = function(event, start_date, end_date) {
+        vm.start_date = start_date;
+        vm.end_date = end_date;
+
+        var data = {
+          q: $(vm.$el).find("select")[0].selectize.query,
+          start_date: start_date,
+          end_date: end_date
+        };
+
+        if (vm.drilldownName && vm.drilldownValue) {
+          data[vm.drilldownName] = vm.drilldownValue;
+        }
+
+        $(vm.$el).find("select")[0].selectize.clear(true);
+        $(vm.$el).find("select")[0].selectize.clearOptions();
+        $(vm.$el).find("select")[0].selectize.clearCache();
+        $(vm.$el).find("select")[0].selectize.refreshOptions();
+        $(vm.$el).find("select")[0].selectize.renderCache['option'] = {};
+        $(vm.$el).find("select")[0].selectize.renderCache['item'] = {};
+
+        if (!vm.minLength || vm.value) {
+          $(vm.$el).find("select")[0].selectize.load(function(callback) {
+            $.ajax({
+              url: vm.url,
+              data: data,
+              type: 'GET',
+              error: function() {
+                callback();
+              },
+              success: function(res) {
+                try {
+                  callback(vm.optionsFilter(res));
+                } catch (e) {
+                  callback(res);
+                }
+              }
+            });
+          });
+        }
+      };
+
+      if (this.dateSensitive) {
+        $(".measure-form").on("dates:changed", this.handleDateSentitivity);
+      }
+    },
+    destroySelect: function() {
+      $(this.$el).find("select").off();
+      $(this.$el).find("select")[0].selectize.destroy();
+
+      if (this.dateSensitive) {
+        $(".measure-form").off("dates:changed", this.handleDateSentitivity);
+      }
     }
   },
   destroyed: function () {
-    $(this.$el).find("select").off();
-    $(this.$el).find("select")[0].selectize.destroy();
-
-    if (this.dateSensitive) {
-      $(".measure-form").off("dates:changed", this.handleDateSentitivity);
-    }
+    this.destroySelect();
   }
 });

--- a/app/assets/javascripts/vue_components/measure-components.js
+++ b/app/assets/javascripts/vue_components/measure-components.js
@@ -1,29 +1,12 @@
 //= require ../components/duty-expressions-parser
 
 var componentCommonFunctionality = {
-  computed: {
-    showMonetaryUnit: function() {
-      return false;
-    }
-  },
   methods: {
     expressionsFriendlyDuplicate: function(options) {
       return DutyExpressionsParser.parse(options);
     },
     onDutyExpressionSelected: function(item) {
       this[this.thing].duty_expression = item;
-
-      if (!this.showMonetaryUnit) {
-        this[this.thing].monetary_unit = null;
-        this[this.thing].monetary_unit_code = null;
-      }
-
-      if (!this.showMeasurementUnit) {
-        this[this.thing].measurement_unit_code = null;
-        this[this.thing].measurement_unit_qualifier_code = null;
-        this[this.thing].measurement_unit = null;
-        this[this.thing].measurement_unit_qualifier = null;
-      }
     },
     onMonetaryUnitSelected: function(item) {
       this[this.thing].monetary_unit = item;
@@ -34,6 +17,22 @@ var componentCommonFunctionality = {
     onMeasurementUnitQualifierSelected: function(item) {
       this[this.thing].measurement_unit_qualifier = item;
     }
+  },
+  watch: {
+    showMeasurementUnit: function(val) {
+      if (!val) {
+        this[this.thing].measurement_unit_code = undefined;
+        this[this.thing].measurement_unit_qualifier_code = undefined;
+        this[this.thing].measurement_unit = undefined;
+        this[this.thing].measurement_unit_qualifier = undefined;
+      }
+    },
+    showMonetaryUnit: function(val) {
+      if (!val) {
+        this[this.thing].monetary_unit = null;
+        this[this.thing].monetary_unit_code = null;
+      }
+    }
   }
 };
 
@@ -43,14 +42,7 @@ Vue.component("measure-component", $.extend({}, {
     "measureComponent",
     "index",
     "hideHelp",
-    "roomDutyAmountOrPercentage",
-    "roomDutyAmountPercentage",
-    "roomDutyAmountNegativePercentage",
-    "roomDutyAmountNumber",
-    "roomDutyAmountMinimum",
-    "roomDutyAmountMaximum",
-    "roomDutyAmountNegativeNumber",
-    "roomDutyRefundAmount",
+    "roomDutyAmount",
     "roomMonetaryUnit",
     "roomMeasurementUnit"
   ],
@@ -58,6 +50,20 @@ Vue.component("measure-component", $.extend({}, {
     return {
       thing: "measureComponent"
     };
+  },
+  computed: {
+    showMonetaryUnit: function() {
+      return false;
+    },
+    showDutyAmount: function() {
+      var ids = ["12", "14", "21", "25", "27", "29", "37", "99"];
+      return this.measureComponent.duty_expression_id && ids.indexOf(this.measureComponent.duty_expression_id) === -1;
+    },
+    showMeasurementUnit: function() {
+      var ids = ["12", "14", "21", "23", "25", "27", "29", "36", "37", "01A", "02A", "04A", "15A", "17A", "19A", "20A", "35A"];
+
+      return this.measureComponent.duty_expression_id && ids.indexOf(this.measureComponent.duty_expression_id) === -1;
+    }
   }
 }, componentCommonFunctionality));
 
@@ -67,14 +73,7 @@ Vue.component("measure-condition-component", $.extend({}, {
     "measureConditionComponent",
     "index",
     "hideHelp",
-    "roomDutyAmountOrPercentage",
-    "roomDutyAmountPercentage",
-    "roomDutyAmountNegativePercentage",
-    "roomDutyAmountNumber",
-    "roomDutyAmountMinimum",
-    "roomDutyAmountMaximum",
-    "roomDutyAmountNegativeNumber",
-    "roomDutyRefundAmount",
+    "roomDutyAmount",
     "roomMonetaryUnit",
     "roomMeasurementUnit"
   ],
@@ -84,8 +83,16 @@ Vue.component("measure-condition-component", $.extend({}, {
     };
   },
   computed: {
-    hideHelp: function() {
-      return this.index > 0;
+    showMonetaryUnit: function() {
+      return false;
+    },
+    showDutyAmount: function() {
+      var ids = ["12", "14", "21", "25", "27", "29", "37", "99"];
+      return this.measureConditionComponent.duty_expression_id && ids.indexOf(this.measureConditionComponent.duty_expression_id) === -1;
+    },
+    showMeasurementUnit: function() {
+      var ids = ["12", "14", "21", "23", "25", "27", "29", "36", "37", "01A", "02A", "04A", "15A", "17A", "19A", "20A", "35A"];
+      return this.measureConditionComponent.duty_expression_id && ids.indexOf(this.measureConditionComponent.duty_expression_id) === -1;
     }
   }
 }, componentCommonFunctionality));

--- a/app/assets/javascripts/vue_components/measure-components.js
+++ b/app/assets/javascripts/vue_components/measure-components.js
@@ -2,57 +2,8 @@
 
 var componentCommonFunctionality = {
   computed: {
-    showDutyAmountOrPercentage: function() {
-      var ids = ["01", "02", "04", "19", "20"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
-    showDutyAmountPercentage: function() {
-      var ids = ["23", "01A", "04A", "19A", "20A"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
-    showDutyAmountNegativePercentage: function() {
-      var ids = ["36", "02A"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
-    showDutyAmountNumber: function() {
-      var ids = ["01B", "04B", "19B", "20B", "06", "07", "09", "11", "12", "13", "14", "21", "25", "27", "29", "31"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
-    showDutyAmountMinimum: function() {
-      var ids = ["15"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
-    showDutyAmountMaximum: function() {
-      var ids = ["17", "35"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
-    showDutyAmountNegativeNumber: function() {
-      var ids = ["02B"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
-    showDutyRefundAmount: function() {
-      var ids = ["40", "41", "42", "43", "44"];
-
-      return ids.indexOf(this[this.thing].duty_expression_id) > -1;
-    },
     showMonetaryUnit: function() {
-      return this.showDutyAmountOrPercentage ||
-             this.showDutyAmountNumber ||
-             this.showDutyAmountMinimum ||
-             this.showDutyAmountMaximum ||
-             this.showDutyRefundAmount;
-    },
-    showMeasurementUnit: function() {
-      var ids = ["23", "36", "37", "01A", "04A", "19A", "20A", "02A"];
-
-      return this[this.thing].duty_expression_id && ids.indexOf(this[this.thing].duty_expression_id) === -1;
+      return false;
     }
   },
   methods: {

--- a/app/assets/javascripts/vue_components/measure-condition.js
+++ b/app/assets/javascripts/vue_components/measure-condition.js
@@ -1,3 +1,5 @@
+//= require ../components/conditions-parser
+
 Vue.component('measure-condition', {
   template: "#condition-template",
   props: [
@@ -10,8 +12,12 @@ Vue.component('measure-condition', {
     "roomRatio",
     "roomEntryPrice",
     "roomAmount",
+    "roomMonetaryUnit",
     "roomCertificateType",
-    "roomCertificate"
+    "roomCertificate",
+    "roomMaximumQuantity",
+    "roomMaximumPricePerUnit",
+    "roomMeasurementUnit"
   ],
   computed: {
     showAction: function() {
@@ -26,6 +32,16 @@ Vue.component('measure-condition', {
     },
     showMinimumPrice: function() {
       var codes = ["F", "G", "L", "N"];
+
+      return codes.indexOf(this.condition.condition_code) > -1;
+    },
+    showMaximumQuantity: function() {
+      var codes = ["E1", "I1"];
+
+      return codes.indexOf(this.condition.condition_code) > -1;
+    },
+    showMaximumPricePerUnit: function() {
+      var codes = ["E2", "I2"];
 
       return codes.indexOf(this.condition.condition_code) > -1;
     },
@@ -44,23 +60,13 @@ Vue.component('measure-condition', {
 
       return codes.indexOf(this.condition.condition_code) > -1;
     },
-    certificateActionHint: function() {
-      var codes = ["A", "B", "C", "E", "I", "H", "Q", "Z"];
-
-      return codes.indexOf(this.condition.condition_code) > -1;
-    },
-    noCertificateActionHint: function() {
-      var codes = ["D", "F", "G", "L", "M", "N", "R", "U", "V"];
-
-      return codes.indexOf(this.condition.condition_code) > -1;
-    },
     showCertificateType: function() {
-      var codes = ["B", "C", "E", "I", "H", "Q", "Z", "V", "E"];
+      var codes = ["B", "C", "E3", "I3", "H", "Q", "Z", "V"];
 
       return codes.indexOf(this.condition.condition_code) > -1;
     },
     showCertificate: function() {
-      var codes = ["A", "B", "C", "E", "I", "H", "Q", "Z", "V", "E"];
+      var codes = ["A", "B", "C", "E3", "I3", "H", "Q", "Z", "V"];
 
       return codes.indexOf(this.condition.condition_code) > -1;
     },
@@ -71,6 +77,16 @@ Vue.component('measure-condition', {
     },
     canRemoveComponent: function() {
       return this.condition.measure_condition_components.length > 1;
+    },
+    showMonetaryUnit: function() {
+      var codes = ["E2", "I2", "M1", "M2"];
+
+      return codes.indexOf(this.condition.condition_code) > -1;
+    },
+    showMeasurementUnit: function() {
+      var codes = ["E2", "I2", "M1", "M2"];
+
+      return codes.indexOf(this.condition.condition_code) > -1;
     }
   },
   watch: {
@@ -95,6 +111,9 @@ Vue.component('measure-condition', {
     }
   },
   methods: {
+    splitConditions: function(options) {
+      return ConditionsParser.parse(options);
+    },
     addMeasureConditionComponent: function() {
       this.condition.measure_condition_components.push({
         duty_expression_id: null,
@@ -127,5 +146,14 @@ Vue.component('measure-condition', {
     onActionSelected: function(obj) {
       this.condition.measure_action = obj;
     },
+    onMonetaryUnitSelected: function(obj) {
+      this.condition.monetary_unit = obj;
+    },
+    onMeasurementUnitSelected: function(item) {
+      this.condition.measurement_unit = item;
+    },
+    onMeasurementUnitQualifierSelected: function(item) {
+      this.condition.measurement_unit_qualifier = item;
+    }
   }
 });

--- a/app/assets/javascripts/vue_components/measure-condition.js
+++ b/app/assets/javascripts/vue_components/measure-condition.js
@@ -13,7 +13,9 @@ Vue.component('measure-condition', {
     "roomCertificate",
     "roomMaximumQuantity",
     "roomMaximumPricePerUnit",
-    "roomMeasurementUnit"
+    "roomMeasurementUnit",
+    "showConditionsDutyAmount",
+    "showConditionsMeasurementUnit"
   ],
   computed: {
     showConditionComponents: function() {

--- a/app/assets/javascripts/vue_components/measure-condition.js
+++ b/app/assets/javascripts/vue_components/measure-condition.js
@@ -30,33 +30,8 @@ Vue.component('measure-condition', {
 
       return codes.indexOf(this.condition.action_code) > -1;
     },
-    showMinimumPrice: function() {
-      var codes = ["F", "G", "L", "N"];
-
-      return codes.indexOf(this.condition.condition_code) > -1;
-    },
-    showMaximumQuantity: function() {
-      var codes = ["E1", "I1"];
-
-      return codes.indexOf(this.condition.condition_code) > -1;
-    },
-    showMaximumPricePerUnit: function() {
-      var codes = ["E2", "I2"];
-
-      return codes.indexOf(this.condition.condition_code) > -1;
-    },
-    showRatio: function() {
-      var codes = ["R", "U"];
-
-      return codes.indexOf(this.condition.condition_code) > -1;
-    },
-    showEntryPrice: function() {
-      var codes = ["V"];
-
-      return codes.indexOf(this.condition.condition_code) > -1;
-    },
-    showAmount: function() {
-      var codes = ["E", "I", "M"];
+    showReferencedValue: function() {
+      var codes = ["E1", "E2", "F", "G", "I1", "I2", "L", "M1", "M2", "N", "R", "S", "U", "V"];
 
       return codes.indexOf(this.condition.condition_code) > -1;
     },
@@ -84,7 +59,7 @@ Vue.component('measure-condition', {
       return codes.indexOf(this.condition.condition_code) > -1;
     },
     showMeasurementUnit: function() {
-      var codes = ["E2", "I2", "M1", "M2"];
+      var codes = ["E1", "E2", "F", "G", "I1", "I2", "L", "M1", "M2", "N", "S", "V"];
 
       return codes.indexOf(this.condition.condition_code) > -1;
     }

--- a/app/assets/javascripts/vue_components/measure-condition.js
+++ b/app/assets/javascripts/vue_components/measure-condition.js
@@ -6,12 +6,8 @@ Vue.component('measure-condition', {
     "condition",
     "hideHelp",
     "index",
-    "roomAction",
     "roomConditionComponents",
-    "roomMinimumPrice",
-    "roomRatio",
-    "roomEntryPrice",
-    "roomAmount",
+    "roomReferencedValue",
     "roomMonetaryUnit",
     "roomCertificateType",
     "roomCertificate",
@@ -20,11 +16,6 @@ Vue.component('measure-condition', {
     "roomMeasurementUnit"
   ],
   computed: {
-    showAction: function() {
-      var codes = ["K", "P", "S", "W", "Y"];
-
-      return this.condition.condition_code && codes.indexOf(this.condition.condition_code) === -1;
-    },
     showConditionComponents: function() {
       var codes = ["01", "02", "03", "11", "12", "13", "15", "27", "34", "36"];
 
@@ -36,12 +27,12 @@ Vue.component('measure-condition', {
       return codes.indexOf(this.condition.condition_code) > -1;
     },
     showCertificateType: function() {
-      var codes = ["B", "C", "E3", "I3", "H", "Q", "Z", "V"];
+      var codes = ["B", "C", "E3", "I3", "H", "K", "P", "Q", "R", "Y", "Z"];
 
       return codes.indexOf(this.condition.condition_code) > -1;
     },
     showCertificate: function() {
-      var codes = ["A", "B", "C", "E3", "I3", "H", "Q", "Z", "V"];
+      var codes = ["A", "B", "C", "E3", "I3", "H", "K", "P", "Q", "R", "Y", "Z"];
 
       return codes.indexOf(this.condition.condition_code) > -1;
     },

--- a/app/assets/javascripts/vue_components/opening-balances-manager.js
+++ b/app/assets/javascripts/vue_components/opening-balances-manager.js
@@ -6,10 +6,9 @@ Vue.component("opening-balances-manager", {
       return ["1", "1_repeating"].indexOf(this.section.period) > -1;
     },
     noPerPeriod: function() {
-      return (
-               this.single ||
-               ( !this.section.staged && !this.section.criticality_each_period && !this.section.duties_each_period )
-             );
+      return this.single && !this.section.staged &&
+             !this.section.criticality_each_period &&
+             !this.section.duties_each_period;
     },
     omitCriticality: function() {
       return window.all_settings.quota_is_licensed == "true";

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -114,6 +114,10 @@ label abbr {
       margin-top: 0;
     }
   }
+
+  .form-hint {
+    min-height: 3.95em;
+  }
 }
 
 .measure-component {

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -98,10 +98,6 @@ label abbr {
     padding-top: 0;
   }
 
-  &:last-of-type {
-    padding-bottom: 15px;
-  }
-
   &:first-of-type:last-of-type {
     padding-bottom: 0 !important;
   }

--- a/app/assets/stylesheets/components/measure-components.scss
+++ b/app/assets/stylesheets/components/measure-components.scss
@@ -1,6 +1,16 @@
 .measure-component {
+  border-bottom: 1px solid $border-colour;
+
   .form-group {
-    margin-bottom: 0;
+    margin-bottom: 0 !important;
+  }
+
+  & + & {
+    padding-top: 6px;
+  }
+
+  &:last-of-type {
+    margin-bottom: 3px;
   }
 
   .measure-form & {
@@ -10,6 +20,6 @@
   }
 
   .form-label {
-    font-size: 16px !important;
+    font-size: 14px !important;
   }
 }

--- a/app/assets/stylesheets/components/measure-components.scss
+++ b/app/assets/stylesheets/components/measure-components.scss
@@ -8,4 +8,8 @@
       justify-content: flex-start !important;
     }
   }
+
+  .form-label {
+    font-size: 16px !important;
+  }
 }

--- a/app/assets/stylesheets/components/measure-condition-component.scss
+++ b/app/assets/stylesheets/components/measure-condition-component.scss
@@ -4,7 +4,7 @@
 
 .measure-condition-component {
   & + .measure-condition-component {
-    margin-top: 10px;
+    margin-top: 6px;
   }
 
   .form-group {
@@ -12,7 +12,7 @@
   }
 
   &:last-child {
-    margin-bottom: 10px;
+    margin-bottom: 3px;
   }
 
   .form-label {

--- a/app/assets/stylesheets/components/measure-condition-component.scss
+++ b/app/assets/stylesheets/components/measure-condition-component.scss
@@ -14,10 +14,8 @@
   &:last-child {
     margin-bottom: 10px;
   }
-}
 
-
-.form-hint-3-line {
-  display: block;
-  height: 4.92em;
+  .form-label {
+    font-size: 16px !important;
+  }
 }

--- a/app/assets/stylesheets/components/measure-condition.scss
+++ b/app/assets/stylesheets/components/measure-condition.scss
@@ -8,9 +8,20 @@
 
   & + & {
     padding-top: 10px;
+    border-top: 1px solid $border-colour;
   }
 
   &:last-of-type {
     margin-bottom: 10px;
+  }
+
+  .measure-form & {
+    [class*="col-"] {
+      justify-content: flex-start !important;
+    }
+  }
+
+  .form-label {
+    font-size: 16px !important;
   }
 }

--- a/app/assets/stylesheets/components/measure-condition.scss
+++ b/app/assets/stylesheets/components/measure-condition.scss
@@ -1,18 +1,17 @@
 .condition,
 .measure-condition {
-  padding-bottom: 10px;
+  border-bottom: 1px solid $border-colour;
 
   .form-group {
     margin-bottom: 0 !important;
   }
 
   & + & {
-    padding-top: 10px;
-    border-top: 1px solid $border-colour;
+    padding-top: 6px;
   }
 
   &:last-of-type {
-    margin-bottom: 10px;
+    margin-bottom: 3px;
   }
 
   .measure-form & {
@@ -22,6 +21,6 @@
   }
 
   .form-label {
-    font-size: 16px !important;
+    font-size: 14px !important;
   }
 }

--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -130,9 +130,9 @@
 }
 
 .abbreviation--duty-expression {
-  flex-basis: 4.5em;
-  min-width: 4.5em;
-  width: 4.5em;
+  flex-basis: 2.1em;
+  min-width: 2.1em;
+  width: 2.1em;
 }
 
 .prefix--footnote-type{

--- a/app/assets/stylesheets/components/select.scss
+++ b/app/assets/stylesheets/components/select.scss
@@ -191,3 +191,7 @@
     vertical-align: top;
   }
 }
+
+.selectize-dropdown {
+  width: auto !important;
+}

--- a/app/assets/stylesheets/simple-grid.scss
+++ b/app/assets/stylesheets/simple-grid.scss
@@ -61,6 +61,10 @@ $gutter: 6px;
         max-width: $maxcol * $col;
       }
     }
+
+    .col-md-1-5 {
+      max-width: $maxcol * 1.2;
+    }
   }
 
   @media (min-width: 1024px) {

--- a/app/value_objects/workbasket_value_objects/attributes_parser_base.rb
+++ b/app/value_objects/workbasket_value_objects/attributes_parser_base.rb
@@ -76,9 +76,11 @@ module WorkbasketValueObjects
       if gn_codes.blank?
         gn_codes = [nil]
       end
+
       if a_codes.blank?
         a_codes = [nil]
       end
+
       # Return a list of GN codes and additional codes, allowing for empty arrays
       gn_codes.product(a_codes)
     end

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -8,7 +8,7 @@ script type="text/x-template" id="condition-template"
 
             span.form-hint v-if="hideHelp !== true"
               | This specifies a requirement the import must meet and determines the customs treatment of the goods concerned.
-          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select the condition to apply ―", "code-class-name" => "prefix--condition", ":on-change" => "onConditionCodeSelected", ":allow-clear" => "true" }
+          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select the condition to apply ―", "code-class-name" => "prefix--condition", ":on-change" => "onConditionCodeSelected", ":allow-clear" => "true", ":options-filter" => "splitConditions" }
 
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomMinimumPrice" do
         .form-group*{ "v-if" => "showMinimumPrice" }
@@ -46,6 +46,30 @@ script type="text/x-template" id="condition-template"
             label.form-label v-if="index == 0"
               | Entry Price (€)
             | &nbsp;
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomMaximumPricePerUnit" do
+        .form-group*{ "v-if" => "showMaximumPricePerUnit" }
+          label.form-label v-if="index == 0"
+            | Maximum price per unit (€)
+            span.form-hint v-if="hideHelp !== true"
+              | Specify the maximum price per unit at or below which this condition will apply.
+          input.form-control type="text" v-model="condition.amount"
+        div v-else=""
+          .form-group
+            label.form-label v-if="index == 0"
+              | Maximum price per unit (€)
+            | &nbsp;
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomMaximumQuantity" do
+        .form-group*{ "v-if" => "showMaximumQuantity" }
+          label.form-label v-if="index == 0"
+            | Maximum quantity
+            span.form-hint v-if="hideHelp !== true"
+              | Specify the maxium quantity at or below which this condition will apply.
+          input.form-control type="text" v-model="condition.amount"
+        div v-else=""
+          .form-group
+            label.form-label v-if="index == 0"
+              | Maximum quantity
+            | &nbsp;
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomAmount" do
         .form-group*{ "v-if" => "showAmount" }
           label.form-label v-if="index == 0"
@@ -55,6 +79,42 @@ script type="text/x-template" id="condition-template"
           .form-group
             label.form-label v-if="index == 0"
               | Amount
+            | &nbsp;
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomMonetaryUnit" do
+        .form-group*{ "v-if" => "showMonetaryUnit" }
+          label.form-label v-if="index == 0"
+            | Unit of measure
+            span.form-hint v-if="hideHelp !== true"
+              | &nbsp;
+          = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "condition.monetary_unit_code", "placeholder" => "― select unit of measure ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected" }
+        div v-else=""
+          .form-group
+            label.form-label v-if="index == 0"
+              | Unit of measure
+            | &nbsp;
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomMeasurementUnit" do
+        .form-group*{ "v-if" => "showMeasurementUnit" }
+          label.form-label v-if="index == 0"
+            | Measurement unit
+            span.form-hint v-if="hideHelp !== true"
+              | &nbsp;
+          = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "condition.measurement_unit_code", "placeholder" => "― select the measurement unit ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected" }
+        div v-else=""
+          .form-group
+            label.form-label v-if="index == 0"
+              | Measurement unit
+            | &nbsp;
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomMeasurementUnit" do
+        .form-group*{ "v-if" => "showMeasurementUnit" }
+          label.form-label v-if="index == 0"
+            | Qualifier
+            span.form-hint v-if="hideHelp !== true"
+              | &nbsp;
+          = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "condition.measurement_unit_qualifier_code", "placeholder" => "― select the measurement unit qualifier ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected" }
+        div v-else=""
+          .form-group
+            label.form-label v-if="index == 0"
+              | Qualifier
             | &nbsp;
       = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomCertificateType" do
         .form-group*{ "v-if" => "showCertificateType" }
@@ -84,10 +144,8 @@ script type="text/x-template" id="condition-template"
         .form-group*{ "v-if" => "showAction" }
           label.form-label v-if="index == 0"
             | Action
-            = content_tag :span, { class: "form-hint", "v-if" => "hideHelp !== true && certificateActionHint" } do
-              | Define the action to take when the specified certificate (or no certificate) is presented.
-            = content_tag :span, { class: "form-hint", "v-if" => "hideHelp !== true && noCertificateActionHint" } do
-              | Define the action to take if the condition is met.
+            = content_tag :span, { class: "form-hint", "v-if" => "hideHelp !== true" } do
+              | &nbsp;
           = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action", ":on-change" => "onActionSelected", ":allow-clear" => "true" }
         div v-else=""
           .form-group

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -39,7 +39,7 @@ script type="text/x-template" id="condition-template"
             label.form-label v-if="index == 0"
               | Qualifier
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomCertificateType" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-2", "v-if" => "roomCertificateType" do
         .form-group*{ "v-if" => "showCertificateType" }
           label.form-label v-if="index == 0"
             | Certificate type(s)
@@ -59,17 +59,12 @@ script type="text/x-template" id="condition-template"
             label.form-label v-if="index == 0"
               | Certificate
             | &nbsp;
-      = content_tag :div, { class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomAction" } do
-        .form-group*{ "v-if" => "showAction" }
+      = content_tag :div, { class: "col-xs-12 col-sm-6 col-md-1" } do
+        .form-group
           label.form-label v-if="index == 0"
             | Action
           = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action", ":on-change" => "onActionSelected", ":compact" => true }
-        div v-else=""
-          .form-group
-            label.form-label v-if="index == 0"
-              | Action
-            | &nbsp;
-      = content_tag :div, { class: "col-flow", "v-if" => "showConditionComponents" } do
+      = content_tag :div, { class: "col-flow" } do
         = content_tag "components-coordinator", nil, { ":components" => "condition.measure_condition_components", "type" => "measure_condition_component", "classes" => "measure-condition-component", ":hide-help" => "hideHelp !== true && index == 0", ":index" => "index", ":compact" => true }
 
       = content_tag :slot

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -63,6 +63,6 @@ script type="text/x-template" id="condition-template"
             | Action
           = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action", ":on-change" => "onActionSelected", ":compact" => true }
       = content_tag :div, { class: "col-md-6" } do
-        = content_tag "components-coordinator", nil, { ":components" => "condition.measure_condition_components", "type" => "measure_condition_component", "classes" => "measure-condition-component", ":hide-help" => "hideHelp !== true && index == 0", ":index" => "index", ":compact" => true }
+        = content_tag "components-coordinator", nil, { ":components" => "condition.measure_condition_components", "type" => "measure_condition_component", "classes" => "measure-condition-component", ":hide-help" => "hideHelp !== true && index == 0", ":index" => "index", ":compact" => true, ":show-conditions-duty-amount" => "showConditionsDutyAmount", ":show-conditions-measurement-unit" => "showConditionsMeasurementUnit" }
 
       = content_tag :slot

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -1,158 +1,75 @@
 script type="text/x-template" id="condition-template"
   div
-    .static-row
-      .col-xs-12.col-sm-6.col-md-4
+    .row
+      .col-xs-12.col-sm-6.col-md-1
         .form-group
           label.form-label v-if="index == 0"
             | Condition
+          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--condition", ":on-change" => "onConditionCodeSelected", ":options-filter" => "splitConditions", ":compact" => true }
 
-            span.form-hint v-if="hideHelp !== true"
-              | This specifies a requirement the import must meet and determines the customs treatment of the goods concerned.
-          = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select the condition to apply ―", "code-class-name" => "prefix--condition", ":on-change" => "onConditionCodeSelected", ":allow-clear" => "true", ":options-filter" => "splitConditions" }
-
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomMinimumPrice" do
-        .form-group*{ "v-if" => "showMinimumPrice" }
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomReferencedValue" do
+        .form-group*{ "v-if" => "showReferencedValue" }
           label.form-label v-if="index == 0"
-            | Minimum Price (€)
-            span.form-hint v-if="hideHelp !== true"
-              | Specify the price (in €) at or above which this condition will apply.
+            | Referenced value
           input.form-control type="text" v-model="condition.amount"
         div v-else=""
           .form-group
             label.form-label v-if="index == 0"
-              | Minimum Price (€)
+              | Referenced value
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomRatio" do
-        .form-group*{ "v-if" => "showRatio" }
-          label.form-label v-if="index == 0"
-            | Ratio
-            span.form-hint v-if="hideHelp !== true"
-              | Specify the ratio at or above which this condition will apply.
-          input.form-control type="text" v-model="condition.amount"
-        div v-else=""
-          .form-group
-            label.form-label v-if="index == 0"
-              | Ratio
-            | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomEntryPrice" do
-        .form-group*{ "v-if" => "showEntryPrice" }
-          label.form-label v-if="index == 0"
-            | Entry Price (€)
-            span.form-hint v-if="hideHelp !== true"
-              | Specify the price (in €) above which this condition will apply.
-          input.form-control type="text" v-model="condition.amount"
-        div v-else=""
-          .form-group
-            label.form-label v-if="index == 0"
-              | Entry Price (€)
-            | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomMaximumPricePerUnit" do
-        .form-group*{ "v-if" => "showMaximumPricePerUnit" }
-          label.form-label v-if="index == 0"
-            | Maximum price per unit (€)
-            span.form-hint v-if="hideHelp !== true"
-              | Specify the maximum price per unit at or below which this condition will apply.
-          input.form-control type="text" v-model="condition.amount"
-        div v-else=""
-          .form-group
-            label.form-label v-if="index == 0"
-              | Maximum price per unit (€)
-            | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomMaximumQuantity" do
-        .form-group*{ "v-if" => "showMaximumQuantity" }
-          label.form-label v-if="index == 0"
-            | Maximum quantity
-            span.form-hint v-if="hideHelp !== true"
-              | Specify the maxium quantity at or below which this condition will apply.
-          input.form-control type="text" v-model="condition.amount"
-        div v-else=""
-          .form-group
-            label.form-label v-if="index == 0"
-              | Maximum quantity
-            | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomAmount" do
-        .form-group*{ "v-if" => "showAmount" }
-          label.form-label v-if="index == 0"
-            | Amount
-          input.form-control type="text" v-model="condition.amount"
-        div v-else=""
-          .form-group
-            label.form-label v-if="index == 0"
-              | Amount
-            | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomMonetaryUnit" do
-        .form-group*{ "v-if" => "showMonetaryUnit" }
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomMeasurementUnit" do
+        .form-group*{ "v-if" => "showMeasurementUnit" }
           label.form-label v-if="index == 0"
             | Unit of measure
             span.form-hint v-if="hideHelp !== true"
               | &nbsp;
-          = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "condition.monetary_unit_code", "placeholder" => "― select unit of measure ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected" }
+          = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "condition.measurement_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":compact" => true }
         div v-else=""
           .form-group
             label.form-label v-if="index == 0"
               | Unit of measure
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomMeasurementUnit" do
-        .form-group*{ "v-if" => "showMeasurementUnit" }
-          label.form-label v-if="index == 0"
-            | Measurement unit
-            span.form-hint v-if="hideHelp !== true"
-              | &nbsp;
-          = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "condition.measurement_unit_code", "placeholder" => "― select the measurement unit ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected" }
-        div v-else=""
-          .form-group
-            label.form-label v-if="index == 0"
-              | Measurement unit
-            | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomMeasurementUnit" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomMeasurementUnit" do
         .form-group*{ "v-if" => "showMeasurementUnit" }
           label.form-label v-if="index == 0"
             | Qualifier
-            span.form-hint v-if="hideHelp !== true"
-              | &nbsp;
-          = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "condition.measurement_unit_qualifier_code", "placeholder" => "― select the measurement unit qualifier ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected" }
+          = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "condition.measurement_unit_qualifier_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":compact" => true }
         div v-else=""
           .form-group
             label.form-label v-if="index == 0"
               | Qualifier
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomCertificateType" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomCertificateType" do
         .form-group*{ "v-if" => "showCertificateType" }
           label.form-label v-if="index == 0"
-            | Certificate/license/document type
-            span.form-hint v-if="hideHelp !== true"
-              | Select the type of certificate that will be required, or select 'no certificate presented' to define the action for that case.
-          = content_tag "custom-select", "", { url: "/certificate_types", "v-model" => "condition.certificate_type_code", "codeField" => "certificate_type_code", "valueField" => "certificate_type_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate type ―", "code-class-name" => "prefix--certificate-type", ":on-change" => "onCertificateTypeSelected", ":allow-clear" => "true" }
+            | Certificate type(s)
+          = content_tag "custom-select", "", { url: "/certificate_types", "v-model" => "condition.certificate_type_code", "codeField" => "certificate_type_code", "valueField" => "certificate_type_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--certificate-type", ":on-change" => "onCertificateTypeSelected", ":compact" => true }
         div v-else=""
           .form-group
             label.form-label v-if="index == 0"
-              | Certificate/license/document type
+              | Certificate type(s)
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-4", "v-if" => "roomCertificate" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomCertificate" do
         .form-group*{ "v-if" => "showCertificate" }
           label.form-label v-if="index == 0"
-            | Certificate/license/document
-            span.form-hint v-if="hideHelp !== true"
-              | Select the type of certificate that will be required, or select 'no certificate presented' to define the action for that case.
-          = content_tag "custom-select", "", { url: "/certificates", "v-model" => "condition.certificate_code", "codeField" => "certificate_code", "valueField" => "certificate_code", "labelField" => "description", "date-sensitive" => true, placeholder: "― select certificate ―", "drilldown-name" => "certificate_type_code", ":drilldown-value" => "condition.certificate_type_code", ":drilldown-required" => "showCertificateType", "code-class-name" => "prefix--certificate", ":on-change" => "onCertificateSelected", ":allow-clear" => "true" }
+            | Certificate
+          = content_tag "custom-select", "", { url: "/certificates", "v-model" => "condition.certificate_code", "codeField" => "certificate_code", "valueField" => "certificate_code", "labelField" => "description", "date-sensitive" => true, "drilldown-name" => "certificate_type_code", ":drilldown-value" => "condition.certificate_type_code", ":drilldown-required" => "showCertificateType", "code-class-name" => "prefix--certificate", ":on-change" => "onCertificateSelected", ":compact" => true }
         div v-else=""
           .form-group
             label.form-label v-if="index == 0"
-              | Certificate/license/document
+              | Certificate
             | &nbsp;
-      = content_tag :div, { class: "col-xs-12 col-sm-6 col-md-3", "v-if" => "roomAction" } do
+      = content_tag :div, { class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomAction" } do
         .form-group*{ "v-if" => "showAction" }
           label.form-label v-if="index == 0"
             | Action
-            = content_tag :span, { class: "form-hint", "v-if" => "hideHelp !== true" } do
-              | &nbsp;
-          = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action", ":on-change" => "onActionSelected", ":allow-clear" => "true" }
+          = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action", ":on-change" => "onActionSelected", ":compact" => true }
         div v-else=""
           .form-group
             label.form-label v-if="index == 0"
               | Action
             | &nbsp;
       = content_tag :div, { class: "col-flow", "v-if" => "showConditionComponents" } do
-        = content_tag "components-coordinator", nil, { ":components" => "condition.measure_condition_components", "type" => "measure_condition_component", "classes" => "measure-condition-component", ":hide-help" => "hideHelp !== true && index == 0", ":index" => "index" }
+        = content_tag "components-coordinator", nil, { ":components" => "condition.measure_condition_components", "type" => "measure_condition_component", "classes" => "measure-condition-component", ":hide-help" => "hideHelp !== true && index == 0", ":index" => "index", ":compact" => true }
 
       = content_tag :slot

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -37,7 +37,7 @@ script type="text/x-template" id="condition-template"
             label.form-label v-if="index == 0"
               | Qualifier
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1-5", "v-if" => "roomCertificateType" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-2", "v-if" => "roomCertificateType" do
         .form-group*{ "v-if" => "showCertificateType" }
           label.form-label v-if="index == 0"
             | Certificate type(s)

--- a/app/views/shared/vue_templates/_condition.html.slim
+++ b/app/views/shared/vue_templates/_condition.html.slim
@@ -7,7 +7,7 @@ script type="text/x-template" id="condition-template"
             | Condition
           = content_tag "custom-select", "", { url: "/measure_condition_codes", "v-model" => "condition.condition_code", "codeField" => "condition_code", "valueField" => "condition_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--condition", ":on-change" => "onConditionCodeSelected", ":options-filter" => "splitConditions", ":compact" => true }
 
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomReferencedValue" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1-5", "v-if" => "roomReferencedValue" do
         .form-group*{ "v-if" => "showReferencedValue" }
           label.form-label v-if="index == 0"
             | Referenced value
@@ -17,12 +17,10 @@ script type="text/x-template" id="condition-template"
             label.form-label v-if="index == 0"
               | Referenced value
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1", "v-if" => "roomMeasurementUnit" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1-5", "v-if" => "roomMeasurementUnit" do
         .form-group*{ "v-if" => "showMeasurementUnit" }
           label.form-label v-if="index == 0"
             | Unit of measure
-            span.form-hint v-if="hideHelp !== true"
-              | &nbsp;
           = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "condition.measurement_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":compact" => true }
         div v-else=""
           .form-group
@@ -39,7 +37,7 @@ script type="text/x-template" id="condition-template"
             label.form-label v-if="index == 0"
               | Qualifier
             | &nbsp;
-      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-2", "v-if" => "roomCertificateType" do
+      = content_tag :div, class: "col-xs-12 col-sm-6 col-md-1-5", "v-if" => "roomCertificateType" do
         .form-group*{ "v-if" => "showCertificateType" }
           label.form-label v-if="index == 0"
             | Certificate type(s)
@@ -64,7 +62,7 @@ script type="text/x-template" id="condition-template"
           label.form-label v-if="index == 0"
             | Action
           = content_tag "custom-select", "", { url: "/measure_actions", "v-model" => "condition.action_code", "codeField" => "action_code", "valueField" => "action_code", "labelField" => "description", "date-sensitive" => true, "code-class-name" => "prefix--measure-action", ":on-change" => "onActionSelected", ":compact" => true }
-      = content_tag :div, { class: "col-flow" } do
+      = content_tag :div, { class: "col-md-6" } do
         = content_tag "components-coordinator", nil, { ":components" => "condition.measure_condition_components", "type" => "measure_condition_component", "classes" => "measure-condition-component", ":hide-help" => "hideHelp !== true && index == 0", ":index" => "index", ":compact" => true }
 
       = content_tag :slot

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -1,33 +1,45 @@
 script type="text/x-template" id="measure-component-template"
   .row
-    .col-md-2
+    .col-md-1-5
       .form-group
         label.form-label v-if="index === 0"
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected" }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected", ":compact" => true, ":showCompactAbbreviation" => true, placeholder: "―" }
 
-    .col-md-1
-      .form-group
+    .col-md-1 v-if="roomDutyAmount"
+      .form-group v-if="showDutyAmount"
         label.form-label v-if="index === 0"
           | Duty amount
         input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-    .col-md-2 v-if="roomMonetaryUnit"
+      .form-group v-else=""
+        label.form-label v-if="index === 0"
+          | Duty amount
+        | &nbsp;
+    .col-md-1-5 v-if="roomMonetaryUnit"
       .form-group v-if="showMonetaryUnit"
         label.form-label v-if="index === 0"
           | Monetary unit
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected" }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected", ":compact" => true, placeholder: "―" }
       .form-group v-else=""
         label.form-label v-if="index === 0"
           | Monetary unit
         | &nbsp;
-    .col-md-2
-      .form-group
+    .col-md-1-5 v-if="roomMeasurementUnit"
+      .form-group v-if="showMeasurementUnit"
         label.form-label v-if="index === 0"
           | Unit of measure
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", ":value.sync" => "measureComponent.measurement_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected" }
-    .col-md-1
-      .form-group
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureComponent.measurement_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":compact" => true, placeholder: "―" }
+      .form-group v-else=""
+        label.form-label v-if="index === 0"
+          | Unit of measure
+        | &nbsp;
+    .col-md-1 v-if="roomMeasurementUnit"
+      .form-group v-if="showMeasurementUnit"
         label.form-label v-if="index === 0"
           | Qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", ":value.sync" => "measureComponent.measurement_unit_qualifier_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected" }
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureComponent.measurement_unit_qualifier_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":compact" => true, placeholder: "―" }
+      .form-group v-else=""
+        label.form-label v-if="index === 0"
+          | Qualifier
+        | &nbsp;
     slot

--- a/app/views/shared/vue_templates/_measure_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_component.html.slim
@@ -1,99 +1,33 @@
 script type="text/x-template" id="measure-component-template"
   .row
-    .col-md-4
+    .col-md-2
       .form-group
         label.form-label v-if="index === 0"
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected" }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureComponent.duty_expression_id", "date-sensitive" => true, "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected" }
 
-    .col-md-3 v-if="roomDutyAmountOrPercentage"
-      .form-group v-if="showDutyAmountOrPercentage"
+    .col-md-1
+      .form-group
         label.form-label v-if="index === 0"
-          | Duty amount (% or €)
+          | Duty amount
         input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (% or €)
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountPercentage"
-      .form-group v-if="showDutyAmountPercentage"
-        label.form-label v-if="index === 0"
-          | Duty amount (%)
-        input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (%)
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountNegativePercentage"
-      .form-group v-if="showDutyAmountNegativePercentage"
-        label.form-label v-if="index === 0"
-          | Duty amount (-%)
-        input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (-%)
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountNumber"
-      .form-group v-if="showDutyAmountNumber"
-        label.form-label v-if="index === 0"
-          | Duty amount (€)
-        input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (€)
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountMinimum"
-      .form-group v-if="showDutyAmountMinimum"
-        label.form-label v-if="index === 0"
-          | Duty amount (at least €)
-        input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (at least €)
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountMaximum"
-      .form-group v-if="showDutyAmountMaximum"
-        label.form-label v-if="index === 0"
-          | Duty amount (not more than €)
-        input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (not more than €)
-        | &nbsp;
-    .col-md-3 v-if="roomDutyRefundAmount"
-      .form-group v-if="showDutyRefundAmount"
-        label.form-label v-if="index === 0"
-          | Refund amount (€)
-        input.form-control v-model="measureComponent.duty_amount" type="number" min="0" step="0.0001"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Refund amount (€)
-        | &nbsp;
-    .col-md-3 v-if="roomMonetaryUnit"
+    .col-md-2 v-if="roomMonetaryUnit"
       .form-group v-if="showMonetaryUnit"
         label.form-label v-if="index === 0"
           | Monetary unit
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected" }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureComponent.monetary_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected" }
       .form-group v-else=""
         label.form-label v-if="index === 0"
           | Monetary unit
         | &nbsp;
-    .col-md-3 v-if="roomMeasurementUnit"
-      .form-group v-if="showMeasurementUnit"
+    .col-md-2
+      .form-group
         label.form-label v-if="index === 0"
-          | Measurement unit
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureComponent.measurement_unit_code", "placeholder" => "― select the measurement unit ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected" }
-      .form-group v-else=""
+          | Unit of measure
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", ":value.sync" => "measureComponent.measurement_unit_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected" }
+    .col-md-1
+      .form-group
         label.form-label v-if="index === 0"
-          | Measurement unit
-        | &nbsp;
-    .col-md-3 v-if="roomMeasurementUnit"
-      .form-group v-if="showMeasurementUnit"
-        label.form-label v-if="index === 0"
-          | Measurement unit qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureComponent.measurement_unit_qualifier_code", "placeholder" => "― select the measurement unit qualifier ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected" }
-      .form-group v-else=""
-        label.form-label v-if="index === 0"
-          | Measurement unit qualifier
-        | &nbsp;
+          | Qualifier
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", ":value.sync" => "measureComponent.measurement_unit_qualifier_code", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected" }
     slot

--- a/app/views/shared/vue_templates/_measure_condition_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.slim
@@ -6,16 +6,12 @@ script type="text/x-template" id="measure-condition-component-template"
           | Duty expression
         = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected", ":allow-clear" => "true", ":compact" => true }
 
-    .col-md-3 v-if="roomDutyAmount"
-      .form-group v-if="showDutyAmount"
+    .col-md-1
+      .form-group
         label.form-label v-if="index == 0"
           | Duty amount
         input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount
-        | &nbsp;
-    .col-md-3 v-if="roomMonetaryUnit"
+    .col-md-2 v-if="roomMonetaryUnit"
       .form-group v-if="showMonetaryUnit"
         label.form-label v-if="index == 0"
           | Monetary unit
@@ -24,22 +20,15 @@ script type="text/x-template" id="measure-condition-component-template"
         label.form-label v-if="index == 0"
           | Monetary unit
         | &nbsp;
-    .col-md-3 v-if="roomMeasurementUnit"
-      .form-group v-if="showMeasurementUnit"
+    .col-md-2
+      .form-group
         label.form-label v-if="index == 0"
           | Unit of measure
         = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":allow-clear" => "true", ":compact" => true }
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Unit of measure
-        | &nbsp;
-    .col-md-3 v-if="roomMeasurementUnit"
-      .form-group v-if="showMeasurementUnit"
+    .col-md-1
+      .form-group
         label.form-label v-if="index == 0"
           | Qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":allow-clear" => "true", ":compact" => true }
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Qualifier
-        | &nbsp;
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", ":value.sync" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":allow-clear" => "true", ":compact" => true }
+
     = content_tag :slot, nil

--- a/app/views/shared/vue_templates/_measure_condition_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.slim
@@ -1,176 +1,45 @@
 script type="text/x-template" id="measure-condition-component-template"
   .static-row.row--flow.measure-condition-component
-    .col-md-4
+    .col-md-2
       .form-group
         label.form-label v-if="index == 0"
-          | Action amount
+          | Duty expression
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected", ":allow-clear" => "true", ":compact" => true }
 
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected", ":allow-clear" => "true" }
-
-    .col-md-3 v-if="roomDutyAmountOrPercentage"
-      .form-group v-if="showDutyAmountOrPercentage"
+    .col-md-3 v-if="roomDutyAmount"
+      .form-group v-if="showDutyAmount"
         label.form-label v-if="index == 0"
-          | Duty amount (% or €)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
+          | Duty amount
         input.form-control v-model="measureConditionComponent.duty_amount"
       .form-group v-else=""
         label.form-label v-if="index == 0"
-          | Duty amount (% or €)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountPercentage"
-      .form-group v-if="showDutyAmountPercentage"
-        label.form-label v-if="index == 0"
-          | Duty amount (%)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (%)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountNegativePercentage"
-      .form-group v-if="showDutyAmountNegativePercentage"
-        label.form-label v-if="index == 0"
-          | Duty amount (-%)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (-%)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountNumber"
-      .form-group v-if="showDutyAmountNumber"
-        label.form-label v-if="index == 0"
-          | Duty amount (€)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (€)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountNegativeNumber"
-      .form-group v-if="showDutyAmountNegativeNumber"
-        label.form-label v-if="index == 0"
-          | Duty amount (-€)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (-€)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountMinimum"
-      .form-group v-if="showDutyAmountMinimum"
-        label.form-label v-if="index == 0"
-          | Duty amount (at least €)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (at least €)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        | &nbsp;
-    .col-md-3 v-if="roomDutyAmountMaximum"
-      .form-group v-if="showDutyAmountMaximum"
-        label.form-label v-if="index == 0"
-          | Duty amount (not more than €)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Duty amount (not more than €)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-    .col-md-3 v-if="roomDutyRefundAmount"
-      .form-group v-if="showDutyRefundAmount"
-        label.form-label v-if="index == 0"
-          | Refund amount (€)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        input.form-control v-model="measureConditionComponent.duty_amount"
-      .form-group v-else=""
-        label.form-label v-if="index == 0"
-          | Refund amount (€)
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
+          | Duty amount
         | &nbsp;
     .col-md-3 v-if="roomMonetaryUnit"
       .form-group v-if="showMonetaryUnit"
         label.form-label v-if="index == 0"
           | Monetary unit
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected", ":allow-clear" => "true" }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected", ":allow-clear" => "true", ":compact" => true }
       .form-group v-else=""
         label.form-label v-if="index == 0"
           | Monetary unit
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
         | &nbsp;
     .col-md-3 v-if="roomMeasurementUnit"
       .form-group v-if="showMeasurementUnit"
         label.form-label v-if="index == 0"
-          | Measurement unit
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":allow-clear" => "true" }
+          | Unit of measure
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":allow-clear" => "true", ":compact" => true }
       .form-group v-else=""
         label.form-label v-if="index == 0"
-          | Measurement unit
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
+          | Unit of measure
         | &nbsp;
     .col-md-3 v-if="roomMeasurementUnit"
       .form-group v-if="showMeasurementUnit"
         label.form-label v-if="index == 0"
-          | Measurement unit qualifier
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":allow-clear" => "true" }
+          | Qualifier
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":allow-clear" => "true", ":compact" => true }
       .form-group v-else=""
         label.form-label v-if="index == 0"
-          | Measurement unit qualifier
-
-          span.form-hint-3-line v-if="hideHelp !== true"
-            | &nbsp;
+          | Qualifier
         | &nbsp;
     = content_tag :slot, nil

--- a/app/views/shared/vue_templates/_measure_condition_component.html.slim
+++ b/app/views/shared/vue_templates/_measure_condition_component.html.slim
@@ -1,34 +1,45 @@
 script type="text/x-template" id="measure-condition-component-template"
-  .static-row.row--flow.measure-condition-component
-    .col-md-2
+  .row.row--flow.measure-condition-component
+    .col-md-1-5
       .form-group
         label.form-label v-if="index == 0"
           | Duty expression
-        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "― select the duty expression to use ―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected", ":allow-clear" => "true", ":compact" => true }
+        = content_tag "custom-select", "", { url: "/duty_expressions", "label-field" => "description", "value-field" => "duty_expression_id", "code-field" => "duty_expression_code", "v-model" => "measureConditionComponent.duty_expression_id", "placeholder" => "―", "code-class-name" => "prefix--duty-expression", "abbreviation-class-name" => "abbreviation--duty-expression", ":options-filter" => "expressionsFriendlyDuplicate", ":on-change" => "onDutyExpressionSelected", ":compact" => true, ":showCompactAbbreviation" => true }
 
-    .col-md-1
-      .form-group
+    .col-md-1 v-if="roomDutyAmount"
+      .form-group v-if="showDutyAmount"
         label.form-label v-if="index == 0"
           | Duty amount
         input.form-control v-model="measureConditionComponent.duty_amount"
-    .col-md-2 v-if="roomMonetaryUnit"
+      .form-group v-else=""
+        label.form-label v-if="index == 0"
+          | Duty amount
+        | &nbsp;
+    .col-md-3 v-if="roomMonetaryUnit"
       .form-group v-if="showMonetaryUnit"
         label.form-label v-if="index == 0"
           | Monetary unit
-        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "― select the monetary unit or blank for EURO ―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected", ":allow-clear" => "true", ":compact" => true }
+        = content_tag "custom-select", "", { url: "/monetary_units", "label-field" => "description", "value-field" => "monetary_unit_code", "code-field" => "monetary_unit_code", "v-model" => "measureConditionComponent.monetary_unit_code", "placeholder" => "―", "date-sensitive" => true, "code-class-name" => "prefix--monetary-unit", ":on-change" => "onMonetaryUnitSelected", ":compact" => true }
       .form-group v-else=""
         label.form-label v-if="index == 0"
           | Monetary unit
         | &nbsp;
-    .col-md-2
-      .form-group
+    .col-md-1-5 v-if="roomMeasurementUnit"
+      .form-group v-if="showMeasurementUnit"
         label.form-label v-if="index == 0"
           | Unit of measure
-        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":allow-clear" => "true", ":compact" => true }
-    .col-md-1
-      .form-group
+        = content_tag "custom-select", "", { url: "/measurement_units", "label-field" => "description", "value-field" => "measurement_unit_code", "code-field" => "measurement_unit_code", "v-model" => "measureConditionComponent.measurement_unit_code", "placeholder" => "―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit", "abbreviation-class-name" => "abbreviation--measurement-unit", ":on-change" => "onMeasurementUnitSelected", ":compact" => true }
+      .form-group v-else=""
+        label.form-label v-if="index == 0"
+          | Unit of measure
+        | &nbsp;
+    .col-md-1 v-if="roomMeasurementUnit"
+      .form-group v-if="showMeasurementUnit"
         label.form-label v-if="index == 0"
           | Qualifier
-        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", ":value.sync" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "― select the duty expression to use ―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":allow-clear" => "true", ":compact" => true }
-
+        = content_tag "custom-select", "", { url: "/measurement_unit_qualifiers", "label-field" => "description", "value-field" => "measurement_unit_qualifier_code", "code-field" => "measurement_unit_qualifier_code", "v-model" => "measureConditionComponent.measurement_unit_qualifier_code", "placeholder" => "―", "date-sensitive" => true, "code-class-name" => "prefix--measurement-unit-qualifier", ":on-change" => "onMeasurementUnitQualifierSelected", ":compact" => true }
+      .form-group v-else=""
+        label.form-label v-if="index == 0"
+          | Qualifier
+        | &nbsp;
     = content_tag :slot, nil

--- a/app/views/workbaskets/create_quota/steps/main/_licensed_block.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_licensed_block.html.slim
@@ -9,7 +9,7 @@ fieldset
           input name="quota_is_licensed" type="hidden" v-model="measure.quota_is_licensed" value="1"
           input#toggle-type name="quota_is_licensed" type="checkbox" v-model="measure.quota_is_licensed" value="1"
           label for="toggle-type"
-            | Yes - use of this quota requires oresentation of a licence
+            | Yes - use of this quota requires presentation of a licence
 
   .form-group.js-workbasket-create-quota-licence-block v-if="measure.quota_is_licensed"
     label.form-label

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,15 +2,14 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.6.9
--- Dumped by pg_dump version 9.6.9
+-- Dumped from database version 9.6.1
+-- Dumped by pg_dump version 10.1
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
 SET idle_in_transaction_session_timeout = 0;
 SET client_encoding = 'UTF8';
 SET standard_conforming_strings = on;
-SELECT pg_catalog.set_config('search_path', '', false);
 SET check_function_bodies = false;
 SET client_min_messages = warning;
 SET row_security = off;
@@ -29,25 +28,13 @@ CREATE EXTENSION IF NOT EXISTS plpgsql WITH SCHEMA pg_catalog;
 COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
---
--- Name: uuid-ossp; Type: EXTENSION; Schema: -; Owner: -
---
-
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
-
-
---
--- Name: EXTENSION "uuid-ossp"; Type: COMMENT; Schema: -; Owner: -
---
-
-COMMENT ON EXTENSION "uuid-ossp" IS 'generate universally unique identifiers (UUIDs)';
-
+SET search_path = public, pg_catalog;
 
 --
 -- Name: reassign_owned(); Type: FUNCTION; Schema: public; Owner: -
 --
 
-CREATE FUNCTION public.reassign_owned() RETURNS event_trigger
+CREATE FUNCTION reassign_owned() RETURNS event_trigger
     LANGUAGE plpgsql
     AS $$
 	begin
@@ -58,7 +45,7 @@ CREATE FUNCTION public.reassign_owned() RETURNS event_trigger
 		END IF;
 
 		-- do not execute if not member of manager role
-		IF NOT pg_has_role(current_user, 'rdsbroker_7f53a659_8eed_49ba_b1cc_e36b227b84cd_manager', 'member') THEN
+		IF NOT pg_has_role(current_user, 'rdsbroker_266a9334_2e5d_4234_b2bf_5f5ebf7d973d_manager', 'member') THEN
 			RETURN;
 		END IF;
 
@@ -67,7 +54,7 @@ CREATE FUNCTION public.reassign_owned() RETURNS event_trigger
 			RETURN;
 		END IF;
 
-		EXECUTE 'reassign owned by "' || current_user || '" to "rdsbroker_7f53a659_8eed_49ba_b1cc_e36b227b84cd_manager"';
+		EXECUTE 'reassign owned by "' || current_user || '" to "rdsbroker_266a9334_2e5d_4234_b2bf_5f5ebf7d973d_manager"';
 	end
 	$$;
 
@@ -80,7 +67,7 @@ SET default_with_oids = false;
 -- Name: additional_code_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.additional_code_description_periods_oplog (
+CREATE TABLE additional_code_description_periods_oplog (
     additional_code_description_period_sid integer,
     additional_code_sid integer,
     additional_code_type_id character varying(1),
@@ -101,7 +88,7 @@ CREATE TABLE public.additional_code_description_periods_oplog (
 -- Name: additional_code_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.additional_code_description_periods AS
+CREATE VIEW additional_code_description_periods AS
  SELECT additional_code_description_periods1.additional_code_description_period_sid,
     additional_code_description_periods1.additional_code_sid,
     additional_code_description_periods1.additional_code_type_id,
@@ -114,9 +101,9 @@ CREATE VIEW public.additional_code_description_periods AS
     additional_code_description_periods1.status,
     additional_code_description_periods1.workbasket_id,
     additional_code_description_periods1.workbasket_sequence_number
-   FROM public.additional_code_description_periods_oplog additional_code_description_periods1
+   FROM additional_code_description_periods_oplog additional_code_description_periods1
   WHERE ((additional_code_description_periods1.oid IN ( SELECT max(additional_code_description_periods2.oid) AS max
-           FROM public.additional_code_description_periods_oplog additional_code_description_periods2
+           FROM additional_code_description_periods_oplog additional_code_description_periods2
           WHERE ((additional_code_description_periods1.additional_code_description_period_sid = additional_code_description_periods2.additional_code_description_period_sid) AND (additional_code_description_periods1.additional_code_sid = additional_code_description_periods2.additional_code_sid) AND ((additional_code_description_periods1.additional_code_type_id)::text = (additional_code_description_periods2.additional_code_type_id)::text)))) AND ((additional_code_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -124,7 +111,7 @@ CREATE VIEW public.additional_code_description_periods AS
 -- Name: additional_code_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.additional_code_description_periods_oid_seq
+CREATE SEQUENCE additional_code_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -136,14 +123,14 @@ CREATE SEQUENCE public.additional_code_description_periods_oid_seq
 -- Name: additional_code_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.additional_code_description_periods_oid_seq OWNED BY public.additional_code_description_periods_oplog.oid;
+ALTER SEQUENCE additional_code_description_periods_oid_seq OWNED BY additional_code_description_periods_oplog.oid;
 
 
 --
 -- Name: additional_code_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.additional_code_descriptions_oplog (
+CREATE TABLE additional_code_descriptions_oplog (
     additional_code_description_period_sid integer,
     language_id character varying(5),
     additional_code_sid integer,
@@ -165,7 +152,7 @@ CREATE TABLE public.additional_code_descriptions_oplog (
 -- Name: additional_code_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.additional_code_descriptions AS
+CREATE VIEW additional_code_descriptions AS
  SELECT additional_code_descriptions1.additional_code_description_period_sid,
     additional_code_descriptions1.language_id,
     additional_code_descriptions1.additional_code_sid,
@@ -179,9 +166,9 @@ CREATE VIEW public.additional_code_descriptions AS
     additional_code_descriptions1.status,
     additional_code_descriptions1.workbasket_id,
     additional_code_descriptions1.workbasket_sequence_number
-   FROM public.additional_code_descriptions_oplog additional_code_descriptions1
+   FROM additional_code_descriptions_oplog additional_code_descriptions1
   WHERE ((additional_code_descriptions1.oid IN ( SELECT max(additional_code_descriptions2.oid) AS max
-           FROM public.additional_code_descriptions_oplog additional_code_descriptions2
+           FROM additional_code_descriptions_oplog additional_code_descriptions2
           WHERE ((additional_code_descriptions1.additional_code_description_period_sid = additional_code_descriptions2.additional_code_description_period_sid) AND (additional_code_descriptions1.additional_code_sid = additional_code_descriptions2.additional_code_sid)))) AND ((additional_code_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -189,7 +176,7 @@ CREATE VIEW public.additional_code_descriptions AS
 -- Name: additional_code_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.additional_code_descriptions_oid_seq
+CREATE SEQUENCE additional_code_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -201,14 +188,14 @@ CREATE SEQUENCE public.additional_code_descriptions_oid_seq
 -- Name: additional_code_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.additional_code_descriptions_oid_seq OWNED BY public.additional_code_descriptions_oplog.oid;
+ALTER SEQUENCE additional_code_descriptions_oid_seq OWNED BY additional_code_descriptions_oplog.oid;
 
 
 --
 -- Name: additional_code_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.additional_code_type_descriptions_oplog (
+CREATE TABLE additional_code_type_descriptions_oplog (
     additional_code_type_id character varying(1),
     language_id character varying(5),
     description text,
@@ -227,7 +214,7 @@ CREATE TABLE public.additional_code_type_descriptions_oplog (
 -- Name: additional_code_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.additional_code_type_descriptions AS
+CREATE VIEW additional_code_type_descriptions AS
  SELECT additional_code_type_descriptions1.additional_code_type_id,
     additional_code_type_descriptions1.language_id,
     additional_code_type_descriptions1.description,
@@ -238,9 +225,9 @@ CREATE VIEW public.additional_code_type_descriptions AS
     additional_code_type_descriptions1.status,
     additional_code_type_descriptions1.workbasket_id,
     additional_code_type_descriptions1.workbasket_sequence_number
-   FROM public.additional_code_type_descriptions_oplog additional_code_type_descriptions1
+   FROM additional_code_type_descriptions_oplog additional_code_type_descriptions1
   WHERE ((additional_code_type_descriptions1.oid IN ( SELECT max(additional_code_type_descriptions2.oid) AS max
-           FROM public.additional_code_type_descriptions_oplog additional_code_type_descriptions2
+           FROM additional_code_type_descriptions_oplog additional_code_type_descriptions2
           WHERE ((additional_code_type_descriptions1.additional_code_type_id)::text = (additional_code_type_descriptions2.additional_code_type_id)::text))) AND ((additional_code_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -248,7 +235,7 @@ CREATE VIEW public.additional_code_type_descriptions AS
 -- Name: additional_code_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.additional_code_type_descriptions_oid_seq
+CREATE SEQUENCE additional_code_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -260,14 +247,14 @@ CREATE SEQUENCE public.additional_code_type_descriptions_oid_seq
 -- Name: additional_code_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.additional_code_type_descriptions_oid_seq OWNED BY public.additional_code_type_descriptions_oplog.oid;
+ALTER SEQUENCE additional_code_type_descriptions_oid_seq OWNED BY additional_code_type_descriptions_oplog.oid;
 
 
 --
 -- Name: additional_code_type_measure_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.additional_code_type_measure_types_oplog (
+CREATE TABLE additional_code_type_measure_types_oplog (
     measure_type_id character varying(3),
     additional_code_type_id character varying(1),
     validity_start_date timestamp without time zone,
@@ -287,7 +274,7 @@ CREATE TABLE public.additional_code_type_measure_types_oplog (
 -- Name: additional_code_type_measure_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.additional_code_type_measure_types AS
+CREATE VIEW additional_code_type_measure_types AS
  SELECT additional_code_type_measure_types1.measure_type_id,
     additional_code_type_measure_types1.additional_code_type_id,
     additional_code_type_measure_types1.validity_start_date,
@@ -299,9 +286,9 @@ CREATE VIEW public.additional_code_type_measure_types AS
     additional_code_type_measure_types1.status,
     additional_code_type_measure_types1.workbasket_id,
     additional_code_type_measure_types1.workbasket_sequence_number
-   FROM public.additional_code_type_measure_types_oplog additional_code_type_measure_types1
+   FROM additional_code_type_measure_types_oplog additional_code_type_measure_types1
   WHERE ((additional_code_type_measure_types1.oid IN ( SELECT max(additional_code_type_measure_types2.oid) AS max
-           FROM public.additional_code_type_measure_types_oplog additional_code_type_measure_types2
+           FROM additional_code_type_measure_types_oplog additional_code_type_measure_types2
           WHERE (((additional_code_type_measure_types1.measure_type_id)::text = (additional_code_type_measure_types2.measure_type_id)::text) AND ((additional_code_type_measure_types1.additional_code_type_id)::text = (additional_code_type_measure_types2.additional_code_type_id)::text)))) AND ((additional_code_type_measure_types1.operation)::text <> 'D'::text));
 
 
@@ -309,7 +296,7 @@ CREATE VIEW public.additional_code_type_measure_types AS
 -- Name: additional_code_type_measure_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.additional_code_type_measure_types_oid_seq
+CREATE SEQUENCE additional_code_type_measure_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -321,14 +308,14 @@ CREATE SEQUENCE public.additional_code_type_measure_types_oid_seq
 -- Name: additional_code_type_measure_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.additional_code_type_measure_types_oid_seq OWNED BY public.additional_code_type_measure_types_oplog.oid;
+ALTER SEQUENCE additional_code_type_measure_types_oid_seq OWNED BY additional_code_type_measure_types_oplog.oid;
 
 
 --
 -- Name: additional_code_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.additional_code_types_oplog (
+CREATE TABLE additional_code_types_oplog (
     additional_code_type_id character varying(1),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -349,7 +336,7 @@ CREATE TABLE public.additional_code_types_oplog (
 -- Name: additional_code_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.additional_code_types AS
+CREATE VIEW additional_code_types AS
  SELECT additional_code_types1.additional_code_type_id,
     additional_code_types1.validity_start_date,
     additional_code_types1.validity_end_date,
@@ -362,9 +349,9 @@ CREATE VIEW public.additional_code_types AS
     additional_code_types1.status,
     additional_code_types1.workbasket_id,
     additional_code_types1.workbasket_sequence_number
-   FROM public.additional_code_types_oplog additional_code_types1
+   FROM additional_code_types_oplog additional_code_types1
   WHERE ((additional_code_types1.oid IN ( SELECT max(additional_code_types2.oid) AS max
-           FROM public.additional_code_types_oplog additional_code_types2
+           FROM additional_code_types_oplog additional_code_types2
           WHERE ((additional_code_types1.additional_code_type_id)::text = (additional_code_types2.additional_code_type_id)::text))) AND ((additional_code_types1.operation)::text <> 'D'::text));
 
 
@@ -372,7 +359,7 @@ CREATE VIEW public.additional_code_types AS
 -- Name: additional_code_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.additional_code_types_oid_seq
+CREATE SEQUENCE additional_code_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -384,14 +371,14 @@ CREATE SEQUENCE public.additional_code_types_oid_seq
 -- Name: additional_code_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.additional_code_types_oid_seq OWNED BY public.additional_code_types_oplog.oid;
+ALTER SEQUENCE additional_code_types_oid_seq OWNED BY additional_code_types_oplog.oid;
 
 
 --
 -- Name: additional_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.additional_codes_oplog (
+CREATE TABLE additional_codes_oplog (
     additional_code_sid integer,
     additional_code_type_id character varying(1),
     additional_code character varying(3),
@@ -412,7 +399,7 @@ CREATE TABLE public.additional_codes_oplog (
 -- Name: additional_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.additional_codes AS
+CREATE VIEW additional_codes AS
  SELECT additional_codes1.additional_code_sid,
     additional_codes1.additional_code_type_id,
     additional_codes1.additional_code,
@@ -425,9 +412,9 @@ CREATE VIEW public.additional_codes AS
     additional_codes1.status,
     additional_codes1.workbasket_id,
     additional_codes1.workbasket_sequence_number
-   FROM public.additional_codes_oplog additional_codes1
+   FROM additional_codes_oplog additional_codes1
   WHERE ((additional_codes1.oid IN ( SELECT max(additional_codes2.oid) AS max
-           FROM public.additional_codes_oplog additional_codes2
+           FROM additional_codes_oplog additional_codes2
           WHERE (additional_codes1.additional_code_sid = additional_codes2.additional_code_sid))) AND ((additional_codes1.operation)::text <> 'D'::text));
 
 
@@ -435,7 +422,7 @@ CREATE VIEW public.additional_codes AS
 -- Name: additional_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.additional_codes_oid_seq
+CREATE SEQUENCE additional_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -447,14 +434,14 @@ CREATE SEQUENCE public.additional_codes_oid_seq
 -- Name: additional_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.additional_codes_oid_seq OWNED BY public.additional_codes_oplog.oid;
+ALTER SEQUENCE additional_codes_oid_seq OWNED BY additional_codes_oplog.oid;
 
 
 --
 -- Name: audits; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.audits (
+CREATE TABLE audits (
     id integer NOT NULL,
     auditable_id integer NOT NULL,
     auditable_type text NOT NULL,
@@ -469,7 +456,7 @@ CREATE TABLE public.audits (
 -- Name: audits_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.audits_id_seq
+CREATE SEQUENCE audits_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -481,14 +468,14 @@ CREATE SEQUENCE public.audits_id_seq
 -- Name: audits_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.audits_id_seq OWNED BY public.audits.id;
+ALTER SEQUENCE audits_id_seq OWNED BY audits.id;
 
 
 --
 -- Name: base_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.base_regulations_oplog (
+CREATE TABLE base_regulations_oplog (
     base_regulation_role integer,
     base_regulation_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -526,7 +513,7 @@ CREATE TABLE public.base_regulations_oplog (
 -- Name: base_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.base_regulations AS
+CREATE VIEW base_regulations AS
  SELECT base_regulations1.base_regulation_role,
     base_regulations1.base_regulation_id,
     base_regulations1.validity_start_date,
@@ -556,9 +543,9 @@ CREATE VIEW public.base_regulations AS
     base_regulations1.status,
     base_regulations1.workbasket_id,
     base_regulations1.workbasket_sequence_number
-   FROM public.base_regulations_oplog base_regulations1
+   FROM base_regulations_oplog base_regulations1
   WHERE ((base_regulations1.oid IN ( SELECT max(base_regulations2.oid) AS max
-           FROM public.base_regulations_oplog base_regulations2
+           FROM base_regulations_oplog base_regulations2
           WHERE (((base_regulations1.base_regulation_id)::text = (base_regulations2.base_regulation_id)::text) AND (base_regulations1.base_regulation_role = base_regulations2.base_regulation_role)))) AND ((base_regulations1.operation)::text <> 'D'::text));
 
 
@@ -566,7 +553,7 @@ CREATE VIEW public.base_regulations AS
 -- Name: base_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.base_regulations_oid_seq
+CREATE SEQUENCE base_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -578,14 +565,14 @@ CREATE SEQUENCE public.base_regulations_oid_seq
 -- Name: base_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.base_regulations_oid_seq OWNED BY public.base_regulations_oplog.oid;
+ALTER SEQUENCE base_regulations_oid_seq OWNED BY base_regulations_oplog.oid;
 
 
 --
 -- Name: certificate_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.certificate_description_periods_oplog (
+CREATE TABLE certificate_description_periods_oplog (
     certificate_description_period_sid integer,
     certificate_type_code character varying(1),
     certificate_code character varying(3),
@@ -606,7 +593,7 @@ CREATE TABLE public.certificate_description_periods_oplog (
 -- Name: certificate_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.certificate_description_periods AS
+CREATE VIEW certificate_description_periods AS
  SELECT certificate_description_periods1.certificate_description_period_sid,
     certificate_description_periods1.certificate_type_code,
     certificate_description_periods1.certificate_code,
@@ -619,9 +606,9 @@ CREATE VIEW public.certificate_description_periods AS
     certificate_description_periods1.status,
     certificate_description_periods1.workbasket_id,
     certificate_description_periods1.workbasket_sequence_number
-   FROM public.certificate_description_periods_oplog certificate_description_periods1
+   FROM certificate_description_periods_oplog certificate_description_periods1
   WHERE ((certificate_description_periods1.oid IN ( SELECT max(certificate_description_periods2.oid) AS max
-           FROM public.certificate_description_periods_oplog certificate_description_periods2
+           FROM certificate_description_periods_oplog certificate_description_periods2
           WHERE (certificate_description_periods1.certificate_description_period_sid = certificate_description_periods2.certificate_description_period_sid))) AND ((certificate_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -629,7 +616,7 @@ CREATE VIEW public.certificate_description_periods AS
 -- Name: certificate_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.certificate_description_periods_oid_seq
+CREATE SEQUENCE certificate_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -641,14 +628,14 @@ CREATE SEQUENCE public.certificate_description_periods_oid_seq
 -- Name: certificate_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.certificate_description_periods_oid_seq OWNED BY public.certificate_description_periods_oplog.oid;
+ALTER SEQUENCE certificate_description_periods_oid_seq OWNED BY certificate_description_periods_oplog.oid;
 
 
 --
 -- Name: certificate_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.certificate_descriptions_oplog (
+CREATE TABLE certificate_descriptions_oplog (
     certificate_description_period_sid integer,
     language_id character varying(5),
     certificate_type_code character varying(1),
@@ -669,7 +656,7 @@ CREATE TABLE public.certificate_descriptions_oplog (
 -- Name: certificate_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.certificate_descriptions AS
+CREATE VIEW certificate_descriptions AS
  SELECT certificate_descriptions1.certificate_description_period_sid,
     certificate_descriptions1.language_id,
     certificate_descriptions1.certificate_type_code,
@@ -682,9 +669,9 @@ CREATE VIEW public.certificate_descriptions AS
     certificate_descriptions1.status,
     certificate_descriptions1.workbasket_id,
     certificate_descriptions1.workbasket_sequence_number
-   FROM public.certificate_descriptions_oplog certificate_descriptions1
+   FROM certificate_descriptions_oplog certificate_descriptions1
   WHERE ((certificate_descriptions1.oid IN ( SELECT max(certificate_descriptions2.oid) AS max
-           FROM public.certificate_descriptions_oplog certificate_descriptions2
+           FROM certificate_descriptions_oplog certificate_descriptions2
           WHERE (certificate_descriptions1.certificate_description_period_sid = certificate_descriptions2.certificate_description_period_sid))) AND ((certificate_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -692,7 +679,7 @@ CREATE VIEW public.certificate_descriptions AS
 -- Name: certificate_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.certificate_descriptions_oid_seq
+CREATE SEQUENCE certificate_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -704,14 +691,14 @@ CREATE SEQUENCE public.certificate_descriptions_oid_seq
 -- Name: certificate_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.certificate_descriptions_oid_seq OWNED BY public.certificate_descriptions_oplog.oid;
+ALTER SEQUENCE certificate_descriptions_oid_seq OWNED BY certificate_descriptions_oplog.oid;
 
 
 --
 -- Name: certificate_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.certificate_type_descriptions_oplog (
+CREATE TABLE certificate_type_descriptions_oplog (
     certificate_type_code character varying(1),
     language_id character varying(5),
     description text,
@@ -730,7 +717,7 @@ CREATE TABLE public.certificate_type_descriptions_oplog (
 -- Name: certificate_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.certificate_type_descriptions AS
+CREATE VIEW certificate_type_descriptions AS
  SELECT certificate_type_descriptions1.certificate_type_code,
     certificate_type_descriptions1.language_id,
     certificate_type_descriptions1.description,
@@ -741,9 +728,9 @@ CREATE VIEW public.certificate_type_descriptions AS
     certificate_type_descriptions1.status,
     certificate_type_descriptions1.workbasket_id,
     certificate_type_descriptions1.workbasket_sequence_number
-   FROM public.certificate_type_descriptions_oplog certificate_type_descriptions1
+   FROM certificate_type_descriptions_oplog certificate_type_descriptions1
   WHERE ((certificate_type_descriptions1.oid IN ( SELECT max(certificate_type_descriptions2.oid) AS max
-           FROM public.certificate_type_descriptions_oplog certificate_type_descriptions2
+           FROM certificate_type_descriptions_oplog certificate_type_descriptions2
           WHERE ((certificate_type_descriptions1.certificate_type_code)::text = (certificate_type_descriptions2.certificate_type_code)::text))) AND ((certificate_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -751,7 +738,7 @@ CREATE VIEW public.certificate_type_descriptions AS
 -- Name: certificate_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.certificate_type_descriptions_oid_seq
+CREATE SEQUENCE certificate_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -763,14 +750,14 @@ CREATE SEQUENCE public.certificate_type_descriptions_oid_seq
 -- Name: certificate_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.certificate_type_descriptions_oid_seq OWNED BY public.certificate_type_descriptions_oplog.oid;
+ALTER SEQUENCE certificate_type_descriptions_oid_seq OWNED BY certificate_type_descriptions_oplog.oid;
 
 
 --
 -- Name: certificate_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.certificate_types_oplog (
+CREATE TABLE certificate_types_oplog (
     certificate_type_code character varying(1),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -789,7 +776,7 @@ CREATE TABLE public.certificate_types_oplog (
 -- Name: certificate_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.certificate_types AS
+CREATE VIEW certificate_types AS
  SELECT certificate_types1.certificate_type_code,
     certificate_types1.validity_start_date,
     certificate_types1.validity_end_date,
@@ -800,9 +787,9 @@ CREATE VIEW public.certificate_types AS
     certificate_types1.status,
     certificate_types1.workbasket_id,
     certificate_types1.workbasket_sequence_number
-   FROM public.certificate_types_oplog certificate_types1
+   FROM certificate_types_oplog certificate_types1
   WHERE ((certificate_types1.oid IN ( SELECT max(certificate_types2.oid) AS max
-           FROM public.certificate_types_oplog certificate_types2
+           FROM certificate_types_oplog certificate_types2
           WHERE ((certificate_types1.certificate_type_code)::text = (certificate_types2.certificate_type_code)::text))) AND ((certificate_types1.operation)::text <> 'D'::text));
 
 
@@ -810,7 +797,7 @@ CREATE VIEW public.certificate_types AS
 -- Name: certificate_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.certificate_types_oid_seq
+CREATE SEQUENCE certificate_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -822,14 +809,14 @@ CREATE SEQUENCE public.certificate_types_oid_seq
 -- Name: certificate_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.certificate_types_oid_seq OWNED BY public.certificate_types_oplog.oid;
+ALTER SEQUENCE certificate_types_oid_seq OWNED BY certificate_types_oplog.oid;
 
 
 --
 -- Name: certificates_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.certificates_oplog (
+CREATE TABLE certificates_oplog (
     certificate_type_code character varying(1),
     certificate_code character varying(3),
     validity_start_date timestamp without time zone,
@@ -850,7 +837,7 @@ CREATE TABLE public.certificates_oplog (
 -- Name: certificates; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.certificates AS
+CREATE VIEW certificates AS
  SELECT certificates1.certificate_type_code,
     certificates1.certificate_code,
     certificates1.validity_start_date,
@@ -863,9 +850,9 @@ CREATE VIEW public.certificates AS
     certificates1.status,
     certificates1.workbasket_id,
     certificates1.workbasket_sequence_number
-   FROM public.certificates_oplog certificates1
+   FROM certificates_oplog certificates1
   WHERE ((certificates1.oid IN ( SELECT max(certificates2.oid) AS max
-           FROM public.certificates_oplog certificates2
+           FROM certificates_oplog certificates2
           WHERE (((certificates1.certificate_code)::text = (certificates2.certificate_code)::text) AND ((certificates1.certificate_type_code)::text = (certificates2.certificate_type_code)::text)))) AND ((certificates1.operation)::text <> 'D'::text));
 
 
@@ -873,7 +860,7 @@ CREATE VIEW public.certificates AS
 -- Name: certificates_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.certificates_oid_seq
+CREATE SEQUENCE certificates_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -885,14 +872,14 @@ CREATE SEQUENCE public.certificates_oid_seq
 -- Name: certificates_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.certificates_oid_seq OWNED BY public.certificates_oplog.oid;
+ALTER SEQUENCE certificates_oid_seq OWNED BY certificates_oplog.oid;
 
 
 --
 -- Name: chapter_notes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chapter_notes (
+CREATE TABLE chapter_notes (
     id integer NOT NULL,
     section_id integer,
     chapter_id character varying(2),
@@ -904,7 +891,7 @@ CREATE TABLE public.chapter_notes (
 -- Name: chapter_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.chapter_notes_id_seq
+CREATE SEQUENCE chapter_notes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -916,14 +903,14 @@ CREATE SEQUENCE public.chapter_notes_id_seq
 -- Name: chapter_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.chapter_notes_id_seq OWNED BY public.chapter_notes.id;
+ALTER SEQUENCE chapter_notes_id_seq OWNED BY chapter_notes.id;
 
 
 --
 -- Name: chapters_sections; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chapters_sections (
+CREATE TABLE chapters_sections (
     goods_nomenclature_sid integer,
     section_id integer
 );
@@ -933,7 +920,7 @@ CREATE TABLE public.chapters_sections (
 -- Name: chief_comm; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_comm (
+CREATE TABLE chief_comm (
     fe_tsmp timestamp without time zone,
     amend_indicator character varying(1),
     cmdty_code character varying(12),
@@ -981,7 +968,7 @@ CREATE TABLE public.chief_comm (
 -- Name: chief_country_code; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_country_code (
+CREATE TABLE chief_country_code (
     chief_country_cd character varying(2),
     country_cd character varying(2)
 );
@@ -991,7 +978,7 @@ CREATE TABLE public.chief_country_code (
 -- Name: chief_country_group; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_country_group (
+CREATE TABLE chief_country_group (
     chief_country_grp character varying(4),
     country_grp_region character varying(4),
     country_exclusions character varying(100)
@@ -1002,7 +989,7 @@ CREATE TABLE public.chief_country_group (
 -- Name: chief_duty_expression; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_duty_expression (
+CREATE TABLE chief_duty_expression (
     id integer NOT NULL,
     adval1_rate boolean,
     adval2_rate boolean,
@@ -1023,7 +1010,7 @@ CREATE TABLE public.chief_duty_expression (
 -- Name: chief_duty_expression_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.chief_duty_expression_id_seq
+CREATE SEQUENCE chief_duty_expression_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1035,14 +1022,14 @@ CREATE SEQUENCE public.chief_duty_expression_id_seq
 -- Name: chief_duty_expression_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.chief_duty_expression_id_seq OWNED BY public.chief_duty_expression.id;
+ALTER SEQUENCE chief_duty_expression_id_seq OWNED BY chief_duty_expression.id;
 
 
 --
 -- Name: chief_measure_type_adco; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_measure_type_adco (
+CREATE TABLE chief_measure_type_adco (
     measure_group_code character varying(2),
     measure_type character varying(3),
     tax_type_code character varying(11),
@@ -1057,7 +1044,7 @@ CREATE TABLE public.chief_measure_type_adco (
 -- Name: chief_measure_type_cond; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_measure_type_cond (
+CREATE TABLE chief_measure_type_cond (
     measure_group_code character varying(2),
     measure_type character varying(3),
     cond_cd character varying(1),
@@ -1072,7 +1059,7 @@ CREATE TABLE public.chief_measure_type_cond (
 -- Name: chief_measure_type_footnote; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_measure_type_footnote (
+CREATE TABLE chief_measure_type_footnote (
     id integer NOT NULL,
     measure_type_id character varying(3),
     footn_type_id character varying(2),
@@ -1084,7 +1071,7 @@ CREATE TABLE public.chief_measure_type_footnote (
 -- Name: chief_measure_type_footnote_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.chief_measure_type_footnote_id_seq
+CREATE SEQUENCE chief_measure_type_footnote_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1096,14 +1083,14 @@ CREATE SEQUENCE public.chief_measure_type_footnote_id_seq
 -- Name: chief_measure_type_footnote_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.chief_measure_type_footnote_id_seq OWNED BY public.chief_measure_type_footnote.id;
+ALTER SEQUENCE chief_measure_type_footnote_id_seq OWNED BY chief_measure_type_footnote.id;
 
 
 --
 -- Name: chief_measurement_unit; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_measurement_unit (
+CREATE TABLE chief_measurement_unit (
     id integer NOT NULL,
     spfc_cmpd_uoq character varying(3),
     spfc_uoq character varying(3),
@@ -1116,7 +1103,7 @@ CREATE TABLE public.chief_measurement_unit (
 -- Name: chief_measurement_unit_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.chief_measurement_unit_id_seq
+CREATE SEQUENCE chief_measurement_unit_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1128,14 +1115,14 @@ CREATE SEQUENCE public.chief_measurement_unit_id_seq
 -- Name: chief_measurement_unit_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.chief_measurement_unit_id_seq OWNED BY public.chief_measurement_unit.id;
+ALTER SEQUENCE chief_measurement_unit_id_seq OWNED BY chief_measurement_unit.id;
 
 
 --
 -- Name: chief_mfcm; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_mfcm (
+CREATE TABLE chief_mfcm (
     fe_tsmp timestamp without time zone,
     msrgp_code character varying(5),
     msr_type character varying(5),
@@ -1157,7 +1144,7 @@ CREATE TABLE public.chief_mfcm (
 -- Name: chief_tame; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_tame (
+CREATE TABLE chief_tame (
     fe_tsmp timestamp without time zone,
     msrgp_code character varying(5),
     msr_type character varying(5),
@@ -1202,7 +1189,7 @@ CREATE TABLE public.chief_tame (
 -- Name: chief_tamf; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_tamf (
+CREATE TABLE chief_tamf (
     fe_tsmp timestamp without time zone,
     msrgp_code character varying(5),
     msr_type character varying(5),
@@ -1240,7 +1227,7 @@ CREATE TABLE public.chief_tamf (
 -- Name: chief_tbl9; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.chief_tbl9 (
+CREATE TABLE chief_tbl9 (
     fe_tsmp timestamp without time zone,
     amend_indicator character varying(1),
     tbl_type character varying(4),
@@ -1255,7 +1242,7 @@ CREATE TABLE public.chief_tbl9 (
 -- Name: complete_abrogation_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.complete_abrogation_regulations_oplog (
+CREATE TABLE complete_abrogation_regulations_oplog (
     complete_abrogation_regulation_role integer,
     complete_abrogation_regulation_id character varying(255),
     published_date date,
@@ -1281,7 +1268,7 @@ CREATE TABLE public.complete_abrogation_regulations_oplog (
 -- Name: complete_abrogation_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.complete_abrogation_regulations AS
+CREATE VIEW complete_abrogation_regulations AS
  SELECT complete_abrogation_regulations1.complete_abrogation_regulation_role,
     complete_abrogation_regulations1.complete_abrogation_regulation_id,
     complete_abrogation_regulations1.published_date,
@@ -1299,9 +1286,9 @@ CREATE VIEW public.complete_abrogation_regulations AS
     complete_abrogation_regulations1.status,
     complete_abrogation_regulations1.workbasket_id,
     complete_abrogation_regulations1.workbasket_sequence_number
-   FROM public.complete_abrogation_regulations_oplog complete_abrogation_regulations1
+   FROM complete_abrogation_regulations_oplog complete_abrogation_regulations1
   WHERE ((complete_abrogation_regulations1.oid IN ( SELECT max(complete_abrogation_regulations2.oid) AS max
-           FROM public.complete_abrogation_regulations_oplog complete_abrogation_regulations2
+           FROM complete_abrogation_regulations_oplog complete_abrogation_regulations2
           WHERE (((complete_abrogation_regulations1.complete_abrogation_regulation_id)::text = (complete_abrogation_regulations2.complete_abrogation_regulation_id)::text) AND (complete_abrogation_regulations1.complete_abrogation_regulation_role = complete_abrogation_regulations2.complete_abrogation_regulation_role)))) AND ((complete_abrogation_regulations1.operation)::text <> 'D'::text));
 
 
@@ -1309,7 +1296,7 @@ CREATE VIEW public.complete_abrogation_regulations AS
 -- Name: complete_abrogation_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.complete_abrogation_regulations_oid_seq
+CREATE SEQUENCE complete_abrogation_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1321,14 +1308,14 @@ CREATE SEQUENCE public.complete_abrogation_regulations_oid_seq
 -- Name: complete_abrogation_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.complete_abrogation_regulations_oid_seq OWNED BY public.complete_abrogation_regulations_oplog.oid;
+ALTER SEQUENCE complete_abrogation_regulations_oid_seq OWNED BY complete_abrogation_regulations_oplog.oid;
 
 
 --
 -- Name: create_measures_workbasket_settings; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.create_measures_workbasket_settings (
+CREATE TABLE create_measures_workbasket_settings (
     id integer NOT NULL,
     workbasket_id integer,
     main_step_settings_jsonb jsonb DEFAULT '{}'::jsonb,
@@ -1345,7 +1332,7 @@ CREATE TABLE public.create_measures_workbasket_settings (
 -- Name: create_measures_workbasket_settings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.create_measures_workbasket_settings_id_seq
+CREATE SEQUENCE create_measures_workbasket_settings_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1357,14 +1344,14 @@ CREATE SEQUENCE public.create_measures_workbasket_settings_id_seq
 -- Name: create_measures_workbasket_settings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.create_measures_workbasket_settings_id_seq OWNED BY public.create_measures_workbasket_settings.id;
+ALTER SEQUENCE create_measures_workbasket_settings_id_seq OWNED BY create_measures_workbasket_settings.id;
 
 
 --
 -- Name: create_quota_workbasket_settings; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.create_quota_workbasket_settings (
+CREATE TABLE create_quota_workbasket_settings (
     id integer NOT NULL,
     workbasket_id integer,
     settings_jsonb jsonb DEFAULT '{}'::jsonb,
@@ -1385,7 +1372,7 @@ CREATE TABLE public.create_quota_workbasket_settings (
 -- Name: create_quota_workbasket_settings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.create_quota_workbasket_settings_id_seq
+CREATE SEQUENCE create_quota_workbasket_settings_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1397,14 +1384,14 @@ CREATE SEQUENCE public.create_quota_workbasket_settings_id_seq
 -- Name: create_quota_workbasket_settings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.create_quota_workbasket_settings_id_seq OWNED BY public.create_quota_workbasket_settings.id;
+ALTER SEQUENCE create_quota_workbasket_settings_id_seq OWNED BY create_quota_workbasket_settings.id;
 
 
 --
 -- Name: data_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.data_migrations (
+CREATE TABLE data_migrations (
     filename text NOT NULL
 );
 
@@ -1413,7 +1400,7 @@ CREATE TABLE public.data_migrations (
 -- Name: db_rollbacks; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.db_rollbacks (
+CREATE TABLE db_rollbacks (
     id integer NOT NULL,
     state character varying(1),
     issue_date timestamp without time zone,
@@ -1427,7 +1414,7 @@ CREATE TABLE public.db_rollbacks (
 -- Name: db_rollbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.db_rollbacks_id_seq
+CREATE SEQUENCE db_rollbacks_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1439,14 +1426,14 @@ CREATE SEQUENCE public.db_rollbacks_id_seq
 -- Name: db_rollbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.db_rollbacks_id_seq OWNED BY public.db_rollbacks.id;
+ALTER SEQUENCE db_rollbacks_id_seq OWNED BY db_rollbacks.id;
 
 
 --
 -- Name: duty_expression_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.duty_expression_descriptions_oplog (
+CREATE TABLE duty_expression_descriptions_oplog (
     duty_expression_id character varying(255),
     language_id character varying(5),
     description text,
@@ -1464,7 +1451,7 @@ CREATE TABLE public.duty_expression_descriptions_oplog (
 -- Name: duty_expression_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.duty_expression_descriptions AS
+CREATE VIEW duty_expression_descriptions AS
  SELECT duty_expression_descriptions1.duty_expression_id,
     duty_expression_descriptions1.language_id,
     duty_expression_descriptions1.description,
@@ -1474,9 +1461,9 @@ CREATE VIEW public.duty_expression_descriptions AS
     duty_expression_descriptions1.status,
     duty_expression_descriptions1.workbasket_id,
     duty_expression_descriptions1.workbasket_sequence_number
-   FROM public.duty_expression_descriptions_oplog duty_expression_descriptions1
+   FROM duty_expression_descriptions_oplog duty_expression_descriptions1
   WHERE ((duty_expression_descriptions1.oid IN ( SELECT max(duty_expression_descriptions2.oid) AS max
-           FROM public.duty_expression_descriptions_oplog duty_expression_descriptions2
+           FROM duty_expression_descriptions_oplog duty_expression_descriptions2
           WHERE ((duty_expression_descriptions1.duty_expression_id)::text = (duty_expression_descriptions2.duty_expression_id)::text))) AND ((duty_expression_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -1484,7 +1471,7 @@ CREATE VIEW public.duty_expression_descriptions AS
 -- Name: duty_expression_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.duty_expression_descriptions_oid_seq
+CREATE SEQUENCE duty_expression_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1496,14 +1483,14 @@ CREATE SEQUENCE public.duty_expression_descriptions_oid_seq
 -- Name: duty_expression_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.duty_expression_descriptions_oid_seq OWNED BY public.duty_expression_descriptions_oplog.oid;
+ALTER SEQUENCE duty_expression_descriptions_oid_seq OWNED BY duty_expression_descriptions_oplog.oid;
 
 
 --
 -- Name: duty_expressions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.duty_expressions_oplog (
+CREATE TABLE duty_expressions_oplog (
     duty_expression_id character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -1524,7 +1511,7 @@ CREATE TABLE public.duty_expressions_oplog (
 -- Name: duty_expressions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.duty_expressions AS
+CREATE VIEW duty_expressions AS
  SELECT duty_expressions1.duty_expression_id,
     duty_expressions1.validity_start_date,
     duty_expressions1.validity_end_date,
@@ -1537,9 +1524,9 @@ CREATE VIEW public.duty_expressions AS
     duty_expressions1.status,
     duty_expressions1.workbasket_id,
     duty_expressions1.workbasket_sequence_number
-   FROM public.duty_expressions_oplog duty_expressions1
+   FROM duty_expressions_oplog duty_expressions1
   WHERE ((duty_expressions1.oid IN ( SELECT max(duty_expressions2.oid) AS max
-           FROM public.duty_expressions_oplog duty_expressions2
+           FROM duty_expressions_oplog duty_expressions2
           WHERE ((duty_expressions1.duty_expression_id)::text = (duty_expressions2.duty_expression_id)::text))) AND ((duty_expressions1.operation)::text <> 'D'::text));
 
 
@@ -1547,7 +1534,7 @@ CREATE VIEW public.duty_expressions AS
 -- Name: duty_expressions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.duty_expressions_oid_seq
+CREATE SEQUENCE duty_expressions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1559,14 +1546,14 @@ CREATE SEQUENCE public.duty_expressions_oid_seq
 -- Name: duty_expressions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.duty_expressions_oid_seq OWNED BY public.duty_expressions_oplog.oid;
+ALTER SEQUENCE duty_expressions_oid_seq OWNED BY duty_expressions_oplog.oid;
 
 
 --
 -- Name: explicit_abrogation_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.explicit_abrogation_regulations_oplog (
+CREATE TABLE explicit_abrogation_regulations_oplog (
     explicit_abrogation_regulation_role integer,
     explicit_abrogation_regulation_id character varying(8),
     published_date date,
@@ -1593,7 +1580,7 @@ CREATE TABLE public.explicit_abrogation_regulations_oplog (
 -- Name: explicit_abrogation_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.explicit_abrogation_regulations AS
+CREATE VIEW explicit_abrogation_regulations AS
  SELECT explicit_abrogation_regulations1.explicit_abrogation_regulation_role,
     explicit_abrogation_regulations1.explicit_abrogation_regulation_id,
     explicit_abrogation_regulations1.published_date,
@@ -1612,9 +1599,9 @@ CREATE VIEW public.explicit_abrogation_regulations AS
     explicit_abrogation_regulations1.status,
     explicit_abrogation_regulations1.workbasket_id,
     explicit_abrogation_regulations1.workbasket_sequence_number
-   FROM public.explicit_abrogation_regulations_oplog explicit_abrogation_regulations1
+   FROM explicit_abrogation_regulations_oplog explicit_abrogation_regulations1
   WHERE ((explicit_abrogation_regulations1.oid IN ( SELECT max(explicit_abrogation_regulations2.oid) AS max
-           FROM public.explicit_abrogation_regulations_oplog explicit_abrogation_regulations2
+           FROM explicit_abrogation_regulations_oplog explicit_abrogation_regulations2
           WHERE (((explicit_abrogation_regulations1.explicit_abrogation_regulation_id)::text = (explicit_abrogation_regulations2.explicit_abrogation_regulation_id)::text) AND (explicit_abrogation_regulations1.explicit_abrogation_regulation_role = explicit_abrogation_regulations2.explicit_abrogation_regulation_role)))) AND ((explicit_abrogation_regulations1.operation)::text <> 'D'::text));
 
 
@@ -1622,7 +1609,7 @@ CREATE VIEW public.explicit_abrogation_regulations AS
 -- Name: explicit_abrogation_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.explicit_abrogation_regulations_oid_seq
+CREATE SEQUENCE explicit_abrogation_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1634,14 +1621,14 @@ CREATE SEQUENCE public.explicit_abrogation_regulations_oid_seq
 -- Name: explicit_abrogation_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.explicit_abrogation_regulations_oid_seq OWNED BY public.explicit_abrogation_regulations_oplog.oid;
+ALTER SEQUENCE explicit_abrogation_regulations_oid_seq OWNED BY explicit_abrogation_regulations_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclature_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.export_refund_nomenclature_description_periods_oplog (
+CREATE TABLE export_refund_nomenclature_description_periods_oplog (
     export_refund_nomenclature_description_period_sid integer,
     export_refund_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -1664,7 +1651,7 @@ CREATE TABLE public.export_refund_nomenclature_description_periods_oplog (
 -- Name: export_refund_nomenclature_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.export_refund_nomenclature_description_periods AS
+CREATE VIEW export_refund_nomenclature_description_periods AS
  SELECT export_refund_nomenclature_description_periods1.export_refund_nomenclature_description_period_sid,
     export_refund_nomenclature_description_periods1.export_refund_nomenclature_sid,
     export_refund_nomenclature_description_periods1.validity_start_date,
@@ -1679,9 +1666,9 @@ CREATE VIEW public.export_refund_nomenclature_description_periods AS
     export_refund_nomenclature_description_periods1.status,
     export_refund_nomenclature_description_periods1.workbasket_id,
     export_refund_nomenclature_description_periods1.workbasket_sequence_number
-   FROM public.export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods1
+   FROM export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods1
   WHERE ((export_refund_nomenclature_description_periods1.oid IN ( SELECT max(export_refund_nomenclature_description_periods2.oid) AS max
-           FROM public.export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods2
+           FROM export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods2
           WHERE ((export_refund_nomenclature_description_periods1.export_refund_nomenclature_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_sid) AND (export_refund_nomenclature_description_periods1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_description_periods2.export_refund_nomenclature_description_period_sid)))) AND ((export_refund_nomenclature_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -1689,7 +1676,7 @@ CREATE VIEW public.export_refund_nomenclature_description_periods AS
 -- Name: export_refund_nomenclature_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.export_refund_nomenclature_description_periods_oid_seq
+CREATE SEQUENCE export_refund_nomenclature_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1701,14 +1688,14 @@ CREATE SEQUENCE public.export_refund_nomenclature_description_periods_oid_seq
 -- Name: export_refund_nomenclature_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.export_refund_nomenclature_description_periods_oid_seq OWNED BY public.export_refund_nomenclature_description_periods_oplog.oid;
+ALTER SEQUENCE export_refund_nomenclature_description_periods_oid_seq OWNED BY export_refund_nomenclature_description_periods_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclature_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.export_refund_nomenclature_descriptions_oplog (
+CREATE TABLE export_refund_nomenclature_descriptions_oplog (
     export_refund_nomenclature_description_period_sid integer,
     language_id character varying(5),
     export_refund_nomenclature_sid integer,
@@ -1731,7 +1718,7 @@ CREATE TABLE public.export_refund_nomenclature_descriptions_oplog (
 -- Name: export_refund_nomenclature_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.export_refund_nomenclature_descriptions AS
+CREATE VIEW export_refund_nomenclature_descriptions AS
  SELECT export_refund_nomenclature_descriptions1.export_refund_nomenclature_description_period_sid,
     export_refund_nomenclature_descriptions1.language_id,
     export_refund_nomenclature_descriptions1.export_refund_nomenclature_sid,
@@ -1746,9 +1733,9 @@ CREATE VIEW public.export_refund_nomenclature_descriptions AS
     export_refund_nomenclature_descriptions1.status,
     export_refund_nomenclature_descriptions1.workbasket_id,
     export_refund_nomenclature_descriptions1.workbasket_sequence_number
-   FROM public.export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions1
+   FROM export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions1
   WHERE ((export_refund_nomenclature_descriptions1.oid IN ( SELECT max(export_refund_nomenclature_descriptions2.oid) AS max
-           FROM public.export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions2
+           FROM export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions2
           WHERE (export_refund_nomenclature_descriptions1.export_refund_nomenclature_description_period_sid = export_refund_nomenclature_descriptions2.export_refund_nomenclature_description_period_sid))) AND ((export_refund_nomenclature_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -1756,7 +1743,7 @@ CREATE VIEW public.export_refund_nomenclature_descriptions AS
 -- Name: export_refund_nomenclature_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.export_refund_nomenclature_descriptions_oid_seq
+CREATE SEQUENCE export_refund_nomenclature_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1768,14 +1755,14 @@ CREATE SEQUENCE public.export_refund_nomenclature_descriptions_oid_seq
 -- Name: export_refund_nomenclature_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.export_refund_nomenclature_descriptions_oid_seq OWNED BY public.export_refund_nomenclature_descriptions_oplog.oid;
+ALTER SEQUENCE export_refund_nomenclature_descriptions_oid_seq OWNED BY export_refund_nomenclature_descriptions_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclature_indents_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.export_refund_nomenclature_indents_oplog (
+CREATE TABLE export_refund_nomenclature_indents_oplog (
     export_refund_nomenclature_indents_sid integer,
     export_refund_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -1799,7 +1786,7 @@ CREATE TABLE public.export_refund_nomenclature_indents_oplog (
 -- Name: export_refund_nomenclature_indents; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.export_refund_nomenclature_indents AS
+CREATE VIEW export_refund_nomenclature_indents AS
  SELECT export_refund_nomenclature_indents1.export_refund_nomenclature_indents_sid,
     export_refund_nomenclature_indents1.export_refund_nomenclature_sid,
     export_refund_nomenclature_indents1.validity_start_date,
@@ -1815,9 +1802,9 @@ CREATE VIEW public.export_refund_nomenclature_indents AS
     export_refund_nomenclature_indents1.status,
     export_refund_nomenclature_indents1.workbasket_id,
     export_refund_nomenclature_indents1.workbasket_sequence_number
-   FROM public.export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents1
+   FROM export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents1
   WHERE ((export_refund_nomenclature_indents1.oid IN ( SELECT max(export_refund_nomenclature_indents2.oid) AS max
-           FROM public.export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents2
+           FROM export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents2
           WHERE (export_refund_nomenclature_indents1.export_refund_nomenclature_indents_sid = export_refund_nomenclature_indents2.export_refund_nomenclature_indents_sid))) AND ((export_refund_nomenclature_indents1.operation)::text <> 'D'::text));
 
 
@@ -1825,7 +1812,7 @@ CREATE VIEW public.export_refund_nomenclature_indents AS
 -- Name: export_refund_nomenclature_indents_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.export_refund_nomenclature_indents_oid_seq
+CREATE SEQUENCE export_refund_nomenclature_indents_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1837,14 +1824,14 @@ CREATE SEQUENCE public.export_refund_nomenclature_indents_oid_seq
 -- Name: export_refund_nomenclature_indents_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.export_refund_nomenclature_indents_oid_seq OWNED BY public.export_refund_nomenclature_indents_oplog.oid;
+ALTER SEQUENCE export_refund_nomenclature_indents_oid_seq OWNED BY export_refund_nomenclature_indents_oplog.oid;
 
 
 --
 -- Name: export_refund_nomenclatures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.export_refund_nomenclatures_oplog (
+CREATE TABLE export_refund_nomenclatures_oplog (
     export_refund_nomenclature_sid integer,
     goods_nomenclature_item_id character varying(10),
     additional_code_type character varying(1),
@@ -1867,7 +1854,7 @@ CREATE TABLE public.export_refund_nomenclatures_oplog (
 -- Name: export_refund_nomenclatures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.export_refund_nomenclatures AS
+CREATE VIEW export_refund_nomenclatures AS
  SELECT export_refund_nomenclatures1.export_refund_nomenclature_sid,
     export_refund_nomenclatures1.goods_nomenclature_item_id,
     export_refund_nomenclatures1.additional_code_type,
@@ -1882,9 +1869,9 @@ CREATE VIEW public.export_refund_nomenclatures AS
     export_refund_nomenclatures1.status,
     export_refund_nomenclatures1.workbasket_id,
     export_refund_nomenclatures1.workbasket_sequence_number
-   FROM public.export_refund_nomenclatures_oplog export_refund_nomenclatures1
+   FROM export_refund_nomenclatures_oplog export_refund_nomenclatures1
   WHERE ((export_refund_nomenclatures1.oid IN ( SELECT max(export_refund_nomenclatures2.oid) AS max
-           FROM public.export_refund_nomenclatures_oplog export_refund_nomenclatures2
+           FROM export_refund_nomenclatures_oplog export_refund_nomenclatures2
           WHERE (export_refund_nomenclatures1.export_refund_nomenclature_sid = export_refund_nomenclatures2.export_refund_nomenclature_sid))) AND ((export_refund_nomenclatures1.operation)::text <> 'D'::text));
 
 
@@ -1892,7 +1879,7 @@ CREATE VIEW public.export_refund_nomenclatures AS
 -- Name: export_refund_nomenclatures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.export_refund_nomenclatures_oid_seq
+CREATE SEQUENCE export_refund_nomenclatures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1904,14 +1891,14 @@ CREATE SEQUENCE public.export_refund_nomenclatures_oid_seq
 -- Name: export_refund_nomenclatures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.export_refund_nomenclatures_oid_seq OWNED BY public.export_refund_nomenclatures_oplog.oid;
+ALTER SEQUENCE export_refund_nomenclatures_oid_seq OWNED BY export_refund_nomenclatures_oplog.oid;
 
 
 --
 -- Name: footnote_association_additional_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_association_additional_codes_oplog (
+CREATE TABLE footnote_association_additional_codes_oplog (
     additional_code_sid integer,
     footnote_type_id character varying(2),
     footnote_id character varying(5),
@@ -1933,7 +1920,7 @@ CREATE TABLE public.footnote_association_additional_codes_oplog (
 -- Name: footnote_association_additional_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_association_additional_codes AS
+CREATE VIEW footnote_association_additional_codes AS
  SELECT footnote_association_additional_codes1.additional_code_sid,
     footnote_association_additional_codes1.footnote_type_id,
     footnote_association_additional_codes1.footnote_id,
@@ -1947,9 +1934,9 @@ CREATE VIEW public.footnote_association_additional_codes AS
     footnote_association_additional_codes1.status,
     footnote_association_additional_codes1.workbasket_id,
     footnote_association_additional_codes1.workbasket_sequence_number
-   FROM public.footnote_association_additional_codes_oplog footnote_association_additional_codes1
+   FROM footnote_association_additional_codes_oplog footnote_association_additional_codes1
   WHERE ((footnote_association_additional_codes1.oid IN ( SELECT max(footnote_association_additional_codes2.oid) AS max
-           FROM public.footnote_association_additional_codes_oplog footnote_association_additional_codes2
+           FROM footnote_association_additional_codes_oplog footnote_association_additional_codes2
           WHERE (((footnote_association_additional_codes1.footnote_id)::text = (footnote_association_additional_codes2.footnote_id)::text) AND ((footnote_association_additional_codes1.footnote_type_id)::text = (footnote_association_additional_codes2.footnote_type_id)::text) AND (footnote_association_additional_codes1.additional_code_sid = footnote_association_additional_codes2.additional_code_sid)))) AND ((footnote_association_additional_codes1.operation)::text <> 'D'::text));
 
 
@@ -1957,7 +1944,7 @@ CREATE VIEW public.footnote_association_additional_codes AS
 -- Name: footnote_association_additional_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_association_additional_codes_oid_seq
+CREATE SEQUENCE footnote_association_additional_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -1969,14 +1956,14 @@ CREATE SEQUENCE public.footnote_association_additional_codes_oid_seq
 -- Name: footnote_association_additional_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_association_additional_codes_oid_seq OWNED BY public.footnote_association_additional_codes_oplog.oid;
+ALTER SEQUENCE footnote_association_additional_codes_oid_seq OWNED BY footnote_association_additional_codes_oplog.oid;
 
 
 --
 -- Name: footnote_association_erns_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_association_erns_oplog (
+CREATE TABLE footnote_association_erns_oplog (
     export_refund_nomenclature_sid integer,
     footnote_type character varying(2),
     footnote_id character varying(5),
@@ -2000,7 +1987,7 @@ CREATE TABLE public.footnote_association_erns_oplog (
 -- Name: footnote_association_erns; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_association_erns AS
+CREATE VIEW footnote_association_erns AS
  SELECT footnote_association_erns1.export_refund_nomenclature_sid,
     footnote_association_erns1.footnote_type,
     footnote_association_erns1.footnote_id,
@@ -2016,9 +2003,9 @@ CREATE VIEW public.footnote_association_erns AS
     footnote_association_erns1.status,
     footnote_association_erns1.workbasket_id,
     footnote_association_erns1.workbasket_sequence_number
-   FROM public.footnote_association_erns_oplog footnote_association_erns1
+   FROM footnote_association_erns_oplog footnote_association_erns1
   WHERE ((footnote_association_erns1.oid IN ( SELECT max(footnote_association_erns2.oid) AS max
-           FROM public.footnote_association_erns_oplog footnote_association_erns2
+           FROM footnote_association_erns_oplog footnote_association_erns2
           WHERE ((footnote_association_erns1.export_refund_nomenclature_sid = footnote_association_erns2.export_refund_nomenclature_sid) AND ((footnote_association_erns1.footnote_id)::text = (footnote_association_erns2.footnote_id)::text) AND ((footnote_association_erns1.footnote_type)::text = (footnote_association_erns2.footnote_type)::text) AND (footnote_association_erns1.validity_start_date = footnote_association_erns2.validity_start_date)))) AND ((footnote_association_erns1.operation)::text <> 'D'::text));
 
 
@@ -2026,7 +2013,7 @@ CREATE VIEW public.footnote_association_erns AS
 -- Name: footnote_association_erns_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_association_erns_oid_seq
+CREATE SEQUENCE footnote_association_erns_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2038,14 +2025,14 @@ CREATE SEQUENCE public.footnote_association_erns_oid_seq
 -- Name: footnote_association_erns_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_association_erns_oid_seq OWNED BY public.footnote_association_erns_oplog.oid;
+ALTER SEQUENCE footnote_association_erns_oid_seq OWNED BY footnote_association_erns_oplog.oid;
 
 
 --
 -- Name: footnote_association_goods_nomenclatures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_association_goods_nomenclatures_oplog (
+CREATE TABLE footnote_association_goods_nomenclatures_oplog (
     goods_nomenclature_sid integer,
     footnote_type character varying(2),
     footnote_id character varying(5),
@@ -2068,7 +2055,7 @@ CREATE TABLE public.footnote_association_goods_nomenclatures_oplog (
 -- Name: footnote_association_goods_nomenclatures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_association_goods_nomenclatures AS
+CREATE VIEW footnote_association_goods_nomenclatures AS
  SELECT footnote_association_goods_nomenclatures1.goods_nomenclature_sid,
     footnote_association_goods_nomenclatures1.footnote_type,
     footnote_association_goods_nomenclatures1.footnote_id,
@@ -2083,9 +2070,9 @@ CREATE VIEW public.footnote_association_goods_nomenclatures AS
     footnote_association_goods_nomenclatures1.status,
     footnote_association_goods_nomenclatures1.workbasket_id,
     footnote_association_goods_nomenclatures1.workbasket_sequence_number
-   FROM public.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures1
+   FROM footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures1
   WHERE ((footnote_association_goods_nomenclatures1.oid IN ( SELECT max(footnote_association_goods_nomenclatures2.oid) AS max
-           FROM public.footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures2
+           FROM footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures2
           WHERE (((footnote_association_goods_nomenclatures1.footnote_id)::text = (footnote_association_goods_nomenclatures2.footnote_id)::text) AND ((footnote_association_goods_nomenclatures1.footnote_type)::text = (footnote_association_goods_nomenclatures2.footnote_type)::text) AND (footnote_association_goods_nomenclatures1.goods_nomenclature_sid = footnote_association_goods_nomenclatures2.goods_nomenclature_sid)))) AND ((footnote_association_goods_nomenclatures1.operation)::text <> 'D'::text));
 
 
@@ -2093,7 +2080,7 @@ CREATE VIEW public.footnote_association_goods_nomenclatures AS
 -- Name: footnote_association_goods_nomenclatures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_association_goods_nomenclatures_oid_seq
+CREATE SEQUENCE footnote_association_goods_nomenclatures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2105,14 +2092,14 @@ CREATE SEQUENCE public.footnote_association_goods_nomenclatures_oid_seq
 -- Name: footnote_association_goods_nomenclatures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_association_goods_nomenclatures_oid_seq OWNED BY public.footnote_association_goods_nomenclatures_oplog.oid;
+ALTER SEQUENCE footnote_association_goods_nomenclatures_oid_seq OWNED BY footnote_association_goods_nomenclatures_oplog.oid;
 
 
 --
 -- Name: footnote_association_measures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_association_measures_oplog (
+CREATE TABLE footnote_association_measures_oplog (
     measure_sid integer,
     footnote_type_id character varying(2),
     footnote_id character varying(5),
@@ -2133,7 +2120,7 @@ CREATE TABLE public.footnote_association_measures_oplog (
 -- Name: footnote_association_measures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_association_measures AS
+CREATE VIEW footnote_association_measures AS
  SELECT footnote_association_measures1.measure_sid,
     footnote_association_measures1.footnote_type_id,
     footnote_association_measures1.footnote_id,
@@ -2146,9 +2133,9 @@ CREATE VIEW public.footnote_association_measures AS
     footnote_association_measures1.status,
     footnote_association_measures1.workbasket_id,
     footnote_association_measures1.workbasket_sequence_number
-   FROM public.footnote_association_measures_oplog footnote_association_measures1
+   FROM footnote_association_measures_oplog footnote_association_measures1
   WHERE ((footnote_association_measures1.oid IN ( SELECT max(footnote_association_measures2.oid) AS max
-           FROM public.footnote_association_measures_oplog footnote_association_measures2
+           FROM footnote_association_measures_oplog footnote_association_measures2
           WHERE ((footnote_association_measures1.measure_sid = footnote_association_measures2.measure_sid) AND ((footnote_association_measures1.footnote_id)::text = (footnote_association_measures2.footnote_id)::text) AND ((footnote_association_measures1.footnote_type_id)::text = (footnote_association_measures2.footnote_type_id)::text)))) AND ((footnote_association_measures1.operation)::text <> 'D'::text));
 
 
@@ -2156,7 +2143,7 @@ CREATE VIEW public.footnote_association_measures AS
 -- Name: footnote_association_measures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_association_measures_oid_seq
+CREATE SEQUENCE footnote_association_measures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2168,14 +2155,14 @@ CREATE SEQUENCE public.footnote_association_measures_oid_seq
 -- Name: footnote_association_measures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_association_measures_oid_seq OWNED BY public.footnote_association_measures_oplog.oid;
+ALTER SEQUENCE footnote_association_measures_oid_seq OWNED BY footnote_association_measures_oplog.oid;
 
 
 --
 -- Name: footnote_association_meursing_headings_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_association_meursing_headings_oplog (
+CREATE TABLE footnote_association_meursing_headings_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number character varying(255),
     row_column_code integer,
@@ -2197,7 +2184,7 @@ CREATE TABLE public.footnote_association_meursing_headings_oplog (
 -- Name: footnote_association_meursing_headings; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_association_meursing_headings AS
+CREATE VIEW footnote_association_meursing_headings AS
  SELECT footnote_association_meursing_headings1.meursing_table_plan_id,
     footnote_association_meursing_headings1.meursing_heading_number,
     footnote_association_meursing_headings1.row_column_code,
@@ -2211,9 +2198,9 @@ CREATE VIEW public.footnote_association_meursing_headings AS
     footnote_association_meursing_headings1.status,
     footnote_association_meursing_headings1.workbasket_id,
     footnote_association_meursing_headings1.workbasket_sequence_number
-   FROM public.footnote_association_meursing_headings_oplog footnote_association_meursing_headings1
+   FROM footnote_association_meursing_headings_oplog footnote_association_meursing_headings1
   WHERE ((footnote_association_meursing_headings1.oid IN ( SELECT max(footnote_association_meursing_headings2.oid) AS max
-           FROM public.footnote_association_meursing_headings_oplog footnote_association_meursing_headings2
+           FROM footnote_association_meursing_headings_oplog footnote_association_meursing_headings2
           WHERE (((footnote_association_meursing_headings1.footnote_id)::text = (footnote_association_meursing_headings2.footnote_id)::text) AND ((footnote_association_meursing_headings1.meursing_table_plan_id)::text = (footnote_association_meursing_headings2.meursing_table_plan_id)::text)))) AND ((footnote_association_meursing_headings1.operation)::text <> 'D'::text));
 
 
@@ -2221,7 +2208,7 @@ CREATE VIEW public.footnote_association_meursing_headings AS
 -- Name: footnote_association_meursing_headings_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_association_meursing_headings_oid_seq
+CREATE SEQUENCE footnote_association_meursing_headings_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2233,14 +2220,14 @@ CREATE SEQUENCE public.footnote_association_meursing_headings_oid_seq
 -- Name: footnote_association_meursing_headings_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_association_meursing_headings_oid_seq OWNED BY public.footnote_association_meursing_headings_oplog.oid;
+ALTER SEQUENCE footnote_association_meursing_headings_oid_seq OWNED BY footnote_association_meursing_headings_oplog.oid;
 
 
 --
 -- Name: footnote_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_description_periods_oplog (
+CREATE TABLE footnote_description_periods_oplog (
     footnote_description_period_sid integer,
     footnote_type_id character varying(2),
     footnote_id character varying(5),
@@ -2263,7 +2250,7 @@ CREATE TABLE public.footnote_description_periods_oplog (
 -- Name: footnote_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_description_periods AS
+CREATE VIEW footnote_description_periods AS
  SELECT footnote_description_periods1.footnote_description_period_sid,
     footnote_description_periods1.footnote_type_id,
     footnote_description_periods1.footnote_id,
@@ -2278,9 +2265,9 @@ CREATE VIEW public.footnote_description_periods AS
     footnote_description_periods1.status,
     footnote_description_periods1.workbasket_id,
     footnote_description_periods1.workbasket_sequence_number
-   FROM public.footnote_description_periods_oplog footnote_description_periods1
+   FROM footnote_description_periods_oplog footnote_description_periods1
   WHERE ((footnote_description_periods1.oid IN ( SELECT max(footnote_description_periods2.oid) AS max
-           FROM public.footnote_description_periods_oplog footnote_description_periods2
+           FROM footnote_description_periods_oplog footnote_description_periods2
           WHERE (((footnote_description_periods1.footnote_id)::text = (footnote_description_periods2.footnote_id)::text) AND ((footnote_description_periods1.footnote_type_id)::text = (footnote_description_periods2.footnote_type_id)::text) AND (footnote_description_periods1.footnote_description_period_sid = footnote_description_periods2.footnote_description_period_sid)))) AND ((footnote_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -2288,7 +2275,7 @@ CREATE VIEW public.footnote_description_periods AS
 -- Name: footnote_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_description_periods_oid_seq
+CREATE SEQUENCE footnote_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2300,14 +2287,14 @@ CREATE SEQUENCE public.footnote_description_periods_oid_seq
 -- Name: footnote_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_description_periods_oid_seq OWNED BY public.footnote_description_periods_oplog.oid;
+ALTER SEQUENCE footnote_description_periods_oid_seq OWNED BY footnote_description_periods_oplog.oid;
 
 
 --
 -- Name: footnote_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_descriptions_oplog (
+CREATE TABLE footnote_descriptions_oplog (
     footnote_description_period_sid integer,
     footnote_type_id character varying(2),
     footnote_id character varying(5),
@@ -2330,7 +2317,7 @@ CREATE TABLE public.footnote_descriptions_oplog (
 -- Name: footnote_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_descriptions AS
+CREATE VIEW footnote_descriptions AS
  SELECT footnote_descriptions1.footnote_description_period_sid,
     footnote_descriptions1.footnote_type_id,
     footnote_descriptions1.footnote_id,
@@ -2345,9 +2332,9 @@ CREATE VIEW public.footnote_descriptions AS
     footnote_descriptions1.status,
     footnote_descriptions1.workbasket_id,
     footnote_descriptions1.workbasket_sequence_number
-   FROM public.footnote_descriptions_oplog footnote_descriptions1
+   FROM footnote_descriptions_oplog footnote_descriptions1
   WHERE ((footnote_descriptions1.oid IN ( SELECT max(footnote_descriptions2.oid) AS max
-           FROM public.footnote_descriptions_oplog footnote_descriptions2
+           FROM footnote_descriptions_oplog footnote_descriptions2
           WHERE ((footnote_descriptions1.footnote_description_period_sid = footnote_descriptions2.footnote_description_period_sid) AND ((footnote_descriptions1.footnote_id)::text = (footnote_descriptions2.footnote_id)::text) AND ((footnote_descriptions1.footnote_type_id)::text = (footnote_descriptions2.footnote_type_id)::text)))) AND ((footnote_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2355,7 +2342,7 @@ CREATE VIEW public.footnote_descriptions AS
 -- Name: footnote_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_descriptions_oid_seq
+CREATE SEQUENCE footnote_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2367,14 +2354,14 @@ CREATE SEQUENCE public.footnote_descriptions_oid_seq
 -- Name: footnote_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_descriptions_oid_seq OWNED BY public.footnote_descriptions_oplog.oid;
+ALTER SEQUENCE footnote_descriptions_oid_seq OWNED BY footnote_descriptions_oplog.oid;
 
 
 --
 -- Name: footnote_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_type_descriptions_oplog (
+CREATE TABLE footnote_type_descriptions_oplog (
     footnote_type_id character varying(2),
     language_id character varying(5),
     description text,
@@ -2393,7 +2380,7 @@ CREATE TABLE public.footnote_type_descriptions_oplog (
 -- Name: footnote_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_type_descriptions AS
+CREATE VIEW footnote_type_descriptions AS
  SELECT footnote_type_descriptions1.footnote_type_id,
     footnote_type_descriptions1.language_id,
     footnote_type_descriptions1.description,
@@ -2404,9 +2391,9 @@ CREATE VIEW public.footnote_type_descriptions AS
     footnote_type_descriptions1.status,
     footnote_type_descriptions1.workbasket_id,
     footnote_type_descriptions1.workbasket_sequence_number
-   FROM public.footnote_type_descriptions_oplog footnote_type_descriptions1
+   FROM footnote_type_descriptions_oplog footnote_type_descriptions1
   WHERE ((footnote_type_descriptions1.oid IN ( SELECT max(footnote_type_descriptions2.oid) AS max
-           FROM public.footnote_type_descriptions_oplog footnote_type_descriptions2
+           FROM footnote_type_descriptions_oplog footnote_type_descriptions2
           WHERE ((footnote_type_descriptions1.footnote_type_id)::text = (footnote_type_descriptions2.footnote_type_id)::text))) AND ((footnote_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2414,7 +2401,7 @@ CREATE VIEW public.footnote_type_descriptions AS
 -- Name: footnote_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_type_descriptions_oid_seq
+CREATE SEQUENCE footnote_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2426,14 +2413,14 @@ CREATE SEQUENCE public.footnote_type_descriptions_oid_seq
 -- Name: footnote_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_type_descriptions_oid_seq OWNED BY public.footnote_type_descriptions_oplog.oid;
+ALTER SEQUENCE footnote_type_descriptions_oid_seq OWNED BY footnote_type_descriptions_oplog.oid;
 
 
 --
 -- Name: footnote_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnote_types_oplog (
+CREATE TABLE footnote_types_oplog (
     footnote_type_id character varying(2),
     application_code integer,
     validity_start_date timestamp without time zone,
@@ -2453,7 +2440,7 @@ CREATE TABLE public.footnote_types_oplog (
 -- Name: footnote_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnote_types AS
+CREATE VIEW footnote_types AS
  SELECT footnote_types1.footnote_type_id,
     footnote_types1.application_code,
     footnote_types1.validity_start_date,
@@ -2465,9 +2452,9 @@ CREATE VIEW public.footnote_types AS
     footnote_types1.status,
     footnote_types1.workbasket_id,
     footnote_types1.workbasket_sequence_number
-   FROM public.footnote_types_oplog footnote_types1
+   FROM footnote_types_oplog footnote_types1
   WHERE ((footnote_types1.oid IN ( SELECT max(footnote_types2.oid) AS max
-           FROM public.footnote_types_oplog footnote_types2
+           FROM footnote_types_oplog footnote_types2
           WHERE ((footnote_types1.footnote_type_id)::text = (footnote_types2.footnote_type_id)::text))) AND ((footnote_types1.operation)::text <> 'D'::text));
 
 
@@ -2475,7 +2462,7 @@ CREATE VIEW public.footnote_types AS
 -- Name: footnote_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnote_types_oid_seq
+CREATE SEQUENCE footnote_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2487,14 +2474,14 @@ CREATE SEQUENCE public.footnote_types_oid_seq
 -- Name: footnote_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnote_types_oid_seq OWNED BY public.footnote_types_oplog.oid;
+ALTER SEQUENCE footnote_types_oid_seq OWNED BY footnote_types_oplog.oid;
 
 
 --
 -- Name: footnotes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.footnotes_oplog (
+CREATE TABLE footnotes_oplog (
     footnote_id character varying(5),
     footnote_type_id character varying(2),
     validity_start_date timestamp without time zone,
@@ -2516,7 +2503,7 @@ CREATE TABLE public.footnotes_oplog (
 -- Name: footnotes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.footnotes AS
+CREATE VIEW footnotes AS
  SELECT footnotes1.footnote_id,
     footnotes1.footnote_type_id,
     footnotes1.validity_start_date,
@@ -2530,9 +2517,9 @@ CREATE VIEW public.footnotes AS
     footnotes1.status,
     footnotes1.workbasket_id,
     footnotes1.workbasket_sequence_number
-   FROM public.footnotes_oplog footnotes1
+   FROM footnotes_oplog footnotes1
   WHERE ((footnotes1.oid IN ( SELECT max(footnotes2.oid) AS max
-           FROM public.footnotes_oplog footnotes2
+           FROM footnotes_oplog footnotes2
           WHERE (((footnotes1.footnote_type_id)::text = (footnotes2.footnote_type_id)::text) AND ((footnotes1.footnote_id)::text = (footnotes2.footnote_id)::text)))) AND ((footnotes1.operation)::text <> 'D'::text));
 
 
@@ -2540,7 +2527,7 @@ CREATE VIEW public.footnotes AS
 -- Name: footnotes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.footnotes_oid_seq
+CREATE SEQUENCE footnotes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2552,14 +2539,14 @@ CREATE SEQUENCE public.footnotes_oid_seq
 -- Name: footnotes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.footnotes_oid_seq OWNED BY public.footnotes_oplog.oid;
+ALTER SEQUENCE footnotes_oid_seq OWNED BY footnotes_oplog.oid;
 
 
 --
 -- Name: fts_regulation_actions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.fts_regulation_actions_oplog (
+CREATE TABLE fts_regulation_actions_oplog (
     fts_regulation_role integer,
     fts_regulation_id character varying(8),
     stopped_regulation_role integer,
@@ -2578,7 +2565,7 @@ CREATE TABLE public.fts_regulation_actions_oplog (
 -- Name: fts_regulation_actions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.fts_regulation_actions AS
+CREATE VIEW fts_regulation_actions AS
  SELECT fts_regulation_actions1.fts_regulation_role,
     fts_regulation_actions1.fts_regulation_id,
     fts_regulation_actions1.stopped_regulation_role,
@@ -2589,9 +2576,9 @@ CREATE VIEW public.fts_regulation_actions AS
     fts_regulation_actions1.status,
     fts_regulation_actions1.workbasket_id,
     fts_regulation_actions1.workbasket_sequence_number
-   FROM public.fts_regulation_actions_oplog fts_regulation_actions1
+   FROM fts_regulation_actions_oplog fts_regulation_actions1
   WHERE ((fts_regulation_actions1.oid IN ( SELECT max(fts_regulation_actions2.oid) AS max
-           FROM public.fts_regulation_actions_oplog fts_regulation_actions2
+           FROM fts_regulation_actions_oplog fts_regulation_actions2
           WHERE (((fts_regulation_actions1.fts_regulation_id)::text = (fts_regulation_actions2.fts_regulation_id)::text) AND (fts_regulation_actions1.fts_regulation_role = fts_regulation_actions2.fts_regulation_role) AND ((fts_regulation_actions1.stopped_regulation_id)::text = (fts_regulation_actions2.stopped_regulation_id)::text) AND (fts_regulation_actions1.stopped_regulation_role = fts_regulation_actions2.stopped_regulation_role)))) AND ((fts_regulation_actions1.operation)::text <> 'D'::text));
 
 
@@ -2599,7 +2586,7 @@ CREATE VIEW public.fts_regulation_actions AS
 -- Name: fts_regulation_actions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.fts_regulation_actions_oid_seq
+CREATE SEQUENCE fts_regulation_actions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2611,14 +2598,14 @@ CREATE SEQUENCE public.fts_regulation_actions_oid_seq
 -- Name: fts_regulation_actions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.fts_regulation_actions_oid_seq OWNED BY public.fts_regulation_actions_oplog.oid;
+ALTER SEQUENCE fts_regulation_actions_oid_seq OWNED BY fts_regulation_actions_oplog.oid;
 
 
 --
 -- Name: full_temporary_stop_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.full_temporary_stop_regulations_oplog (
+CREATE TABLE full_temporary_stop_regulations_oplog (
     full_temporary_stop_regulation_role integer,
     full_temporary_stop_regulation_id character varying(8),
     published_date date,
@@ -2651,7 +2638,7 @@ CREATE TABLE public.full_temporary_stop_regulations_oplog (
 -- Name: full_temporary_stop_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.full_temporary_stop_regulations AS
+CREATE VIEW full_temporary_stop_regulations AS
  SELECT full_temporary_stop_regulations1.full_temporary_stop_regulation_role,
     full_temporary_stop_regulations1.full_temporary_stop_regulation_id,
     full_temporary_stop_regulations1.published_date,
@@ -2676,9 +2663,9 @@ CREATE VIEW public.full_temporary_stop_regulations AS
     full_temporary_stop_regulations1.workbasket_sequence_number,
     full_temporary_stop_regulations1.complete_abrogation_regulation_role,
     full_temporary_stop_regulations1.complete_abrogation_regulation_id
-   FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations1
+   FROM full_temporary_stop_regulations_oplog full_temporary_stop_regulations1
   WHERE ((full_temporary_stop_regulations1.oid IN ( SELECT max(full_temporary_stop_regulations2.oid) AS max
-           FROM public.full_temporary_stop_regulations_oplog full_temporary_stop_regulations2
+           FROM full_temporary_stop_regulations_oplog full_temporary_stop_regulations2
           WHERE (((full_temporary_stop_regulations1.full_temporary_stop_regulation_id)::text = (full_temporary_stop_regulations2.full_temporary_stop_regulation_id)::text) AND (full_temporary_stop_regulations1.full_temporary_stop_regulation_role = full_temporary_stop_regulations2.full_temporary_stop_regulation_role)))) AND ((full_temporary_stop_regulations1.operation)::text <> 'D'::text));
 
 
@@ -2686,7 +2673,7 @@ CREATE VIEW public.full_temporary_stop_regulations AS
 -- Name: full_temporary_stop_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.full_temporary_stop_regulations_oid_seq
+CREATE SEQUENCE full_temporary_stop_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2698,14 +2685,14 @@ CREATE SEQUENCE public.full_temporary_stop_regulations_oid_seq
 -- Name: full_temporary_stop_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.full_temporary_stop_regulations_oid_seq OWNED BY public.full_temporary_stop_regulations_oplog.oid;
+ALTER SEQUENCE full_temporary_stop_regulations_oid_seq OWNED BY full_temporary_stop_regulations_oplog.oid;
 
 
 --
 -- Name: geographical_area_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.geographical_area_description_periods_oplog (
+CREATE TABLE geographical_area_description_periods_oplog (
     geographical_area_description_period_sid integer,
     geographical_area_sid integer,
     validity_start_date timestamp without time zone,
@@ -2726,7 +2713,7 @@ CREATE TABLE public.geographical_area_description_periods_oplog (
 -- Name: geographical_area_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.geographical_area_description_periods AS
+CREATE VIEW geographical_area_description_periods AS
  SELECT geographical_area_description_periods1.geographical_area_description_period_sid,
     geographical_area_description_periods1.geographical_area_sid,
     geographical_area_description_periods1.validity_start_date,
@@ -2739,9 +2726,9 @@ CREATE VIEW public.geographical_area_description_periods AS
     geographical_area_description_periods1.status,
     geographical_area_description_periods1.workbasket_id,
     geographical_area_description_periods1.workbasket_sequence_number
-   FROM public.geographical_area_description_periods_oplog geographical_area_description_periods1
+   FROM geographical_area_description_periods_oplog geographical_area_description_periods1
   WHERE ((geographical_area_description_periods1.oid IN ( SELECT max(geographical_area_description_periods2.oid) AS max
-           FROM public.geographical_area_description_periods_oplog geographical_area_description_periods2
+           FROM geographical_area_description_periods_oplog geographical_area_description_periods2
           WHERE ((geographical_area_description_periods1.geographical_area_description_period_sid = geographical_area_description_periods2.geographical_area_description_period_sid) AND (geographical_area_description_periods1.geographical_area_sid = geographical_area_description_periods2.geographical_area_sid)))) AND ((geographical_area_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -2749,7 +2736,7 @@ CREATE VIEW public.geographical_area_description_periods AS
 -- Name: geographical_area_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.geographical_area_description_periods_oid_seq
+CREATE SEQUENCE geographical_area_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2761,14 +2748,14 @@ CREATE SEQUENCE public.geographical_area_description_periods_oid_seq
 -- Name: geographical_area_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.geographical_area_description_periods_oid_seq OWNED BY public.geographical_area_description_periods_oplog.oid;
+ALTER SEQUENCE geographical_area_description_periods_oid_seq OWNED BY geographical_area_description_periods_oplog.oid;
 
 
 --
 -- Name: geographical_area_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.geographical_area_descriptions_oplog (
+CREATE TABLE geographical_area_descriptions_oplog (
     geographical_area_description_period_sid integer,
     language_id character varying(5),
     geographical_area_sid integer,
@@ -2789,7 +2776,7 @@ CREATE TABLE public.geographical_area_descriptions_oplog (
 -- Name: geographical_area_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.geographical_area_descriptions AS
+CREATE VIEW geographical_area_descriptions AS
  SELECT geographical_area_descriptions1.geographical_area_description_period_sid,
     geographical_area_descriptions1.language_id,
     geographical_area_descriptions1.geographical_area_sid,
@@ -2802,9 +2789,9 @@ CREATE VIEW public.geographical_area_descriptions AS
     geographical_area_descriptions1.status,
     geographical_area_descriptions1.workbasket_id,
     geographical_area_descriptions1.workbasket_sequence_number
-   FROM public.geographical_area_descriptions_oplog geographical_area_descriptions1
+   FROM geographical_area_descriptions_oplog geographical_area_descriptions1
   WHERE ((geographical_area_descriptions1.oid IN ( SELECT max(geographical_area_descriptions2.oid) AS max
-           FROM public.geographical_area_descriptions_oplog geographical_area_descriptions2
+           FROM geographical_area_descriptions_oplog geographical_area_descriptions2
           WHERE ((geographical_area_descriptions1.geographical_area_description_period_sid = geographical_area_descriptions2.geographical_area_description_period_sid) AND (geographical_area_descriptions1.geographical_area_sid = geographical_area_descriptions2.geographical_area_sid)))) AND ((geographical_area_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -2812,7 +2799,7 @@ CREATE VIEW public.geographical_area_descriptions AS
 -- Name: geographical_area_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.geographical_area_descriptions_oid_seq
+CREATE SEQUENCE geographical_area_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2824,14 +2811,14 @@ CREATE SEQUENCE public.geographical_area_descriptions_oid_seq
 -- Name: geographical_area_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.geographical_area_descriptions_oid_seq OWNED BY public.geographical_area_descriptions_oplog.oid;
+ALTER SEQUENCE geographical_area_descriptions_oid_seq OWNED BY geographical_area_descriptions_oplog.oid;
 
 
 --
 -- Name: geographical_area_memberships_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.geographical_area_memberships_oplog (
+CREATE TABLE geographical_area_memberships_oplog (
     geographical_area_sid integer,
     geographical_area_group_sid integer,
     validity_start_date timestamp without time zone,
@@ -2851,7 +2838,7 @@ CREATE TABLE public.geographical_area_memberships_oplog (
 -- Name: geographical_area_memberships; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.geographical_area_memberships AS
+CREATE VIEW geographical_area_memberships AS
  SELECT geographical_area_memberships1.geographical_area_sid,
     geographical_area_memberships1.geographical_area_group_sid,
     geographical_area_memberships1.validity_start_date,
@@ -2863,9 +2850,9 @@ CREATE VIEW public.geographical_area_memberships AS
     geographical_area_memberships1.status,
     geographical_area_memberships1.workbasket_id,
     geographical_area_memberships1.workbasket_sequence_number
-   FROM public.geographical_area_memberships_oplog geographical_area_memberships1
+   FROM geographical_area_memberships_oplog geographical_area_memberships1
   WHERE ((geographical_area_memberships1.oid IN ( SELECT max(geographical_area_memberships2.oid) AS max
-           FROM public.geographical_area_memberships_oplog geographical_area_memberships2
+           FROM geographical_area_memberships_oplog geographical_area_memberships2
           WHERE ((geographical_area_memberships1.geographical_area_sid = geographical_area_memberships2.geographical_area_sid) AND (geographical_area_memberships1.geographical_area_group_sid = geographical_area_memberships2.geographical_area_group_sid) AND (geographical_area_memberships1.validity_start_date = geographical_area_memberships2.validity_start_date)))) AND ((geographical_area_memberships1.operation)::text <> 'D'::text));
 
 
@@ -2873,7 +2860,7 @@ CREATE VIEW public.geographical_area_memberships AS
 -- Name: geographical_area_memberships_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.geographical_area_memberships_oid_seq
+CREATE SEQUENCE geographical_area_memberships_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2885,14 +2872,14 @@ CREATE SEQUENCE public.geographical_area_memberships_oid_seq
 -- Name: geographical_area_memberships_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.geographical_area_memberships_oid_seq OWNED BY public.geographical_area_memberships_oplog.oid;
+ALTER SEQUENCE geographical_area_memberships_oid_seq OWNED BY geographical_area_memberships_oplog.oid;
 
 
 --
 -- Name: geographical_areas_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.geographical_areas_oplog (
+CREATE TABLE geographical_areas_oplog (
     geographical_area_sid integer,
     parent_geographical_area_group_sid integer,
     validity_start_date timestamp without time zone,
@@ -2914,7 +2901,7 @@ CREATE TABLE public.geographical_areas_oplog (
 -- Name: geographical_areas; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.geographical_areas AS
+CREATE VIEW geographical_areas AS
  SELECT geographical_areas1.geographical_area_sid,
     geographical_areas1.parent_geographical_area_group_sid,
     geographical_areas1.validity_start_date,
@@ -2928,9 +2915,9 @@ CREATE VIEW public.geographical_areas AS
     geographical_areas1.status,
     geographical_areas1.workbasket_id,
     geographical_areas1.workbasket_sequence_number
-   FROM public.geographical_areas_oplog geographical_areas1
+   FROM geographical_areas_oplog geographical_areas1
   WHERE ((geographical_areas1.oid IN ( SELECT max(geographical_areas2.oid) AS max
-           FROM public.geographical_areas_oplog geographical_areas2
+           FROM geographical_areas_oplog geographical_areas2
           WHERE (geographical_areas1.geographical_area_sid = geographical_areas2.geographical_area_sid))) AND ((geographical_areas1.operation)::text <> 'D'::text));
 
 
@@ -2938,7 +2925,7 @@ CREATE VIEW public.geographical_areas AS
 -- Name: geographical_areas_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.geographical_areas_oid_seq
+CREATE SEQUENCE geographical_areas_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -2950,14 +2937,14 @@ CREATE SEQUENCE public.geographical_areas_oid_seq
 -- Name: geographical_areas_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.geographical_areas_oid_seq OWNED BY public.geographical_areas_oplog.oid;
+ALTER SEQUENCE geographical_areas_oid_seq OWNED BY geographical_areas_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_description_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclature_description_periods_oplog (
+CREATE TABLE goods_nomenclature_description_periods_oplog (
     goods_nomenclature_description_period_sid integer,
     goods_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -2978,7 +2965,7 @@ CREATE TABLE public.goods_nomenclature_description_periods_oplog (
 -- Name: goods_nomenclature_description_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclature_description_periods AS
+CREATE VIEW goods_nomenclature_description_periods AS
  SELECT goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid,
     goods_nomenclature_description_periods1.goods_nomenclature_sid,
     goods_nomenclature_description_periods1.validity_start_date,
@@ -2991,9 +2978,9 @@ CREATE VIEW public.goods_nomenclature_description_periods AS
     goods_nomenclature_description_periods1.status,
     goods_nomenclature_description_periods1.workbasket_id,
     goods_nomenclature_description_periods1.workbasket_sequence_number
-   FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
+   FROM goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods1
   WHERE ((goods_nomenclature_description_periods1.oid IN ( SELECT max(goods_nomenclature_description_periods2.oid) AS max
-           FROM public.goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
+           FROM goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods2
           WHERE (goods_nomenclature_description_periods1.goods_nomenclature_description_period_sid = goods_nomenclature_description_periods2.goods_nomenclature_description_period_sid))) AND ((goods_nomenclature_description_periods1.operation)::text <> 'D'::text));
 
 
@@ -3001,7 +2988,7 @@ CREATE VIEW public.goods_nomenclature_description_periods AS
 -- Name: goods_nomenclature_description_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclature_description_periods_oid_seq
+CREATE SEQUENCE goods_nomenclature_description_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3013,14 +3000,14 @@ CREATE SEQUENCE public.goods_nomenclature_description_periods_oid_seq
 -- Name: goods_nomenclature_description_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclature_description_periods_oid_seq OWNED BY public.goods_nomenclature_description_periods_oplog.oid;
+ALTER SEQUENCE goods_nomenclature_description_periods_oid_seq OWNED BY goods_nomenclature_description_periods_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclature_descriptions_oplog (
+CREATE TABLE goods_nomenclature_descriptions_oplog (
     goods_nomenclature_description_period_sid integer,
     language_id character varying(5),
     goods_nomenclature_sid integer,
@@ -3041,7 +3028,7 @@ CREATE TABLE public.goods_nomenclature_descriptions_oplog (
 -- Name: goods_nomenclature_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclature_descriptions AS
+CREATE VIEW goods_nomenclature_descriptions AS
  SELECT goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid,
     goods_nomenclature_descriptions1.language_id,
     goods_nomenclature_descriptions1.goods_nomenclature_sid,
@@ -3054,9 +3041,9 @@ CREATE VIEW public.goods_nomenclature_descriptions AS
     goods_nomenclature_descriptions1.status,
     goods_nomenclature_descriptions1.workbasket_id,
     goods_nomenclature_descriptions1.workbasket_sequence_number
-   FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
+   FROM goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions1
   WHERE ((goods_nomenclature_descriptions1.oid IN ( SELECT max(goods_nomenclature_descriptions2.oid) AS max
-           FROM public.goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
+           FROM goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions2
           WHERE ((goods_nomenclature_descriptions1.goods_nomenclature_sid = goods_nomenclature_descriptions2.goods_nomenclature_sid) AND (goods_nomenclature_descriptions1.goods_nomenclature_description_period_sid = goods_nomenclature_descriptions2.goods_nomenclature_description_period_sid)))) AND ((goods_nomenclature_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3064,7 +3051,7 @@ CREATE VIEW public.goods_nomenclature_descriptions AS
 -- Name: goods_nomenclature_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclature_descriptions_oid_seq
+CREATE SEQUENCE goods_nomenclature_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3076,14 +3063,14 @@ CREATE SEQUENCE public.goods_nomenclature_descriptions_oid_seq
 -- Name: goods_nomenclature_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclature_descriptions_oid_seq OWNED BY public.goods_nomenclature_descriptions_oplog.oid;
+ALTER SEQUENCE goods_nomenclature_descriptions_oid_seq OWNED BY goods_nomenclature_descriptions_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_group_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclature_group_descriptions_oplog (
+CREATE TABLE goods_nomenclature_group_descriptions_oplog (
     goods_nomenclature_group_type character varying(1),
     goods_nomenclature_group_id character varying(6),
     language_id character varying(5),
@@ -3102,7 +3089,7 @@ CREATE TABLE public.goods_nomenclature_group_descriptions_oplog (
 -- Name: goods_nomenclature_group_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclature_group_descriptions AS
+CREATE VIEW goods_nomenclature_group_descriptions AS
  SELECT goods_nomenclature_group_descriptions1.goods_nomenclature_group_type,
     goods_nomenclature_group_descriptions1.goods_nomenclature_group_id,
     goods_nomenclature_group_descriptions1.language_id,
@@ -3113,9 +3100,9 @@ CREATE VIEW public.goods_nomenclature_group_descriptions AS
     goods_nomenclature_group_descriptions1.status,
     goods_nomenclature_group_descriptions1.workbasket_id,
     goods_nomenclature_group_descriptions1.workbasket_sequence_number
-   FROM public.goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions1
+   FROM goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions1
   WHERE ((goods_nomenclature_group_descriptions1.oid IN ( SELECT max(goods_nomenclature_group_descriptions2.oid) AS max
-           FROM public.goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions2
+           FROM goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions2
           WHERE (((goods_nomenclature_group_descriptions1.goods_nomenclature_group_id)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_group_descriptions1.goods_nomenclature_group_type)::text = (goods_nomenclature_group_descriptions2.goods_nomenclature_group_type)::text)))) AND ((goods_nomenclature_group_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3123,7 +3110,7 @@ CREATE VIEW public.goods_nomenclature_group_descriptions AS
 -- Name: goods_nomenclature_group_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclature_group_descriptions_oid_seq
+CREATE SEQUENCE goods_nomenclature_group_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3135,14 +3122,14 @@ CREATE SEQUENCE public.goods_nomenclature_group_descriptions_oid_seq
 -- Name: goods_nomenclature_group_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclature_group_descriptions_oid_seq OWNED BY public.goods_nomenclature_group_descriptions_oplog.oid;
+ALTER SEQUENCE goods_nomenclature_group_descriptions_oid_seq OWNED BY goods_nomenclature_group_descriptions_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_groups_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclature_groups_oplog (
+CREATE TABLE goods_nomenclature_groups_oplog (
     goods_nomenclature_group_type character varying(1),
     goods_nomenclature_group_id character varying(6),
     validity_start_date timestamp without time zone,
@@ -3162,7 +3149,7 @@ CREATE TABLE public.goods_nomenclature_groups_oplog (
 -- Name: goods_nomenclature_groups; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclature_groups AS
+CREATE VIEW goods_nomenclature_groups AS
  SELECT goods_nomenclature_groups1.goods_nomenclature_group_type,
     goods_nomenclature_groups1.goods_nomenclature_group_id,
     goods_nomenclature_groups1.validity_start_date,
@@ -3174,9 +3161,9 @@ CREATE VIEW public.goods_nomenclature_groups AS
     goods_nomenclature_groups1.status,
     goods_nomenclature_groups1.workbasket_id,
     goods_nomenclature_groups1.workbasket_sequence_number
-   FROM public.goods_nomenclature_groups_oplog goods_nomenclature_groups1
+   FROM goods_nomenclature_groups_oplog goods_nomenclature_groups1
   WHERE ((goods_nomenclature_groups1.oid IN ( SELECT max(goods_nomenclature_groups2.oid) AS max
-           FROM public.goods_nomenclature_groups_oplog goods_nomenclature_groups2
+           FROM goods_nomenclature_groups_oplog goods_nomenclature_groups2
           WHERE (((goods_nomenclature_groups1.goods_nomenclature_group_id)::text = (goods_nomenclature_groups2.goods_nomenclature_group_id)::text) AND ((goods_nomenclature_groups1.goods_nomenclature_group_type)::text = (goods_nomenclature_groups2.goods_nomenclature_group_type)::text)))) AND ((goods_nomenclature_groups1.operation)::text <> 'D'::text));
 
 
@@ -3184,7 +3171,7 @@ CREATE VIEW public.goods_nomenclature_groups AS
 -- Name: goods_nomenclature_groups_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclature_groups_oid_seq
+CREATE SEQUENCE goods_nomenclature_groups_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3196,14 +3183,14 @@ CREATE SEQUENCE public.goods_nomenclature_groups_oid_seq
 -- Name: goods_nomenclature_groups_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclature_groups_oid_seq OWNED BY public.goods_nomenclature_groups_oplog.oid;
+ALTER SEQUENCE goods_nomenclature_groups_oid_seq OWNED BY goods_nomenclature_groups_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_indents_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclature_indents_oplog (
+CREATE TABLE goods_nomenclature_indents_oplog (
     goods_nomenclature_indent_sid integer,
     goods_nomenclature_sid integer,
     validity_start_date timestamp without time zone,
@@ -3225,7 +3212,7 @@ CREATE TABLE public.goods_nomenclature_indents_oplog (
 -- Name: goods_nomenclature_indents; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclature_indents AS
+CREATE VIEW goods_nomenclature_indents AS
  SELECT goods_nomenclature_indents1.goods_nomenclature_indent_sid,
     goods_nomenclature_indents1.goods_nomenclature_sid,
     goods_nomenclature_indents1.validity_start_date,
@@ -3239,9 +3226,9 @@ CREATE VIEW public.goods_nomenclature_indents AS
     goods_nomenclature_indents1.status,
     goods_nomenclature_indents1.workbasket_id,
     goods_nomenclature_indents1.workbasket_sequence_number
-   FROM public.goods_nomenclature_indents_oplog goods_nomenclature_indents1
+   FROM goods_nomenclature_indents_oplog goods_nomenclature_indents1
   WHERE ((goods_nomenclature_indents1.oid IN ( SELECT max(goods_nomenclature_indents2.oid) AS max
-           FROM public.goods_nomenclature_indents_oplog goods_nomenclature_indents2
+           FROM goods_nomenclature_indents_oplog goods_nomenclature_indents2
           WHERE (goods_nomenclature_indents1.goods_nomenclature_indent_sid = goods_nomenclature_indents2.goods_nomenclature_indent_sid))) AND ((goods_nomenclature_indents1.operation)::text <> 'D'::text));
 
 
@@ -3249,7 +3236,7 @@ CREATE VIEW public.goods_nomenclature_indents AS
 -- Name: goods_nomenclature_indents_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclature_indents_oid_seq
+CREATE SEQUENCE goods_nomenclature_indents_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3261,14 +3248,14 @@ CREATE SEQUENCE public.goods_nomenclature_indents_oid_seq
 -- Name: goods_nomenclature_indents_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclature_indents_oid_seq OWNED BY public.goods_nomenclature_indents_oplog.oid;
+ALTER SEQUENCE goods_nomenclature_indents_oid_seq OWNED BY goods_nomenclature_indents_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_origins_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclature_origins_oplog (
+CREATE TABLE goods_nomenclature_origins_oplog (
     goods_nomenclature_sid integer,
     derived_goods_nomenclature_item_id character varying(10),
     derived_productline_suffix character varying(2),
@@ -3288,7 +3275,7 @@ CREATE TABLE public.goods_nomenclature_origins_oplog (
 -- Name: goods_nomenclature_origins; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclature_origins AS
+CREATE VIEW goods_nomenclature_origins AS
  SELECT goods_nomenclature_origins1.goods_nomenclature_sid,
     goods_nomenclature_origins1.derived_goods_nomenclature_item_id,
     goods_nomenclature_origins1.derived_productline_suffix,
@@ -3300,9 +3287,9 @@ CREATE VIEW public.goods_nomenclature_origins AS
     goods_nomenclature_origins1.status,
     goods_nomenclature_origins1.workbasket_id,
     goods_nomenclature_origins1.workbasket_sequence_number
-   FROM public.goods_nomenclature_origins_oplog goods_nomenclature_origins1
+   FROM goods_nomenclature_origins_oplog goods_nomenclature_origins1
   WHERE ((goods_nomenclature_origins1.oid IN ( SELECT max(goods_nomenclature_origins2.oid) AS max
-           FROM public.goods_nomenclature_origins_oplog goods_nomenclature_origins2
+           FROM goods_nomenclature_origins_oplog goods_nomenclature_origins2
           WHERE ((goods_nomenclature_origins1.goods_nomenclature_sid = goods_nomenclature_origins2.goods_nomenclature_sid) AND ((goods_nomenclature_origins1.derived_goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.derived_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.derived_productline_suffix)::text = (goods_nomenclature_origins2.derived_productline_suffix)::text) AND ((goods_nomenclature_origins1.goods_nomenclature_item_id)::text = (goods_nomenclature_origins2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_origins1.productline_suffix)::text = (goods_nomenclature_origins2.productline_suffix)::text)))) AND ((goods_nomenclature_origins1.operation)::text <> 'D'::text));
 
 
@@ -3310,7 +3297,7 @@ CREATE VIEW public.goods_nomenclature_origins AS
 -- Name: goods_nomenclature_origins_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclature_origins_oid_seq
+CREATE SEQUENCE goods_nomenclature_origins_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3322,14 +3309,14 @@ CREATE SEQUENCE public.goods_nomenclature_origins_oid_seq
 -- Name: goods_nomenclature_origins_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclature_origins_oid_seq OWNED BY public.goods_nomenclature_origins_oplog.oid;
+ALTER SEQUENCE goods_nomenclature_origins_oid_seq OWNED BY goods_nomenclature_origins_oplog.oid;
 
 
 --
 -- Name: goods_nomenclature_successors_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclature_successors_oplog (
+CREATE TABLE goods_nomenclature_successors_oplog (
     goods_nomenclature_sid integer,
     absorbed_goods_nomenclature_item_id character varying(10),
     absorbed_productline_suffix character varying(2),
@@ -3349,7 +3336,7 @@ CREATE TABLE public.goods_nomenclature_successors_oplog (
 -- Name: goods_nomenclature_successors; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclature_successors AS
+CREATE VIEW goods_nomenclature_successors AS
  SELECT goods_nomenclature_successors1.goods_nomenclature_sid,
     goods_nomenclature_successors1.absorbed_goods_nomenclature_item_id,
     goods_nomenclature_successors1.absorbed_productline_suffix,
@@ -3361,9 +3348,9 @@ CREATE VIEW public.goods_nomenclature_successors AS
     goods_nomenclature_successors1.status,
     goods_nomenclature_successors1.workbasket_id,
     goods_nomenclature_successors1.workbasket_sequence_number
-   FROM public.goods_nomenclature_successors_oplog goods_nomenclature_successors1
+   FROM goods_nomenclature_successors_oplog goods_nomenclature_successors1
   WHERE ((goods_nomenclature_successors1.oid IN ( SELECT max(goods_nomenclature_successors2.oid) AS max
-           FROM public.goods_nomenclature_successors_oplog goods_nomenclature_successors2
+           FROM goods_nomenclature_successors_oplog goods_nomenclature_successors2
           WHERE ((goods_nomenclature_successors1.goods_nomenclature_sid = goods_nomenclature_successors2.goods_nomenclature_sid) AND ((goods_nomenclature_successors1.absorbed_goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.absorbed_goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.absorbed_productline_suffix)::text = (goods_nomenclature_successors2.absorbed_productline_suffix)::text) AND ((goods_nomenclature_successors1.goods_nomenclature_item_id)::text = (goods_nomenclature_successors2.goods_nomenclature_item_id)::text) AND ((goods_nomenclature_successors1.productline_suffix)::text = (goods_nomenclature_successors2.productline_suffix)::text)))) AND ((goods_nomenclature_successors1.operation)::text <> 'D'::text));
 
 
@@ -3371,7 +3358,7 @@ CREATE VIEW public.goods_nomenclature_successors AS
 -- Name: goods_nomenclature_successors_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclature_successors_oid_seq
+CREATE SEQUENCE goods_nomenclature_successors_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3383,14 +3370,14 @@ CREATE SEQUENCE public.goods_nomenclature_successors_oid_seq
 -- Name: goods_nomenclature_successors_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclature_successors_oid_seq OWNED BY public.goods_nomenclature_successors_oplog.oid;
+ALTER SEQUENCE goods_nomenclature_successors_oid_seq OWNED BY goods_nomenclature_successors_oplog.oid;
 
 
 --
 -- Name: goods_nomenclatures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.goods_nomenclatures_oplog (
+CREATE TABLE goods_nomenclatures_oplog (
     goods_nomenclature_sid integer,
     goods_nomenclature_item_id character varying(10),
     producline_suffix character varying(255),
@@ -3411,7 +3398,7 @@ CREATE TABLE public.goods_nomenclatures_oplog (
 -- Name: goods_nomenclatures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.goods_nomenclatures AS
+CREATE VIEW goods_nomenclatures AS
  SELECT goods_nomenclatures1.goods_nomenclature_sid,
     goods_nomenclatures1.goods_nomenclature_item_id,
     goods_nomenclatures1.producline_suffix,
@@ -3424,9 +3411,9 @@ CREATE VIEW public.goods_nomenclatures AS
     goods_nomenclatures1.status,
     goods_nomenclatures1.workbasket_id,
     goods_nomenclatures1.workbasket_sequence_number
-   FROM public.goods_nomenclatures_oplog goods_nomenclatures1
+   FROM goods_nomenclatures_oplog goods_nomenclatures1
   WHERE ((goods_nomenclatures1.oid IN ( SELECT max(goods_nomenclatures2.oid) AS max
-           FROM public.goods_nomenclatures_oplog goods_nomenclatures2
+           FROM goods_nomenclatures_oplog goods_nomenclatures2
           WHERE (goods_nomenclatures1.goods_nomenclature_sid = goods_nomenclatures2.goods_nomenclature_sid))) AND ((goods_nomenclatures1.operation)::text <> 'D'::text));
 
 
@@ -3434,7 +3421,7 @@ CREATE VIEW public.goods_nomenclatures AS
 -- Name: goods_nomenclatures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.goods_nomenclatures_oid_seq
+CREATE SEQUENCE goods_nomenclatures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3446,14 +3433,14 @@ CREATE SEQUENCE public.goods_nomenclatures_oid_seq
 -- Name: goods_nomenclatures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.goods_nomenclatures_oid_seq OWNED BY public.goods_nomenclatures_oplog.oid;
+ALTER SEQUENCE goods_nomenclatures_oid_seq OWNED BY goods_nomenclatures_oplog.oid;
 
 
 --
 -- Name: hidden_goods_nomenclatures; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.hidden_goods_nomenclatures (
+CREATE TABLE hidden_goods_nomenclatures (
     goods_nomenclature_item_id text,
     created_at timestamp without time zone
 );
@@ -3463,7 +3450,7 @@ CREATE TABLE public.hidden_goods_nomenclatures (
 -- Name: language_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.language_descriptions_oplog (
+CREATE TABLE language_descriptions_oplog (
     language_code_id character varying(255),
     language_id character varying(5),
     description text,
@@ -3481,7 +3468,7 @@ CREATE TABLE public.language_descriptions_oplog (
 -- Name: language_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.language_descriptions AS
+CREATE VIEW language_descriptions AS
  SELECT language_descriptions1.language_code_id,
     language_descriptions1.language_id,
     language_descriptions1.description,
@@ -3491,9 +3478,9 @@ CREATE VIEW public.language_descriptions AS
     language_descriptions1.status,
     language_descriptions1.workbasket_id,
     language_descriptions1.workbasket_sequence_number
-   FROM public.language_descriptions_oplog language_descriptions1
+   FROM language_descriptions_oplog language_descriptions1
   WHERE ((language_descriptions1.oid IN ( SELECT max(language_descriptions2.oid) AS max
-           FROM public.language_descriptions_oplog language_descriptions2
+           FROM language_descriptions_oplog language_descriptions2
           WHERE (((language_descriptions1.language_id)::text = (language_descriptions2.language_id)::text) AND ((language_descriptions1.language_code_id)::text = (language_descriptions2.language_code_id)::text)))) AND ((language_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3501,7 +3488,7 @@ CREATE VIEW public.language_descriptions AS
 -- Name: language_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.language_descriptions_oid_seq
+CREATE SEQUENCE language_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3513,14 +3500,14 @@ CREATE SEQUENCE public.language_descriptions_oid_seq
 -- Name: language_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.language_descriptions_oid_seq OWNED BY public.language_descriptions_oplog.oid;
+ALTER SEQUENCE language_descriptions_oid_seq OWNED BY language_descriptions_oplog.oid;
 
 
 --
 -- Name: languages_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.languages_oplog (
+CREATE TABLE languages_oplog (
     language_id character varying(5),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3538,7 +3525,7 @@ CREATE TABLE public.languages_oplog (
 -- Name: languages; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.languages AS
+CREATE VIEW languages AS
  SELECT languages1.language_id,
     languages1.validity_start_date,
     languages1.validity_end_date,
@@ -3548,9 +3535,9 @@ CREATE VIEW public.languages AS
     languages1.status,
     languages1.workbasket_id,
     languages1.workbasket_sequence_number
-   FROM public.languages_oplog languages1
+   FROM languages_oplog languages1
   WHERE ((languages1.oid IN ( SELECT max(languages2.oid) AS max
-           FROM public.languages_oplog languages2
+           FROM languages_oplog languages2
           WHERE ((languages1.language_id)::text = (languages2.language_id)::text))) AND ((languages1.operation)::text <> 'D'::text));
 
 
@@ -3558,7 +3545,7 @@ CREATE VIEW public.languages AS
 -- Name: languages_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.languages_oid_seq
+CREATE SEQUENCE languages_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3570,14 +3557,14 @@ CREATE SEQUENCE public.languages_oid_seq
 -- Name: languages_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.languages_oid_seq OWNED BY public.languages_oplog.oid;
+ALTER SEQUENCE languages_oid_seq OWNED BY languages_oplog.oid;
 
 
 --
 -- Name: measure_action_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_action_descriptions_oplog (
+CREATE TABLE measure_action_descriptions_oplog (
     action_code character varying(255),
     language_id character varying(5),
     description text,
@@ -3595,7 +3582,7 @@ CREATE TABLE public.measure_action_descriptions_oplog (
 -- Name: measure_action_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_action_descriptions AS
+CREATE VIEW measure_action_descriptions AS
  SELECT measure_action_descriptions1.action_code,
     measure_action_descriptions1.language_id,
     measure_action_descriptions1.description,
@@ -3605,9 +3592,9 @@ CREATE VIEW public.measure_action_descriptions AS
     measure_action_descriptions1.status,
     measure_action_descriptions1.workbasket_id,
     measure_action_descriptions1.workbasket_sequence_number
-   FROM public.measure_action_descriptions_oplog measure_action_descriptions1
+   FROM measure_action_descriptions_oplog measure_action_descriptions1
   WHERE ((measure_action_descriptions1.oid IN ( SELECT max(measure_action_descriptions2.oid) AS max
-           FROM public.measure_action_descriptions_oplog measure_action_descriptions2
+           FROM measure_action_descriptions_oplog measure_action_descriptions2
           WHERE ((measure_action_descriptions1.action_code)::text = (measure_action_descriptions2.action_code)::text))) AND ((measure_action_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3615,7 +3602,7 @@ CREATE VIEW public.measure_action_descriptions AS
 -- Name: measure_action_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_action_descriptions_oid_seq
+CREATE SEQUENCE measure_action_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3627,14 +3614,14 @@ CREATE SEQUENCE public.measure_action_descriptions_oid_seq
 -- Name: measure_action_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_action_descriptions_oid_seq OWNED BY public.measure_action_descriptions_oplog.oid;
+ALTER SEQUENCE measure_action_descriptions_oid_seq OWNED BY measure_action_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_actions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_actions_oplog (
+CREATE TABLE measure_actions_oplog (
     action_code character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3652,7 +3639,7 @@ CREATE TABLE public.measure_actions_oplog (
 -- Name: measure_actions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_actions AS
+CREATE VIEW measure_actions AS
  SELECT measure_actions1.action_code,
     measure_actions1.validity_start_date,
     measure_actions1.validity_end_date,
@@ -3662,9 +3649,9 @@ CREATE VIEW public.measure_actions AS
     measure_actions1.status,
     measure_actions1.workbasket_id,
     measure_actions1.workbasket_sequence_number
-   FROM public.measure_actions_oplog measure_actions1
+   FROM measure_actions_oplog measure_actions1
   WHERE ((measure_actions1.oid IN ( SELECT max(measure_actions2.oid) AS max
-           FROM public.measure_actions_oplog measure_actions2
+           FROM measure_actions_oplog measure_actions2
           WHERE ((measure_actions1.action_code)::text = (measure_actions2.action_code)::text))) AND ((measure_actions1.operation)::text <> 'D'::text));
 
 
@@ -3672,7 +3659,7 @@ CREATE VIEW public.measure_actions AS
 -- Name: measure_actions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_actions_oid_seq
+CREATE SEQUENCE measure_actions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3684,14 +3671,14 @@ CREATE SEQUENCE public.measure_actions_oid_seq
 -- Name: measure_actions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_actions_oid_seq OWNED BY public.measure_actions_oplog.oid;
+ALTER SEQUENCE measure_actions_oid_seq OWNED BY measure_actions_oplog.oid;
 
 
 --
 -- Name: measure_components_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_components_oplog (
+CREATE TABLE measure_components_oplog (
     measure_sid integer,
     duty_expression_id character varying(255),
     duty_amount double precision,
@@ -3716,7 +3703,7 @@ CREATE TABLE public.measure_components_oplog (
 -- Name: measure_components; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_components AS
+CREATE VIEW measure_components AS
  SELECT measure_components1.measure_sid,
     measure_components1.duty_expression_id,
     measure_components1.duty_amount,
@@ -3733,9 +3720,9 @@ CREATE VIEW public.measure_components AS
     measure_components1.workbasket_id,
     measure_components1.workbasket_sequence_number,
     measure_components1.original_duty_expression_id
-   FROM public.measure_components_oplog measure_components1
+   FROM measure_components_oplog measure_components1
   WHERE ((measure_components1.oid IN ( SELECT max(measure_components2.oid) AS max
-           FROM public.measure_components_oplog measure_components2
+           FROM measure_components_oplog measure_components2
           WHERE ((measure_components1.measure_sid = measure_components2.measure_sid) AND ((measure_components1.duty_expression_id)::text = (measure_components2.duty_expression_id)::text)))) AND ((measure_components1.operation)::text <> 'D'::text));
 
 
@@ -3743,7 +3730,7 @@ CREATE VIEW public.measure_components AS
 -- Name: measure_components_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_components_oid_seq
+CREATE SEQUENCE measure_components_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3755,14 +3742,14 @@ CREATE SEQUENCE public.measure_components_oid_seq
 -- Name: measure_components_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_components_oid_seq OWNED BY public.measure_components_oplog.oid;
+ALTER SEQUENCE measure_components_oid_seq OWNED BY measure_components_oplog.oid;
 
 
 --
 -- Name: measure_condition_code_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_condition_code_descriptions_oplog (
+CREATE TABLE measure_condition_code_descriptions_oplog (
     condition_code character varying(255),
     language_id character varying(5),
     description text,
@@ -3780,7 +3767,7 @@ CREATE TABLE public.measure_condition_code_descriptions_oplog (
 -- Name: measure_condition_code_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_condition_code_descriptions AS
+CREATE VIEW measure_condition_code_descriptions AS
  SELECT measure_condition_code_descriptions1.condition_code,
     measure_condition_code_descriptions1.language_id,
     measure_condition_code_descriptions1.description,
@@ -3790,9 +3777,9 @@ CREATE VIEW public.measure_condition_code_descriptions AS
     measure_condition_code_descriptions1.status,
     measure_condition_code_descriptions1.workbasket_id,
     measure_condition_code_descriptions1.workbasket_sequence_number
-   FROM public.measure_condition_code_descriptions_oplog measure_condition_code_descriptions1
+   FROM measure_condition_code_descriptions_oplog measure_condition_code_descriptions1
   WHERE ((measure_condition_code_descriptions1.oid IN ( SELECT max(measure_condition_code_descriptions2.oid) AS max
-           FROM public.measure_condition_code_descriptions_oplog measure_condition_code_descriptions2
+           FROM measure_condition_code_descriptions_oplog measure_condition_code_descriptions2
           WHERE ((measure_condition_code_descriptions1.condition_code)::text = (measure_condition_code_descriptions2.condition_code)::text))) AND ((measure_condition_code_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -3800,7 +3787,7 @@ CREATE VIEW public.measure_condition_code_descriptions AS
 -- Name: measure_condition_code_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_condition_code_descriptions_oid_seq
+CREATE SEQUENCE measure_condition_code_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3812,14 +3799,14 @@ CREATE SEQUENCE public.measure_condition_code_descriptions_oid_seq
 -- Name: measure_condition_code_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_condition_code_descriptions_oid_seq OWNED BY public.measure_condition_code_descriptions_oplog.oid;
+ALTER SEQUENCE measure_condition_code_descriptions_oid_seq OWNED BY measure_condition_code_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_condition_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_condition_codes_oplog (
+CREATE TABLE measure_condition_codes_oplog (
     condition_code character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -3837,7 +3824,7 @@ CREATE TABLE public.measure_condition_codes_oplog (
 -- Name: measure_condition_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_condition_codes AS
+CREATE VIEW measure_condition_codes AS
  SELECT measure_condition_codes1.condition_code,
     measure_condition_codes1.validity_start_date,
     measure_condition_codes1.validity_end_date,
@@ -3847,9 +3834,9 @@ CREATE VIEW public.measure_condition_codes AS
     measure_condition_codes1.status,
     measure_condition_codes1.workbasket_id,
     measure_condition_codes1.workbasket_sequence_number
-   FROM public.measure_condition_codes_oplog measure_condition_codes1
+   FROM measure_condition_codes_oplog measure_condition_codes1
   WHERE ((measure_condition_codes1.oid IN ( SELECT max(measure_condition_codes2.oid) AS max
-           FROM public.measure_condition_codes_oplog measure_condition_codes2
+           FROM measure_condition_codes_oplog measure_condition_codes2
           WHERE ((measure_condition_codes1.condition_code)::text = (measure_condition_codes2.condition_code)::text))) AND ((measure_condition_codes1.operation)::text <> 'D'::text));
 
 
@@ -3857,7 +3844,7 @@ CREATE VIEW public.measure_condition_codes AS
 -- Name: measure_condition_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_condition_codes_oid_seq
+CREATE SEQUENCE measure_condition_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3869,14 +3856,14 @@ CREATE SEQUENCE public.measure_condition_codes_oid_seq
 -- Name: measure_condition_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_condition_codes_oid_seq OWNED BY public.measure_condition_codes_oplog.oid;
+ALTER SEQUENCE measure_condition_codes_oid_seq OWNED BY measure_condition_codes_oplog.oid;
 
 
 --
 -- Name: measure_condition_components_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_condition_components_oplog (
+CREATE TABLE measure_condition_components_oplog (
     measure_condition_sid integer,
     duty_expression_id character varying(255),
     duty_amount double precision,
@@ -3901,7 +3888,7 @@ CREATE TABLE public.measure_condition_components_oplog (
 -- Name: measure_condition_components; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_condition_components AS
+CREATE VIEW measure_condition_components AS
  SELECT measure_condition_components1.measure_condition_sid,
     measure_condition_components1.duty_expression_id,
     measure_condition_components1.duty_amount,
@@ -3918,9 +3905,9 @@ CREATE VIEW public.measure_condition_components AS
     measure_condition_components1.workbasket_id,
     measure_condition_components1.workbasket_sequence_number,
     measure_condition_components1.original_duty_expression_id
-   FROM public.measure_condition_components_oplog measure_condition_components1
+   FROM measure_condition_components_oplog measure_condition_components1
   WHERE ((measure_condition_components1.oid IN ( SELECT max(measure_condition_components2.oid) AS max
-           FROM public.measure_condition_components_oplog measure_condition_components2
+           FROM measure_condition_components_oplog measure_condition_components2
           WHERE ((measure_condition_components1.measure_condition_sid = measure_condition_components2.measure_condition_sid) AND ((measure_condition_components1.duty_expression_id)::text = (measure_condition_components2.duty_expression_id)::text)))) AND ((measure_condition_components1.operation)::text <> 'D'::text));
 
 
@@ -3928,7 +3915,7 @@ CREATE VIEW public.measure_condition_components AS
 -- Name: measure_condition_components_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_condition_components_oid_seq
+CREATE SEQUENCE measure_condition_components_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -3940,14 +3927,14 @@ CREATE SEQUENCE public.measure_condition_components_oid_seq
 -- Name: measure_condition_components_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_condition_components_oid_seq OWNED BY public.measure_condition_components_oplog.oid;
+ALTER SEQUENCE measure_condition_components_oid_seq OWNED BY measure_condition_components_oplog.oid;
 
 
 --
 -- Name: measure_conditions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_conditions_oplog (
+CREATE TABLE measure_conditions_oplog (
     measure_condition_sid integer,
     measure_sid integer,
     condition_code character varying(255),
@@ -3977,7 +3964,7 @@ CREATE TABLE public.measure_conditions_oplog (
 -- Name: measure_conditions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_conditions AS
+CREATE VIEW measure_conditions AS
  SELECT measure_conditions1.measure_condition_sid,
     measure_conditions1.measure_sid,
     measure_conditions1.condition_code,
@@ -3999,9 +3986,9 @@ CREATE VIEW public.measure_conditions AS
     measure_conditions1.workbasket_id,
     measure_conditions1.workbasket_sequence_number,
     measure_conditions1.original_measure_condition_code
-   FROM public.measure_conditions_oplog measure_conditions1
+   FROM measure_conditions_oplog measure_conditions1
   WHERE ((measure_conditions1.oid IN ( SELECT max(measure_conditions2.oid) AS max
-           FROM public.measure_conditions_oplog measure_conditions2
+           FROM measure_conditions_oplog measure_conditions2
           WHERE (measure_conditions1.measure_condition_sid = measure_conditions2.measure_condition_sid))) AND ((measure_conditions1.operation)::text <> 'D'::text));
 
 
@@ -4009,7 +3996,7 @@ CREATE VIEW public.measure_conditions AS
 -- Name: measure_conditions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_conditions_oid_seq
+CREATE SEQUENCE measure_conditions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4021,14 +4008,14 @@ CREATE SEQUENCE public.measure_conditions_oid_seq
 -- Name: measure_conditions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_conditions_oid_seq OWNED BY public.measure_conditions_oplog.oid;
+ALTER SEQUENCE measure_conditions_oid_seq OWNED BY measure_conditions_oplog.oid;
 
 
 --
 -- Name: measure_excluded_geographical_areas_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_excluded_geographical_areas_oplog (
+CREATE TABLE measure_excluded_geographical_areas_oplog (
     measure_sid integer,
     excluded_geographical_area character varying(255),
     geographical_area_sid integer,
@@ -4049,7 +4036,7 @@ CREATE TABLE public.measure_excluded_geographical_areas_oplog (
 -- Name: measure_excluded_geographical_areas; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_excluded_geographical_areas AS
+CREATE VIEW measure_excluded_geographical_areas AS
  SELECT measure_excluded_geographical_areas1.measure_sid,
     measure_excluded_geographical_areas1.excluded_geographical_area,
     measure_excluded_geographical_areas1.geographical_area_sid,
@@ -4062,9 +4049,9 @@ CREATE VIEW public.measure_excluded_geographical_areas AS
     measure_excluded_geographical_areas1.status,
     measure_excluded_geographical_areas1.workbasket_id,
     measure_excluded_geographical_areas1.workbasket_sequence_number
-   FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas1
+   FROM measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas1
   WHERE ((measure_excluded_geographical_areas1.oid IN ( SELECT max(measure_excluded_geographical_areas2.oid) AS max
-           FROM public.measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas2
+           FROM measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas2
           WHERE ((measure_excluded_geographical_areas1.measure_sid = measure_excluded_geographical_areas2.measure_sid) AND (measure_excluded_geographical_areas1.geographical_area_sid = measure_excluded_geographical_areas2.geographical_area_sid)))) AND ((measure_excluded_geographical_areas1.operation)::text <> 'D'::text));
 
 
@@ -4072,7 +4059,7 @@ CREATE VIEW public.measure_excluded_geographical_areas AS
 -- Name: measure_excluded_geographical_areas_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_excluded_geographical_areas_oid_seq
+CREATE SEQUENCE measure_excluded_geographical_areas_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4084,14 +4071,14 @@ CREATE SEQUENCE public.measure_excluded_geographical_areas_oid_seq
 -- Name: measure_excluded_geographical_areas_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_excluded_geographical_areas_oid_seq OWNED BY public.measure_excluded_geographical_areas_oplog.oid;
+ALTER SEQUENCE measure_excluded_geographical_areas_oid_seq OWNED BY measure_excluded_geographical_areas_oplog.oid;
 
 
 --
 -- Name: measure_partial_temporary_stops_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_partial_temporary_stops_oplog (
+CREATE TABLE measure_partial_temporary_stops_oplog (
     measure_sid integer,
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4115,7 +4102,7 @@ CREATE TABLE public.measure_partial_temporary_stops_oplog (
 -- Name: measure_partial_temporary_stops; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_partial_temporary_stops AS
+CREATE VIEW measure_partial_temporary_stops AS
  SELECT measure_partial_temporary_stops1.measure_sid,
     measure_partial_temporary_stops1.validity_start_date,
     measure_partial_temporary_stops1.validity_end_date,
@@ -4131,9 +4118,9 @@ CREATE VIEW public.measure_partial_temporary_stops AS
     measure_partial_temporary_stops1.status,
     measure_partial_temporary_stops1.workbasket_id,
     measure_partial_temporary_stops1.workbasket_sequence_number
-   FROM public.measure_partial_temporary_stops_oplog measure_partial_temporary_stops1
+   FROM measure_partial_temporary_stops_oplog measure_partial_temporary_stops1
   WHERE ((measure_partial_temporary_stops1.oid IN ( SELECT max(measure_partial_temporary_stops2.oid) AS max
-           FROM public.measure_partial_temporary_stops_oplog measure_partial_temporary_stops2
+           FROM measure_partial_temporary_stops_oplog measure_partial_temporary_stops2
           WHERE ((measure_partial_temporary_stops1.measure_sid = measure_partial_temporary_stops2.measure_sid) AND ((measure_partial_temporary_stops1.partial_temporary_stop_regulation_id)::text = (measure_partial_temporary_stops2.partial_temporary_stop_regulation_id)::text)))) AND ((measure_partial_temporary_stops1.operation)::text <> 'D'::text));
 
 
@@ -4141,7 +4128,7 @@ CREATE VIEW public.measure_partial_temporary_stops AS
 -- Name: measure_partial_temporary_stops_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_partial_temporary_stops_oid_seq
+CREATE SEQUENCE measure_partial_temporary_stops_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4153,14 +4140,14 @@ CREATE SEQUENCE public.measure_partial_temporary_stops_oid_seq
 -- Name: measure_partial_temporary_stops_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_partial_temporary_stops_oid_seq OWNED BY public.measure_partial_temporary_stops_oplog.oid;
+ALTER SEQUENCE measure_partial_temporary_stops_oid_seq OWNED BY measure_partial_temporary_stops_oplog.oid;
 
 
 --
 -- Name: measure_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_type_descriptions_oplog (
+CREATE TABLE measure_type_descriptions_oplog (
     measure_type_id character varying(3),
     language_id character varying(5),
     description text,
@@ -4179,7 +4166,7 @@ CREATE TABLE public.measure_type_descriptions_oplog (
 -- Name: measure_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_type_descriptions AS
+CREATE VIEW measure_type_descriptions AS
  SELECT measure_type_descriptions1.measure_type_id,
     measure_type_descriptions1.language_id,
     measure_type_descriptions1.description,
@@ -4190,9 +4177,9 @@ CREATE VIEW public.measure_type_descriptions AS
     measure_type_descriptions1.status,
     measure_type_descriptions1.workbasket_id,
     measure_type_descriptions1.workbasket_sequence_number
-   FROM public.measure_type_descriptions_oplog measure_type_descriptions1
+   FROM measure_type_descriptions_oplog measure_type_descriptions1
   WHERE ((measure_type_descriptions1.oid IN ( SELECT max(measure_type_descriptions2.oid) AS max
-           FROM public.measure_type_descriptions_oplog measure_type_descriptions2
+           FROM measure_type_descriptions_oplog measure_type_descriptions2
           WHERE ((measure_type_descriptions1.measure_type_id)::text = (measure_type_descriptions2.measure_type_id)::text))) AND ((measure_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -4200,7 +4187,7 @@ CREATE VIEW public.measure_type_descriptions AS
 -- Name: measure_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_type_descriptions_oid_seq
+CREATE SEQUENCE measure_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4212,14 +4199,14 @@ CREATE SEQUENCE public.measure_type_descriptions_oid_seq
 -- Name: measure_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_type_descriptions_oid_seq OWNED BY public.measure_type_descriptions_oplog.oid;
+ALTER SEQUENCE measure_type_descriptions_oid_seq OWNED BY measure_type_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_type_series_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_type_series_oplog (
+CREATE TABLE measure_type_series_oplog (
     measure_type_series_id character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4238,7 +4225,7 @@ CREATE TABLE public.measure_type_series_oplog (
 -- Name: measure_type_series; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_type_series AS
+CREATE VIEW measure_type_series AS
  SELECT measure_type_series1.measure_type_series_id,
     measure_type_series1.validity_start_date,
     measure_type_series1.validity_end_date,
@@ -4249,9 +4236,9 @@ CREATE VIEW public.measure_type_series AS
     measure_type_series1.status,
     measure_type_series1.workbasket_id,
     measure_type_series1.workbasket_sequence_number
-   FROM public.measure_type_series_oplog measure_type_series1
+   FROM measure_type_series_oplog measure_type_series1
   WHERE ((measure_type_series1.oid IN ( SELECT max(measure_type_series2.oid) AS max
-           FROM public.measure_type_series_oplog measure_type_series2
+           FROM measure_type_series_oplog measure_type_series2
           WHERE ((measure_type_series1.measure_type_series_id)::text = (measure_type_series2.measure_type_series_id)::text))) AND ((measure_type_series1.operation)::text <> 'D'::text));
 
 
@@ -4259,7 +4246,7 @@ CREATE VIEW public.measure_type_series AS
 -- Name: measure_type_series_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_type_series_descriptions_oplog (
+CREATE TABLE measure_type_series_descriptions_oplog (
     measure_type_series_id character varying(255),
     language_id character varying(5),
     description text,
@@ -4277,7 +4264,7 @@ CREATE TABLE public.measure_type_series_descriptions_oplog (
 -- Name: measure_type_series_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_type_series_descriptions AS
+CREATE VIEW measure_type_series_descriptions AS
  SELECT measure_type_series_descriptions1.measure_type_series_id,
     measure_type_series_descriptions1.language_id,
     measure_type_series_descriptions1.description,
@@ -4287,9 +4274,9 @@ CREATE VIEW public.measure_type_series_descriptions AS
     measure_type_series_descriptions1.status,
     measure_type_series_descriptions1.workbasket_id,
     measure_type_series_descriptions1.workbasket_sequence_number
-   FROM public.measure_type_series_descriptions_oplog measure_type_series_descriptions1
+   FROM measure_type_series_descriptions_oplog measure_type_series_descriptions1
   WHERE ((measure_type_series_descriptions1.oid IN ( SELECT max(measure_type_series_descriptions2.oid) AS max
-           FROM public.measure_type_series_descriptions_oplog measure_type_series_descriptions2
+           FROM measure_type_series_descriptions_oplog measure_type_series_descriptions2
           WHERE ((measure_type_series_descriptions1.measure_type_series_id)::text = (measure_type_series_descriptions2.measure_type_series_id)::text))) AND ((measure_type_series_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -4297,7 +4284,7 @@ CREATE VIEW public.measure_type_series_descriptions AS
 -- Name: measure_type_series_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_type_series_descriptions_oid_seq
+CREATE SEQUENCE measure_type_series_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4309,14 +4296,14 @@ CREATE SEQUENCE public.measure_type_series_descriptions_oid_seq
 -- Name: measure_type_series_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_type_series_descriptions_oid_seq OWNED BY public.measure_type_series_descriptions_oplog.oid;
+ALTER SEQUENCE measure_type_series_descriptions_oid_seq OWNED BY measure_type_series_descriptions_oplog.oid;
 
 
 --
 -- Name: measure_type_series_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_type_series_oid_seq
+CREATE SEQUENCE measure_type_series_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4328,14 +4315,14 @@ CREATE SEQUENCE public.measure_type_series_oid_seq
 -- Name: measure_type_series_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_type_series_oid_seq OWNED BY public.measure_type_series_oplog.oid;
+ALTER SEQUENCE measure_type_series_oid_seq OWNED BY measure_type_series_oplog.oid;
 
 
 --
 -- Name: measure_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measure_types_oplog (
+CREATE TABLE measure_types_oplog (
     measure_type_id character varying(3),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4362,7 +4349,7 @@ CREATE TABLE public.measure_types_oplog (
 -- Name: measure_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measure_types AS
+CREATE VIEW measure_types AS
  SELECT measure_types1.measure_type_id,
     measure_types1.validity_start_date,
     measure_types1.validity_end_date,
@@ -4381,9 +4368,9 @@ CREATE VIEW public.measure_types AS
     measure_types1.status,
     measure_types1.workbasket_id,
     measure_types1.workbasket_sequence_number
-   FROM public.measure_types_oplog measure_types1
+   FROM measure_types_oplog measure_types1
   WHERE ((measure_types1.oid IN ( SELECT max(measure_types2.oid) AS max
-           FROM public.measure_types_oplog measure_types2
+           FROM measure_types_oplog measure_types2
           WHERE ((measure_types1.measure_type_id)::text = (measure_types2.measure_type_id)::text))) AND ((measure_types1.operation)::text <> 'D'::text));
 
 
@@ -4391,7 +4378,7 @@ CREATE VIEW public.measure_types AS
 -- Name: measure_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measure_types_oid_seq
+CREATE SEQUENCE measure_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4403,14 +4390,14 @@ CREATE SEQUENCE public.measure_types_oid_seq
 -- Name: measure_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measure_types_oid_seq OWNED BY public.measure_types_oplog.oid;
+ALTER SEQUENCE measure_types_oid_seq OWNED BY measure_types_oplog.oid;
 
 
 --
 -- Name: measurement_unit_abbreviations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measurement_unit_abbreviations (
+CREATE TABLE measurement_unit_abbreviations (
     id integer NOT NULL,
     abbreviation text,
     measurement_unit_code text,
@@ -4422,7 +4409,7 @@ CREATE TABLE public.measurement_unit_abbreviations (
 -- Name: measurement_unit_abbreviations_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measurement_unit_abbreviations_id_seq
+CREATE SEQUENCE measurement_unit_abbreviations_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4434,14 +4421,14 @@ CREATE SEQUENCE public.measurement_unit_abbreviations_id_seq
 -- Name: measurement_unit_abbreviations_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measurement_unit_abbreviations_id_seq OWNED BY public.measurement_unit_abbreviations.id;
+ALTER SEQUENCE measurement_unit_abbreviations_id_seq OWNED BY measurement_unit_abbreviations.id;
 
 
 --
 -- Name: measurement_unit_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measurement_unit_descriptions_oplog (
+CREATE TABLE measurement_unit_descriptions_oplog (
     measurement_unit_code character varying(3),
     language_id character varying(5),
     description text,
@@ -4459,7 +4446,7 @@ CREATE TABLE public.measurement_unit_descriptions_oplog (
 -- Name: measurement_unit_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measurement_unit_descriptions AS
+CREATE VIEW measurement_unit_descriptions AS
  SELECT measurement_unit_descriptions1.measurement_unit_code,
     measurement_unit_descriptions1.language_id,
     measurement_unit_descriptions1.description,
@@ -4469,9 +4456,9 @@ CREATE VIEW public.measurement_unit_descriptions AS
     measurement_unit_descriptions1.status,
     measurement_unit_descriptions1.workbasket_id,
     measurement_unit_descriptions1.workbasket_sequence_number
-   FROM public.measurement_unit_descriptions_oplog measurement_unit_descriptions1
+   FROM measurement_unit_descriptions_oplog measurement_unit_descriptions1
   WHERE ((measurement_unit_descriptions1.oid IN ( SELECT max(measurement_unit_descriptions2.oid) AS max
-           FROM public.measurement_unit_descriptions_oplog measurement_unit_descriptions2
+           FROM measurement_unit_descriptions_oplog measurement_unit_descriptions2
           WHERE ((measurement_unit_descriptions1.measurement_unit_code)::text = (measurement_unit_descriptions2.measurement_unit_code)::text))) AND ((measurement_unit_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -4479,7 +4466,7 @@ CREATE VIEW public.measurement_unit_descriptions AS
 -- Name: measurement_unit_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measurement_unit_descriptions_oid_seq
+CREATE SEQUENCE measurement_unit_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4491,14 +4478,14 @@ CREATE SEQUENCE public.measurement_unit_descriptions_oid_seq
 -- Name: measurement_unit_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measurement_unit_descriptions_oid_seq OWNED BY public.measurement_unit_descriptions_oplog.oid;
+ALTER SEQUENCE measurement_unit_descriptions_oid_seq OWNED BY measurement_unit_descriptions_oplog.oid;
 
 
 --
 -- Name: measurement_unit_qualifier_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measurement_unit_qualifier_descriptions_oplog (
+CREATE TABLE measurement_unit_qualifier_descriptions_oplog (
     measurement_unit_qualifier_code character varying(1),
     language_id character varying(5),
     description text,
@@ -4516,7 +4503,7 @@ CREATE TABLE public.measurement_unit_qualifier_descriptions_oplog (
 -- Name: measurement_unit_qualifier_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measurement_unit_qualifier_descriptions AS
+CREATE VIEW measurement_unit_qualifier_descriptions AS
  SELECT measurement_unit_qualifier_descriptions1.measurement_unit_qualifier_code,
     measurement_unit_qualifier_descriptions1.language_id,
     measurement_unit_qualifier_descriptions1.description,
@@ -4526,9 +4513,9 @@ CREATE VIEW public.measurement_unit_qualifier_descriptions AS
     measurement_unit_qualifier_descriptions1.status,
     measurement_unit_qualifier_descriptions1.workbasket_id,
     measurement_unit_qualifier_descriptions1.workbasket_sequence_number
-   FROM public.measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions1
+   FROM measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions1
   WHERE ((measurement_unit_qualifier_descriptions1.oid IN ( SELECT max(measurement_unit_qualifier_descriptions2.oid) AS max
-           FROM public.measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions2
+           FROM measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions2
           WHERE ((measurement_unit_qualifier_descriptions1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifier_descriptions2.measurement_unit_qualifier_code)::text))) AND ((measurement_unit_qualifier_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -4536,7 +4523,7 @@ CREATE VIEW public.measurement_unit_qualifier_descriptions AS
 -- Name: measurement_unit_qualifier_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measurement_unit_qualifier_descriptions_oid_seq
+CREATE SEQUENCE measurement_unit_qualifier_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4548,14 +4535,14 @@ CREATE SEQUENCE public.measurement_unit_qualifier_descriptions_oid_seq
 -- Name: measurement_unit_qualifier_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measurement_unit_qualifier_descriptions_oid_seq OWNED BY public.measurement_unit_qualifier_descriptions_oplog.oid;
+ALTER SEQUENCE measurement_unit_qualifier_descriptions_oid_seq OWNED BY measurement_unit_qualifier_descriptions_oplog.oid;
 
 
 --
 -- Name: measurement_unit_qualifiers_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measurement_unit_qualifiers_oplog (
+CREATE TABLE measurement_unit_qualifiers_oplog (
     measurement_unit_qualifier_code character varying(1),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4573,7 +4560,7 @@ CREATE TABLE public.measurement_unit_qualifiers_oplog (
 -- Name: measurement_unit_qualifiers; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measurement_unit_qualifiers AS
+CREATE VIEW measurement_unit_qualifiers AS
  SELECT measurement_unit_qualifiers1.measurement_unit_qualifier_code,
     measurement_unit_qualifiers1.validity_start_date,
     measurement_unit_qualifiers1.validity_end_date,
@@ -4583,9 +4570,9 @@ CREATE VIEW public.measurement_unit_qualifiers AS
     measurement_unit_qualifiers1.status,
     measurement_unit_qualifiers1.workbasket_id,
     measurement_unit_qualifiers1.workbasket_sequence_number
-   FROM public.measurement_unit_qualifiers_oplog measurement_unit_qualifiers1
+   FROM measurement_unit_qualifiers_oplog measurement_unit_qualifiers1
   WHERE ((measurement_unit_qualifiers1.oid IN ( SELECT max(measurement_unit_qualifiers2.oid) AS max
-           FROM public.measurement_unit_qualifiers_oplog measurement_unit_qualifiers2
+           FROM measurement_unit_qualifiers_oplog measurement_unit_qualifiers2
           WHERE ((measurement_unit_qualifiers1.measurement_unit_qualifier_code)::text = (measurement_unit_qualifiers2.measurement_unit_qualifier_code)::text))) AND ((measurement_unit_qualifiers1.operation)::text <> 'D'::text));
 
 
@@ -4593,7 +4580,7 @@ CREATE VIEW public.measurement_unit_qualifiers AS
 -- Name: measurement_unit_qualifiers_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measurement_unit_qualifiers_oid_seq
+CREATE SEQUENCE measurement_unit_qualifiers_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4605,14 +4592,14 @@ CREATE SEQUENCE public.measurement_unit_qualifiers_oid_seq
 -- Name: measurement_unit_qualifiers_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measurement_unit_qualifiers_oid_seq OWNED BY public.measurement_unit_qualifiers_oplog.oid;
+ALTER SEQUENCE measurement_unit_qualifiers_oid_seq OWNED BY measurement_unit_qualifiers_oplog.oid;
 
 
 --
 -- Name: measurement_units_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measurement_units_oplog (
+CREATE TABLE measurement_units_oplog (
     measurement_unit_code character varying(3),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -4630,7 +4617,7 @@ CREATE TABLE public.measurement_units_oplog (
 -- Name: measurement_units; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measurement_units AS
+CREATE VIEW measurement_units AS
  SELECT measurement_units1.measurement_unit_code,
     measurement_units1.validity_start_date,
     measurement_units1.validity_end_date,
@@ -4640,9 +4627,9 @@ CREATE VIEW public.measurement_units AS
     measurement_units1.status,
     measurement_units1.workbasket_id,
     measurement_units1.workbasket_sequence_number
-   FROM public.measurement_units_oplog measurement_units1
+   FROM measurement_units_oplog measurement_units1
   WHERE ((measurement_units1.oid IN ( SELECT max(measurement_units2.oid) AS max
-           FROM public.measurement_units_oplog measurement_units2
+           FROM measurement_units_oplog measurement_units2
           WHERE ((measurement_units1.measurement_unit_code)::text = (measurement_units2.measurement_unit_code)::text))) AND ((measurement_units1.operation)::text <> 'D'::text));
 
 
@@ -4650,7 +4637,7 @@ CREATE VIEW public.measurement_units AS
 -- Name: measurement_units_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measurement_units_oid_seq
+CREATE SEQUENCE measurement_units_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4662,14 +4649,14 @@ CREATE SEQUENCE public.measurement_units_oid_seq
 -- Name: measurement_units_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measurement_units_oid_seq OWNED BY public.measurement_units_oplog.oid;
+ALTER SEQUENCE measurement_units_oid_seq OWNED BY measurement_units_oplog.oid;
 
 
 --
 -- Name: measurements_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measurements_oplog (
+CREATE TABLE measurements_oplog (
     measurement_unit_code character varying(3),
     measurement_unit_qualifier_code character varying(1),
     validity_start_date timestamp without time zone,
@@ -4688,7 +4675,7 @@ CREATE TABLE public.measurements_oplog (
 -- Name: measurements; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measurements AS
+CREATE VIEW measurements AS
  SELECT measurements1.measurement_unit_code,
     measurements1.measurement_unit_qualifier_code,
     measurements1.validity_start_date,
@@ -4699,9 +4686,9 @@ CREATE VIEW public.measurements AS
     measurements1.status,
     measurements1.workbasket_id,
     measurements1.workbasket_sequence_number
-   FROM public.measurements_oplog measurements1
+   FROM measurements_oplog measurements1
   WHERE ((measurements1.oid IN ( SELECT max(measurements2.oid) AS max
-           FROM public.measurements_oplog measurements2
+           FROM measurements_oplog measurements2
           WHERE (((measurements1.measurement_unit_code)::text = (measurements2.measurement_unit_code)::text) AND ((measurements1.measurement_unit_qualifier_code)::text = (measurements2.measurement_unit_qualifier_code)::text)))) AND ((measurements1.operation)::text <> 'D'::text));
 
 
@@ -4709,7 +4696,7 @@ CREATE VIEW public.measurements AS
 -- Name: measurements_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measurements_oid_seq
+CREATE SEQUENCE measurements_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4721,14 +4708,14 @@ CREATE SEQUENCE public.measurements_oid_seq
 -- Name: measurements_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measurements_oid_seq OWNED BY public.measurements_oplog.oid;
+ALTER SEQUENCE measurements_oid_seq OWNED BY measurements_oplog.oid;
 
 
 --
 -- Name: measures_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.measures_oplog (
+CREATE TABLE measures_oplog (
     measure_sid integer,
     measure_type_id character varying(3),
     geographical_area_id character varying(255),
@@ -4773,7 +4760,7 @@ CREATE TABLE public.measures_oplog (
 -- Name: measures; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.measures AS
+CREATE VIEW measures AS
  SELECT measures1.measure_sid,
     measures1.measure_type_id,
     measures1.geographical_area_id,
@@ -4810,9 +4797,9 @@ CREATE VIEW public.measures AS
     measures1.searchable_data,
     measures1.searchable_data_updated_at,
     measures1.workbasket_sequence_number
-   FROM public.measures_oplog measures1
+   FROM measures_oplog measures1
   WHERE ((measures1.oid IN ( SELECT max(measures2.oid) AS max
-           FROM public.measures_oplog measures2
+           FROM measures_oplog measures2
           WHERE (measures1.measure_sid = measures2.measure_sid))) AND ((measures1.operation)::text <> 'D'::text));
 
 
@@ -4820,7 +4807,7 @@ CREATE VIEW public.measures AS
 -- Name: measures_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.measures_oid_seq
+CREATE SEQUENCE measures_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4832,14 +4819,14 @@ CREATE SEQUENCE public.measures_oid_seq
 -- Name: measures_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.measures_oid_seq OWNED BY public.measures_oplog.oid;
+ALTER SEQUENCE measures_oid_seq OWNED BY measures_oplog.oid;
 
 
 --
 -- Name: meursing_additional_codes_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.meursing_additional_codes_oplog (
+CREATE TABLE meursing_additional_codes_oplog (
     meursing_additional_code_sid integer,
     additional_code character varying(3),
     validity_start_date timestamp without time zone,
@@ -4858,7 +4845,7 @@ CREATE TABLE public.meursing_additional_codes_oplog (
 -- Name: meursing_additional_codes; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.meursing_additional_codes AS
+CREATE VIEW meursing_additional_codes AS
  SELECT meursing_additional_codes1.meursing_additional_code_sid,
     meursing_additional_codes1.additional_code,
     meursing_additional_codes1.validity_start_date,
@@ -4869,9 +4856,9 @@ CREATE VIEW public.meursing_additional_codes AS
     meursing_additional_codes1.status,
     meursing_additional_codes1.workbasket_id,
     meursing_additional_codes1.workbasket_sequence_number
-   FROM public.meursing_additional_codes_oplog meursing_additional_codes1
+   FROM meursing_additional_codes_oplog meursing_additional_codes1
   WHERE ((meursing_additional_codes1.oid IN ( SELECT max(meursing_additional_codes2.oid) AS max
-           FROM public.meursing_additional_codes_oplog meursing_additional_codes2
+           FROM meursing_additional_codes_oplog meursing_additional_codes2
           WHERE (meursing_additional_codes1.meursing_additional_code_sid = meursing_additional_codes2.meursing_additional_code_sid))) AND ((meursing_additional_codes1.operation)::text <> 'D'::text));
 
 
@@ -4879,7 +4866,7 @@ CREATE VIEW public.meursing_additional_codes AS
 -- Name: meursing_additional_codes_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.meursing_additional_codes_oid_seq
+CREATE SEQUENCE meursing_additional_codes_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4891,14 +4878,14 @@ CREATE SEQUENCE public.meursing_additional_codes_oid_seq
 -- Name: meursing_additional_codes_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.meursing_additional_codes_oid_seq OWNED BY public.meursing_additional_codes_oplog.oid;
+ALTER SEQUENCE meursing_additional_codes_oid_seq OWNED BY meursing_additional_codes_oplog.oid;
 
 
 --
 -- Name: meursing_heading_texts_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.meursing_heading_texts_oplog (
+CREATE TABLE meursing_heading_texts_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number integer,
     row_column_code integer,
@@ -4918,7 +4905,7 @@ CREATE TABLE public.meursing_heading_texts_oplog (
 -- Name: meursing_heading_texts; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.meursing_heading_texts AS
+CREATE VIEW meursing_heading_texts AS
  SELECT meursing_heading_texts1.meursing_table_plan_id,
     meursing_heading_texts1.meursing_heading_number,
     meursing_heading_texts1.row_column_code,
@@ -4930,9 +4917,9 @@ CREATE VIEW public.meursing_heading_texts AS
     meursing_heading_texts1.status,
     meursing_heading_texts1.workbasket_id,
     meursing_heading_texts1.workbasket_sequence_number
-   FROM public.meursing_heading_texts_oplog meursing_heading_texts1
+   FROM meursing_heading_texts_oplog meursing_heading_texts1
   WHERE ((meursing_heading_texts1.oid IN ( SELECT max(meursing_heading_texts2.oid) AS max
-           FROM public.meursing_heading_texts_oplog meursing_heading_texts2
+           FROM meursing_heading_texts_oplog meursing_heading_texts2
           WHERE (((meursing_heading_texts1.meursing_table_plan_id)::text = (meursing_heading_texts2.meursing_table_plan_id)::text) AND (meursing_heading_texts1.meursing_heading_number = meursing_heading_texts2.meursing_heading_number) AND (meursing_heading_texts1.row_column_code = meursing_heading_texts2.row_column_code)))) AND ((meursing_heading_texts1.operation)::text <> 'D'::text));
 
 
@@ -4940,7 +4927,7 @@ CREATE VIEW public.meursing_heading_texts AS
 -- Name: meursing_heading_texts_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.meursing_heading_texts_oid_seq
+CREATE SEQUENCE meursing_heading_texts_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -4952,14 +4939,14 @@ CREATE SEQUENCE public.meursing_heading_texts_oid_seq
 -- Name: meursing_heading_texts_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.meursing_heading_texts_oid_seq OWNED BY public.meursing_heading_texts_oplog.oid;
+ALTER SEQUENCE meursing_heading_texts_oid_seq OWNED BY meursing_heading_texts_oplog.oid;
 
 
 --
 -- Name: meursing_headings_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.meursing_headings_oplog (
+CREATE TABLE meursing_headings_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number text,
     row_column_code integer,
@@ -4979,7 +4966,7 @@ CREATE TABLE public.meursing_headings_oplog (
 -- Name: meursing_headings; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.meursing_headings AS
+CREATE VIEW meursing_headings AS
  SELECT meursing_headings1.meursing_table_plan_id,
     meursing_headings1.meursing_heading_number,
     meursing_headings1.row_column_code,
@@ -4991,9 +4978,9 @@ CREATE VIEW public.meursing_headings AS
     meursing_headings1.status,
     meursing_headings1.workbasket_id,
     meursing_headings1.workbasket_sequence_number
-   FROM public.meursing_headings_oplog meursing_headings1
+   FROM meursing_headings_oplog meursing_headings1
   WHERE ((meursing_headings1.oid IN ( SELECT max(meursing_headings2.oid) AS max
-           FROM public.meursing_headings_oplog meursing_headings2
+           FROM meursing_headings_oplog meursing_headings2
           WHERE (((meursing_headings1.meursing_table_plan_id)::text = (meursing_headings2.meursing_table_plan_id)::text) AND (meursing_headings1.meursing_heading_number = meursing_headings2.meursing_heading_number) AND (meursing_headings1.row_column_code = meursing_headings2.row_column_code)))) AND ((meursing_headings1.operation)::text <> 'D'::text));
 
 
@@ -5001,7 +4988,7 @@ CREATE VIEW public.meursing_headings AS
 -- Name: meursing_headings_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.meursing_headings_oid_seq
+CREATE SEQUENCE meursing_headings_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5013,14 +5000,14 @@ CREATE SEQUENCE public.meursing_headings_oid_seq
 -- Name: meursing_headings_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.meursing_headings_oid_seq OWNED BY public.meursing_headings_oplog.oid;
+ALTER SEQUENCE meursing_headings_oid_seq OWNED BY meursing_headings_oplog.oid;
 
 
 --
 -- Name: meursing_subheadings_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.meursing_subheadings_oplog (
+CREATE TABLE meursing_subheadings_oplog (
     meursing_table_plan_id character varying(2),
     meursing_heading_number integer,
     row_column_code integer,
@@ -5042,7 +5029,7 @@ CREATE TABLE public.meursing_subheadings_oplog (
 -- Name: meursing_subheadings; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.meursing_subheadings AS
+CREATE VIEW meursing_subheadings AS
  SELECT meursing_subheadings1.meursing_table_plan_id,
     meursing_subheadings1.meursing_heading_number,
     meursing_subheadings1.row_column_code,
@@ -5056,9 +5043,9 @@ CREATE VIEW public.meursing_subheadings AS
     meursing_subheadings1.status,
     meursing_subheadings1.workbasket_id,
     meursing_subheadings1.workbasket_sequence_number
-   FROM public.meursing_subheadings_oplog meursing_subheadings1
+   FROM meursing_subheadings_oplog meursing_subheadings1
   WHERE ((meursing_subheadings1.oid IN ( SELECT max(meursing_subheadings2.oid) AS max
-           FROM public.meursing_subheadings_oplog meursing_subheadings2
+           FROM meursing_subheadings_oplog meursing_subheadings2
           WHERE (((meursing_subheadings1.meursing_table_plan_id)::text = (meursing_subheadings2.meursing_table_plan_id)::text) AND (meursing_subheadings1.meursing_heading_number = meursing_subheadings2.meursing_heading_number) AND (meursing_subheadings1.row_column_code = meursing_subheadings2.row_column_code) AND (meursing_subheadings1.subheading_sequence_number = meursing_subheadings2.subheading_sequence_number)))) AND ((meursing_subheadings1.operation)::text <> 'D'::text));
 
 
@@ -5066,7 +5053,7 @@ CREATE VIEW public.meursing_subheadings AS
 -- Name: meursing_subheadings_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.meursing_subheadings_oid_seq
+CREATE SEQUENCE meursing_subheadings_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5078,14 +5065,14 @@ CREATE SEQUENCE public.meursing_subheadings_oid_seq
 -- Name: meursing_subheadings_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.meursing_subheadings_oid_seq OWNED BY public.meursing_subheadings_oplog.oid;
+ALTER SEQUENCE meursing_subheadings_oid_seq OWNED BY meursing_subheadings_oplog.oid;
 
 
 --
 -- Name: meursing_table_cell_components_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.meursing_table_cell_components_oplog (
+CREATE TABLE meursing_table_cell_components_oplog (
     meursing_additional_code_sid integer,
     meursing_table_plan_id character varying(2),
     heading_number integer,
@@ -5108,7 +5095,7 @@ CREATE TABLE public.meursing_table_cell_components_oplog (
 -- Name: meursing_table_cell_components; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.meursing_table_cell_components AS
+CREATE VIEW meursing_table_cell_components AS
  SELECT meursing_table_cell_components1.meursing_additional_code_sid,
     meursing_table_cell_components1.meursing_table_plan_id,
     meursing_table_cell_components1.heading_number,
@@ -5123,9 +5110,9 @@ CREATE VIEW public.meursing_table_cell_components AS
     meursing_table_cell_components1.status,
     meursing_table_cell_components1.workbasket_id,
     meursing_table_cell_components1.workbasket_sequence_number
-   FROM public.meursing_table_cell_components_oplog meursing_table_cell_components1
+   FROM meursing_table_cell_components_oplog meursing_table_cell_components1
   WHERE ((meursing_table_cell_components1.oid IN ( SELECT max(meursing_table_cell_components2.oid) AS max
-           FROM public.meursing_table_cell_components_oplog meursing_table_cell_components2
+           FROM meursing_table_cell_components_oplog meursing_table_cell_components2
           WHERE (((meursing_table_cell_components1.meursing_table_plan_id)::text = (meursing_table_cell_components2.meursing_table_plan_id)::text) AND (meursing_table_cell_components1.heading_number = meursing_table_cell_components2.heading_number) AND (meursing_table_cell_components1.row_column_code = meursing_table_cell_components2.row_column_code) AND (meursing_table_cell_components1.meursing_additional_code_sid = meursing_table_cell_components2.meursing_additional_code_sid)))) AND ((meursing_table_cell_components1.operation)::text <> 'D'::text));
 
 
@@ -5133,7 +5120,7 @@ CREATE VIEW public.meursing_table_cell_components AS
 -- Name: meursing_table_cell_components_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.meursing_table_cell_components_oid_seq
+CREATE SEQUENCE meursing_table_cell_components_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5145,14 +5132,14 @@ CREATE SEQUENCE public.meursing_table_cell_components_oid_seq
 -- Name: meursing_table_cell_components_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.meursing_table_cell_components_oid_seq OWNED BY public.meursing_table_cell_components_oplog.oid;
+ALTER SEQUENCE meursing_table_cell_components_oid_seq OWNED BY meursing_table_cell_components_oplog.oid;
 
 
 --
 -- Name: meursing_table_plans_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.meursing_table_plans_oplog (
+CREATE TABLE meursing_table_plans_oplog (
     meursing_table_plan_id character varying(2),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -5170,7 +5157,7 @@ CREATE TABLE public.meursing_table_plans_oplog (
 -- Name: meursing_table_plans; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.meursing_table_plans AS
+CREATE VIEW meursing_table_plans AS
  SELECT meursing_table_plans1.meursing_table_plan_id,
     meursing_table_plans1.validity_start_date,
     meursing_table_plans1.validity_end_date,
@@ -5180,9 +5167,9 @@ CREATE VIEW public.meursing_table_plans AS
     meursing_table_plans1.status,
     meursing_table_plans1.workbasket_id,
     meursing_table_plans1.workbasket_sequence_number
-   FROM public.meursing_table_plans_oplog meursing_table_plans1
+   FROM meursing_table_plans_oplog meursing_table_plans1
   WHERE ((meursing_table_plans1.oid IN ( SELECT max(meursing_table_plans2.oid) AS max
-           FROM public.meursing_table_plans_oplog meursing_table_plans2
+           FROM meursing_table_plans_oplog meursing_table_plans2
           WHERE ((meursing_table_plans1.meursing_table_plan_id)::text = (meursing_table_plans2.meursing_table_plan_id)::text))) AND ((meursing_table_plans1.operation)::text <> 'D'::text));
 
 
@@ -5190,7 +5177,7 @@ CREATE VIEW public.meursing_table_plans AS
 -- Name: meursing_table_plans_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.meursing_table_plans_oid_seq
+CREATE SEQUENCE meursing_table_plans_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5202,14 +5189,14 @@ CREATE SEQUENCE public.meursing_table_plans_oid_seq
 -- Name: meursing_table_plans_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.meursing_table_plans_oid_seq OWNED BY public.meursing_table_plans_oplog.oid;
+ALTER SEQUENCE meursing_table_plans_oid_seq OWNED BY meursing_table_plans_oplog.oid;
 
 
 --
 -- Name: modification_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.modification_regulations_oplog (
+CREATE TABLE modification_regulations_oplog (
     modification_regulation_role integer,
     modification_regulation_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -5245,7 +5232,7 @@ CREATE TABLE public.modification_regulations_oplog (
 -- Name: modification_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.modification_regulations AS
+CREATE VIEW modification_regulations AS
  SELECT modification_regulations1.modification_regulation_role,
     modification_regulations1.modification_regulation_id,
     modification_regulations1.validity_start_date,
@@ -5273,9 +5260,9 @@ CREATE VIEW public.modification_regulations AS
     modification_regulations1.status,
     modification_regulations1.workbasket_id,
     modification_regulations1.workbasket_sequence_number
-   FROM public.modification_regulations_oplog modification_regulations1
+   FROM modification_regulations_oplog modification_regulations1
   WHERE ((modification_regulations1.oid IN ( SELECT max(modification_regulations2.oid) AS max
-           FROM public.modification_regulations_oplog modification_regulations2
+           FROM modification_regulations_oplog modification_regulations2
           WHERE (((modification_regulations1.modification_regulation_id)::text = (modification_regulations2.modification_regulation_id)::text) AND (modification_regulations1.modification_regulation_role = modification_regulations2.modification_regulation_role)))) AND ((modification_regulations1.operation)::text <> 'D'::text));
 
 
@@ -5283,7 +5270,7 @@ CREATE VIEW public.modification_regulations AS
 -- Name: modification_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.modification_regulations_oid_seq
+CREATE SEQUENCE modification_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5295,14 +5282,14 @@ CREATE SEQUENCE public.modification_regulations_oid_seq
 -- Name: modification_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.modification_regulations_oid_seq OWNED BY public.modification_regulations_oplog.oid;
+ALTER SEQUENCE modification_regulations_oid_seq OWNED BY modification_regulations_oplog.oid;
 
 
 --
 -- Name: monetary_exchange_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.monetary_exchange_periods_oplog (
+CREATE TABLE monetary_exchange_periods_oplog (
     monetary_exchange_period_sid integer,
     parent_monetary_unit_code character varying(255),
     validity_start_date timestamp without time zone,
@@ -5321,7 +5308,7 @@ CREATE TABLE public.monetary_exchange_periods_oplog (
 -- Name: monetary_exchange_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.monetary_exchange_periods AS
+CREATE VIEW monetary_exchange_periods AS
  SELECT monetary_exchange_periods1.monetary_exchange_period_sid,
     monetary_exchange_periods1.parent_monetary_unit_code,
     monetary_exchange_periods1.validity_start_date,
@@ -5332,9 +5319,9 @@ CREATE VIEW public.monetary_exchange_periods AS
     monetary_exchange_periods1.status,
     monetary_exchange_periods1.workbasket_id,
     monetary_exchange_periods1.workbasket_sequence_number
-   FROM public.monetary_exchange_periods_oplog monetary_exchange_periods1
+   FROM monetary_exchange_periods_oplog monetary_exchange_periods1
   WHERE ((monetary_exchange_periods1.oid IN ( SELECT max(monetary_exchange_periods2.oid) AS max
-           FROM public.monetary_exchange_periods_oplog monetary_exchange_periods2
+           FROM monetary_exchange_periods_oplog monetary_exchange_periods2
           WHERE ((monetary_exchange_periods1.monetary_exchange_period_sid = monetary_exchange_periods2.monetary_exchange_period_sid) AND ((monetary_exchange_periods1.parent_monetary_unit_code)::text = (monetary_exchange_periods2.parent_monetary_unit_code)::text)))) AND ((monetary_exchange_periods1.operation)::text <> 'D'::text));
 
 
@@ -5342,7 +5329,7 @@ CREATE VIEW public.monetary_exchange_periods AS
 -- Name: monetary_exchange_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.monetary_exchange_periods_oid_seq
+CREATE SEQUENCE monetary_exchange_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5354,14 +5341,14 @@ CREATE SEQUENCE public.monetary_exchange_periods_oid_seq
 -- Name: monetary_exchange_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.monetary_exchange_periods_oid_seq OWNED BY public.monetary_exchange_periods_oplog.oid;
+ALTER SEQUENCE monetary_exchange_periods_oid_seq OWNED BY monetary_exchange_periods_oplog.oid;
 
 
 --
 -- Name: monetary_exchange_rates_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.monetary_exchange_rates_oplog (
+CREATE TABLE monetary_exchange_rates_oplog (
     monetary_exchange_period_sid integer,
     child_monetary_unit_code character varying(255),
     exchange_rate numeric(16,8),
@@ -5379,7 +5366,7 @@ CREATE TABLE public.monetary_exchange_rates_oplog (
 -- Name: monetary_exchange_rates; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.monetary_exchange_rates AS
+CREATE VIEW monetary_exchange_rates AS
  SELECT monetary_exchange_rates1.monetary_exchange_period_sid,
     monetary_exchange_rates1.child_monetary_unit_code,
     monetary_exchange_rates1.exchange_rate,
@@ -5389,9 +5376,9 @@ CREATE VIEW public.monetary_exchange_rates AS
     monetary_exchange_rates1.status,
     monetary_exchange_rates1.workbasket_id,
     monetary_exchange_rates1.workbasket_sequence_number
-   FROM public.monetary_exchange_rates_oplog monetary_exchange_rates1
+   FROM monetary_exchange_rates_oplog monetary_exchange_rates1
   WHERE ((monetary_exchange_rates1.oid IN ( SELECT max(monetary_exchange_rates2.oid) AS max
-           FROM public.monetary_exchange_rates_oplog monetary_exchange_rates2
+           FROM monetary_exchange_rates_oplog monetary_exchange_rates2
           WHERE ((monetary_exchange_rates1.monetary_exchange_period_sid = monetary_exchange_rates2.monetary_exchange_period_sid) AND ((monetary_exchange_rates1.child_monetary_unit_code)::text = (monetary_exchange_rates2.child_monetary_unit_code)::text)))) AND ((monetary_exchange_rates1.operation)::text <> 'D'::text));
 
 
@@ -5399,7 +5386,7 @@ CREATE VIEW public.monetary_exchange_rates AS
 -- Name: monetary_exchange_rates_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.monetary_exchange_rates_oid_seq
+CREATE SEQUENCE monetary_exchange_rates_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5411,14 +5398,14 @@ CREATE SEQUENCE public.monetary_exchange_rates_oid_seq
 -- Name: monetary_exchange_rates_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.monetary_exchange_rates_oid_seq OWNED BY public.monetary_exchange_rates_oplog.oid;
+ALTER SEQUENCE monetary_exchange_rates_oid_seq OWNED BY monetary_exchange_rates_oplog.oid;
 
 
 --
 -- Name: monetary_unit_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.monetary_unit_descriptions_oplog (
+CREATE TABLE monetary_unit_descriptions_oplog (
     monetary_unit_code character varying(255),
     language_id character varying(5),
     description text,
@@ -5436,7 +5423,7 @@ CREATE TABLE public.monetary_unit_descriptions_oplog (
 -- Name: monetary_unit_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.monetary_unit_descriptions AS
+CREATE VIEW monetary_unit_descriptions AS
  SELECT monetary_unit_descriptions1.monetary_unit_code,
     monetary_unit_descriptions1.language_id,
     monetary_unit_descriptions1.description,
@@ -5446,9 +5433,9 @@ CREATE VIEW public.monetary_unit_descriptions AS
     monetary_unit_descriptions1.status,
     monetary_unit_descriptions1.workbasket_id,
     monetary_unit_descriptions1.workbasket_sequence_number
-   FROM public.monetary_unit_descriptions_oplog monetary_unit_descriptions1
+   FROM monetary_unit_descriptions_oplog monetary_unit_descriptions1
   WHERE ((monetary_unit_descriptions1.oid IN ( SELECT max(monetary_unit_descriptions2.oid) AS max
-           FROM public.monetary_unit_descriptions_oplog monetary_unit_descriptions2
+           FROM monetary_unit_descriptions_oplog monetary_unit_descriptions2
           WHERE ((monetary_unit_descriptions1.monetary_unit_code)::text = (monetary_unit_descriptions2.monetary_unit_code)::text))) AND ((monetary_unit_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -5456,7 +5443,7 @@ CREATE VIEW public.monetary_unit_descriptions AS
 -- Name: monetary_unit_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.monetary_unit_descriptions_oid_seq
+CREATE SEQUENCE monetary_unit_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5468,14 +5455,14 @@ CREATE SEQUENCE public.monetary_unit_descriptions_oid_seq
 -- Name: monetary_unit_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.monetary_unit_descriptions_oid_seq OWNED BY public.monetary_unit_descriptions_oplog.oid;
+ALTER SEQUENCE monetary_unit_descriptions_oid_seq OWNED BY monetary_unit_descriptions_oplog.oid;
 
 
 --
 -- Name: monetary_units_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.monetary_units_oplog (
+CREATE TABLE monetary_units_oplog (
     monetary_unit_code character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -5493,7 +5480,7 @@ CREATE TABLE public.monetary_units_oplog (
 -- Name: monetary_units; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.monetary_units AS
+CREATE VIEW monetary_units AS
  SELECT monetary_units1.monetary_unit_code,
     monetary_units1.validity_start_date,
     monetary_units1.validity_end_date,
@@ -5503,9 +5490,9 @@ CREATE VIEW public.monetary_units AS
     monetary_units1.status,
     monetary_units1.workbasket_id,
     monetary_units1.workbasket_sequence_number
-   FROM public.monetary_units_oplog monetary_units1
+   FROM monetary_units_oplog monetary_units1
   WHERE ((monetary_units1.oid IN ( SELECT max(monetary_units2.oid) AS max
-           FROM public.monetary_units_oplog monetary_units2
+           FROM monetary_units_oplog monetary_units2
           WHERE ((monetary_units1.monetary_unit_code)::text = (monetary_units2.monetary_unit_code)::text))) AND ((monetary_units1.operation)::text <> 'D'::text));
 
 
@@ -5513,7 +5500,7 @@ CREATE VIEW public.monetary_units AS
 -- Name: monetary_units_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.monetary_units_oid_seq
+CREATE SEQUENCE monetary_units_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5525,14 +5512,14 @@ CREATE SEQUENCE public.monetary_units_oid_seq
 -- Name: monetary_units_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.monetary_units_oid_seq OWNED BY public.monetary_units_oplog.oid;
+ALTER SEQUENCE monetary_units_oid_seq OWNED BY monetary_units_oplog.oid;
 
 
 --
 -- Name: nomenclature_group_memberships_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.nomenclature_group_memberships_oplog (
+CREATE TABLE nomenclature_group_memberships_oplog (
     goods_nomenclature_sid integer,
     goods_nomenclature_group_type character varying(1),
     goods_nomenclature_group_id character varying(6),
@@ -5554,7 +5541,7 @@ CREATE TABLE public.nomenclature_group_memberships_oplog (
 -- Name: nomenclature_group_memberships; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.nomenclature_group_memberships AS
+CREATE VIEW nomenclature_group_memberships AS
  SELECT nomenclature_group_memberships1.goods_nomenclature_sid,
     nomenclature_group_memberships1.goods_nomenclature_group_type,
     nomenclature_group_memberships1.goods_nomenclature_group_id,
@@ -5568,9 +5555,9 @@ CREATE VIEW public.nomenclature_group_memberships AS
     nomenclature_group_memberships1.status,
     nomenclature_group_memberships1.workbasket_id,
     nomenclature_group_memberships1.workbasket_sequence_number
-   FROM public.nomenclature_group_memberships_oplog nomenclature_group_memberships1
+   FROM nomenclature_group_memberships_oplog nomenclature_group_memberships1
   WHERE ((nomenclature_group_memberships1.oid IN ( SELECT max(nomenclature_group_memberships2.oid) AS max
-           FROM public.nomenclature_group_memberships_oplog nomenclature_group_memberships2
+           FROM nomenclature_group_memberships_oplog nomenclature_group_memberships2
           WHERE ((nomenclature_group_memberships1.goods_nomenclature_sid = nomenclature_group_memberships2.goods_nomenclature_sid) AND ((nomenclature_group_memberships1.goods_nomenclature_group_id)::text = (nomenclature_group_memberships2.goods_nomenclature_group_id)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_group_type)::text = (nomenclature_group_memberships2.goods_nomenclature_group_type)::text) AND ((nomenclature_group_memberships1.goods_nomenclature_item_id)::text = (nomenclature_group_memberships2.goods_nomenclature_item_id)::text) AND (nomenclature_group_memberships1.validity_start_date = nomenclature_group_memberships2.validity_start_date)))) AND ((nomenclature_group_memberships1.operation)::text <> 'D'::text));
 
 
@@ -5578,7 +5565,7 @@ CREATE VIEW public.nomenclature_group_memberships AS
 -- Name: nomenclature_group_memberships_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.nomenclature_group_memberships_oid_seq
+CREATE SEQUENCE nomenclature_group_memberships_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5590,14 +5577,14 @@ CREATE SEQUENCE public.nomenclature_group_memberships_oid_seq
 -- Name: nomenclature_group_memberships_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.nomenclature_group_memberships_oid_seq OWNED BY public.nomenclature_group_memberships_oplog.oid;
+ALTER SEQUENCE nomenclature_group_memberships_oid_seq OWNED BY nomenclature_group_memberships_oplog.oid;
 
 
 --
 -- Name: prorogation_regulation_actions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.prorogation_regulation_actions_oplog (
+CREATE TABLE prorogation_regulation_actions_oplog (
     prorogation_regulation_role integer,
     prorogation_regulation_id character varying(8),
     prorogated_regulation_role integer,
@@ -5617,7 +5604,7 @@ CREATE TABLE public.prorogation_regulation_actions_oplog (
 -- Name: prorogation_regulation_actions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.prorogation_regulation_actions AS
+CREATE VIEW prorogation_regulation_actions AS
  SELECT prorogation_regulation_actions1.prorogation_regulation_role,
     prorogation_regulation_actions1.prorogation_regulation_id,
     prorogation_regulation_actions1.prorogated_regulation_role,
@@ -5629,9 +5616,9 @@ CREATE VIEW public.prorogation_regulation_actions AS
     prorogation_regulation_actions1.status,
     prorogation_regulation_actions1.workbasket_id,
     prorogation_regulation_actions1.workbasket_sequence_number
-   FROM public.prorogation_regulation_actions_oplog prorogation_regulation_actions1
+   FROM prorogation_regulation_actions_oplog prorogation_regulation_actions1
   WHERE ((prorogation_regulation_actions1.oid IN ( SELECT max(prorogation_regulation_actions2.oid) AS max
-           FROM public.prorogation_regulation_actions_oplog prorogation_regulation_actions2
+           FROM prorogation_regulation_actions_oplog prorogation_regulation_actions2
           WHERE (((prorogation_regulation_actions1.prorogation_regulation_id)::text = (prorogation_regulation_actions2.prorogation_regulation_id)::text) AND (prorogation_regulation_actions1.prorogation_regulation_role = prorogation_regulation_actions2.prorogation_regulation_role) AND ((prorogation_regulation_actions1.prorogated_regulation_id)::text = (prorogation_regulation_actions2.prorogated_regulation_id)::text) AND (prorogation_regulation_actions1.prorogated_regulation_role = prorogation_regulation_actions2.prorogated_regulation_role)))) AND ((prorogation_regulation_actions1.operation)::text <> 'D'::text));
 
 
@@ -5639,7 +5626,7 @@ CREATE VIEW public.prorogation_regulation_actions AS
 -- Name: prorogation_regulation_actions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.prorogation_regulation_actions_oid_seq
+CREATE SEQUENCE prorogation_regulation_actions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5651,14 +5638,14 @@ CREATE SEQUENCE public.prorogation_regulation_actions_oid_seq
 -- Name: prorogation_regulation_actions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.prorogation_regulation_actions_oid_seq OWNED BY public.prorogation_regulation_actions_oplog.oid;
+ALTER SEQUENCE prorogation_regulation_actions_oid_seq OWNED BY prorogation_regulation_actions_oplog.oid;
 
 
 --
 -- Name: prorogation_regulations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.prorogation_regulations_oplog (
+CREATE TABLE prorogation_regulations_oplog (
     prorogation_regulation_role integer,
     prorogation_regulation_id character varying(255),
     published_date date,
@@ -5684,7 +5671,7 @@ CREATE TABLE public.prorogation_regulations_oplog (
 -- Name: prorogation_regulations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.prorogation_regulations AS
+CREATE VIEW prorogation_regulations AS
  SELECT prorogation_regulations1.prorogation_regulation_role,
     prorogation_regulations1.prorogation_regulation_id,
     prorogation_regulations1.published_date,
@@ -5702,9 +5689,9 @@ CREATE VIEW public.prorogation_regulations AS
     prorogation_regulations1.status,
     prorogation_regulations1.workbasket_id,
     prorogation_regulations1.workbasket_sequence_number
-   FROM public.prorogation_regulations_oplog prorogation_regulations1
+   FROM prorogation_regulations_oplog prorogation_regulations1
   WHERE ((prorogation_regulations1.oid IN ( SELECT max(prorogation_regulations2.oid) AS max
-           FROM public.prorogation_regulations_oplog prorogation_regulations2
+           FROM prorogation_regulations_oplog prorogation_regulations2
           WHERE (((prorogation_regulations1.prorogation_regulation_id)::text = (prorogation_regulations2.prorogation_regulation_id)::text) AND (prorogation_regulations1.prorogation_regulation_role = prorogation_regulations2.prorogation_regulation_role)))) AND ((prorogation_regulations1.operation)::text <> 'D'::text));
 
 
@@ -5712,7 +5699,7 @@ CREATE VIEW public.prorogation_regulations AS
 -- Name: prorogation_regulations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.prorogation_regulations_oid_seq
+CREATE SEQUENCE prorogation_regulations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5724,14 +5711,14 @@ CREATE SEQUENCE public.prorogation_regulations_oid_seq
 -- Name: prorogation_regulations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.prorogation_regulations_oid_seq OWNED BY public.prorogation_regulations_oplog.oid;
+ALTER SEQUENCE prorogation_regulations_oid_seq OWNED BY prorogation_regulations_oplog.oid;
 
 
 --
 -- Name: publication_sigles_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.publication_sigles_oplog (
+CREATE TABLE publication_sigles_oplog (
     oid integer NOT NULL,
     code_type_id character varying(4),
     code character varying(10),
@@ -5752,7 +5739,7 @@ CREATE TABLE public.publication_sigles_oplog (
 -- Name: publication_sigles; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.publication_sigles AS
+CREATE VIEW publication_sigles AS
  SELECT publication_sigles1.oid,
     publication_sigles1.code_type_id,
     publication_sigles1.code,
@@ -5765,9 +5752,9 @@ CREATE VIEW public.publication_sigles AS
     publication_sigles1.status,
     publication_sigles1.workbasket_id,
     publication_sigles1.workbasket_sequence_number
-   FROM public.publication_sigles_oplog publication_sigles1
+   FROM publication_sigles_oplog publication_sigles1
   WHERE ((publication_sigles1.oid IN ( SELECT max(publication_sigles2.oid) AS max
-           FROM public.publication_sigles_oplog publication_sigles2
+           FROM publication_sigles_oplog publication_sigles2
           WHERE (((publication_sigles1.code)::text = (publication_sigles2.code)::text) AND ((publication_sigles1.code_type_id)::text = (publication_sigles2.code_type_id)::text)))) AND ((publication_sigles1.operation)::text <> 'D'::text));
 
 
@@ -5775,7 +5762,7 @@ CREATE VIEW public.publication_sigles AS
 -- Name: publication_sigles_oplog_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.publication_sigles_oplog_oid_seq
+CREATE SEQUENCE publication_sigles_oplog_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5787,14 +5774,14 @@ CREATE SEQUENCE public.publication_sigles_oplog_oid_seq
 -- Name: publication_sigles_oplog_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.publication_sigles_oplog_oid_seq OWNED BY public.publication_sigles_oplog.oid;
+ALTER SEQUENCE publication_sigles_oplog_oid_seq OWNED BY publication_sigles_oplog.oid;
 
 
 --
 -- Name: quota_associations_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_associations_oplog (
+CREATE TABLE quota_associations_oplog (
     main_quota_definition_sid integer,
     sub_quota_definition_sid integer,
     relation_type character varying(255),
@@ -5813,7 +5800,7 @@ CREATE TABLE public.quota_associations_oplog (
 -- Name: quota_associations; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_associations AS
+CREATE VIEW quota_associations AS
  SELECT quota_associations1.main_quota_definition_sid,
     quota_associations1.sub_quota_definition_sid,
     quota_associations1.relation_type,
@@ -5824,9 +5811,9 @@ CREATE VIEW public.quota_associations AS
     quota_associations1.status,
     quota_associations1.workbasket_id,
     quota_associations1.workbasket_sequence_number
-   FROM public.quota_associations_oplog quota_associations1
+   FROM quota_associations_oplog quota_associations1
   WHERE ((quota_associations1.oid IN ( SELECT max(quota_associations2.oid) AS max
-           FROM public.quota_associations_oplog quota_associations2
+           FROM quota_associations_oplog quota_associations2
           WHERE ((quota_associations1.main_quota_definition_sid = quota_associations2.main_quota_definition_sid) AND (quota_associations1.sub_quota_definition_sid = quota_associations2.sub_quota_definition_sid)))) AND ((quota_associations1.operation)::text <> 'D'::text));
 
 
@@ -5834,7 +5821,7 @@ CREATE VIEW public.quota_associations AS
 -- Name: quota_associations_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_associations_oid_seq
+CREATE SEQUENCE quota_associations_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5846,14 +5833,14 @@ CREATE SEQUENCE public.quota_associations_oid_seq
 -- Name: quota_associations_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_associations_oid_seq OWNED BY public.quota_associations_oplog.oid;
+ALTER SEQUENCE quota_associations_oid_seq OWNED BY quota_associations_oplog.oid;
 
 
 --
 -- Name: quota_balance_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_balance_events_oplog (
+CREATE TABLE quota_balance_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     last_import_date_in_allocation date,
@@ -5874,7 +5861,7 @@ CREATE TABLE public.quota_balance_events_oplog (
 -- Name: quota_balance_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_balance_events AS
+CREATE VIEW quota_balance_events AS
  SELECT quota_balance_events1.quota_definition_sid,
     quota_balance_events1.occurrence_timestamp,
     quota_balance_events1.last_import_date_in_allocation,
@@ -5887,9 +5874,9 @@ CREATE VIEW public.quota_balance_events AS
     quota_balance_events1.status,
     quota_balance_events1.workbasket_id,
     quota_balance_events1.workbasket_sequence_number
-   FROM public.quota_balance_events_oplog quota_balance_events1
+   FROM quota_balance_events_oplog quota_balance_events1
   WHERE ((quota_balance_events1.oid IN ( SELECT max(quota_balance_events2.oid) AS max
-           FROM public.quota_balance_events_oplog quota_balance_events2
+           FROM quota_balance_events_oplog quota_balance_events2
           WHERE ((quota_balance_events1.quota_definition_sid = quota_balance_events2.quota_definition_sid) AND (quota_balance_events1.occurrence_timestamp = quota_balance_events2.occurrence_timestamp)))) AND ((quota_balance_events1.operation)::text <> 'D'::text));
 
 
@@ -5897,7 +5884,7 @@ CREATE VIEW public.quota_balance_events AS
 -- Name: quota_balance_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_balance_events_oid_seq
+CREATE SEQUENCE quota_balance_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5909,14 +5896,14 @@ CREATE SEQUENCE public.quota_balance_events_oid_seq
 -- Name: quota_balance_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_balance_events_oid_seq OWNED BY public.quota_balance_events_oplog.oid;
+ALTER SEQUENCE quota_balance_events_oid_seq OWNED BY quota_balance_events_oplog.oid;
 
 
 --
 -- Name: quota_blocking_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_blocking_periods_oplog (
+CREATE TABLE quota_blocking_periods_oplog (
     quota_blocking_period_sid integer,
     quota_definition_sid integer,
     blocking_start_date date,
@@ -5937,7 +5924,7 @@ CREATE TABLE public.quota_blocking_periods_oplog (
 -- Name: quota_blocking_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_blocking_periods AS
+CREATE VIEW quota_blocking_periods AS
  SELECT quota_blocking_periods1.quota_blocking_period_sid,
     quota_blocking_periods1.quota_definition_sid,
     quota_blocking_periods1.blocking_start_date,
@@ -5950,9 +5937,9 @@ CREATE VIEW public.quota_blocking_periods AS
     quota_blocking_periods1.status,
     quota_blocking_periods1.workbasket_id,
     quota_blocking_periods1.workbasket_sequence_number
-   FROM public.quota_blocking_periods_oplog quota_blocking_periods1
+   FROM quota_blocking_periods_oplog quota_blocking_periods1
   WHERE ((quota_blocking_periods1.oid IN ( SELECT max(quota_blocking_periods2.oid) AS max
-           FROM public.quota_blocking_periods_oplog quota_blocking_periods2
+           FROM quota_blocking_periods_oplog quota_blocking_periods2
           WHERE (quota_blocking_periods1.quota_blocking_period_sid = quota_blocking_periods2.quota_blocking_period_sid))) AND ((quota_blocking_periods1.operation)::text <> 'D'::text));
 
 
@@ -5960,7 +5947,7 @@ CREATE VIEW public.quota_blocking_periods AS
 -- Name: quota_blocking_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_blocking_periods_oid_seq
+CREATE SEQUENCE quota_blocking_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -5972,14 +5959,14 @@ CREATE SEQUENCE public.quota_blocking_periods_oid_seq
 -- Name: quota_blocking_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_blocking_periods_oid_seq OWNED BY public.quota_blocking_periods_oplog.oid;
+ALTER SEQUENCE quota_blocking_periods_oid_seq OWNED BY quota_blocking_periods_oplog.oid;
 
 
 --
 -- Name: quota_critical_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_critical_events_oplog (
+CREATE TABLE quota_critical_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     critical_state character varying(255),
@@ -5998,7 +5985,7 @@ CREATE TABLE public.quota_critical_events_oplog (
 -- Name: quota_critical_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_critical_events AS
+CREATE VIEW quota_critical_events AS
  SELECT quota_critical_events1.quota_definition_sid,
     quota_critical_events1.occurrence_timestamp,
     quota_critical_events1.critical_state,
@@ -6009,9 +5996,9 @@ CREATE VIEW public.quota_critical_events AS
     quota_critical_events1.status,
     quota_critical_events1.workbasket_id,
     quota_critical_events1.workbasket_sequence_number
-   FROM public.quota_critical_events_oplog quota_critical_events1
+   FROM quota_critical_events_oplog quota_critical_events1
   WHERE ((quota_critical_events1.oid IN ( SELECT max(quota_critical_events2.oid) AS max
-           FROM public.quota_critical_events_oplog quota_critical_events2
+           FROM quota_critical_events_oplog quota_critical_events2
           WHERE ((quota_critical_events1.quota_definition_sid = quota_critical_events2.quota_definition_sid) AND (quota_critical_events1.occurrence_timestamp = quota_critical_events2.occurrence_timestamp))
           GROUP BY quota_critical_events2.oid
           ORDER BY quota_critical_events2.oid DESC)) AND ((quota_critical_events1.operation)::text <> 'D'::text));
@@ -6021,7 +6008,7 @@ CREATE VIEW public.quota_critical_events AS
 -- Name: quota_critical_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_critical_events_oid_seq
+CREATE SEQUENCE quota_critical_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6033,14 +6020,14 @@ CREATE SEQUENCE public.quota_critical_events_oid_seq
 -- Name: quota_critical_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_critical_events_oid_seq OWNED BY public.quota_critical_events_oplog.oid;
+ALTER SEQUENCE quota_critical_events_oid_seq OWNED BY quota_critical_events_oplog.oid;
 
 
 --
 -- Name: quota_definitions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_definitions_oplog (
+CREATE TABLE quota_definitions_oplog (
     quota_definition_sid integer,
     quota_order_number_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -6073,7 +6060,7 @@ CREATE TABLE public.quota_definitions_oplog (
 -- Name: quota_definitions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_definitions AS
+CREATE VIEW quota_definitions AS
  SELECT quota_definitions1.quota_definition_sid,
     quota_definitions1.quota_order_number_id,
     quota_definitions1.validity_start_date,
@@ -6098,9 +6085,9 @@ CREATE VIEW public.quota_definitions AS
     quota_definitions1.workbasket_id,
     quota_definitions1.workbasket_sequence_number,
     quota_definitions1.workbasket_type_of_quota
-   FROM public.quota_definitions_oplog quota_definitions1
+   FROM quota_definitions_oplog quota_definitions1
   WHERE ((quota_definitions1.oid IN ( SELECT max(quota_definitions2.oid) AS max
-           FROM public.quota_definitions_oplog quota_definitions2
+           FROM quota_definitions_oplog quota_definitions2
           WHERE (quota_definitions1.quota_definition_sid = quota_definitions2.quota_definition_sid))) AND ((quota_definitions1.operation)::text <> 'D'::text));
 
 
@@ -6108,7 +6095,7 @@ CREATE VIEW public.quota_definitions AS
 -- Name: quota_definitions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_definitions_oid_seq
+CREATE SEQUENCE quota_definitions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6120,14 +6107,14 @@ CREATE SEQUENCE public.quota_definitions_oid_seq
 -- Name: quota_definitions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_definitions_oid_seq OWNED BY public.quota_definitions_oplog.oid;
+ALTER SEQUENCE quota_definitions_oid_seq OWNED BY quota_definitions_oplog.oid;
 
 
 --
 -- Name: quota_exhaustion_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_exhaustion_events_oplog (
+CREATE TABLE quota_exhaustion_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     exhaustion_date date,
@@ -6145,7 +6132,7 @@ CREATE TABLE public.quota_exhaustion_events_oplog (
 -- Name: quota_exhaustion_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_exhaustion_events AS
+CREATE VIEW quota_exhaustion_events AS
  SELECT quota_exhaustion_events1.quota_definition_sid,
     quota_exhaustion_events1.occurrence_timestamp,
     quota_exhaustion_events1.exhaustion_date,
@@ -6155,9 +6142,9 @@ CREATE VIEW public.quota_exhaustion_events AS
     quota_exhaustion_events1.status,
     quota_exhaustion_events1.workbasket_id,
     quota_exhaustion_events1.workbasket_sequence_number
-   FROM public.quota_exhaustion_events_oplog quota_exhaustion_events1
+   FROM quota_exhaustion_events_oplog quota_exhaustion_events1
   WHERE ((quota_exhaustion_events1.oid IN ( SELECT max(quota_exhaustion_events2.oid) AS max
-           FROM public.quota_exhaustion_events_oplog quota_exhaustion_events2
+           FROM quota_exhaustion_events_oplog quota_exhaustion_events2
           WHERE (quota_exhaustion_events1.quota_definition_sid = quota_exhaustion_events2.quota_definition_sid))) AND ((quota_exhaustion_events1.operation)::text <> 'D'::text));
 
 
@@ -6165,7 +6152,7 @@ CREATE VIEW public.quota_exhaustion_events AS
 -- Name: quota_exhaustion_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_exhaustion_events_oid_seq
+CREATE SEQUENCE quota_exhaustion_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6177,14 +6164,14 @@ CREATE SEQUENCE public.quota_exhaustion_events_oid_seq
 -- Name: quota_exhaustion_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_exhaustion_events_oid_seq OWNED BY public.quota_exhaustion_events_oplog.oid;
+ALTER SEQUENCE quota_exhaustion_events_oid_seq OWNED BY quota_exhaustion_events_oplog.oid;
 
 
 --
 -- Name: quota_order_number_origin_exclusions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_order_number_origin_exclusions_oplog (
+CREATE TABLE quota_order_number_origin_exclusions_oplog (
     quota_order_number_origin_sid integer,
     excluded_geographical_area_sid integer,
     created_at timestamp without time zone,
@@ -6204,7 +6191,7 @@ CREATE TABLE public.quota_order_number_origin_exclusions_oplog (
 -- Name: quota_order_number_origin_exclusions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_order_number_origin_exclusions AS
+CREATE VIEW quota_order_number_origin_exclusions AS
  SELECT quota_order_number_origin_exclusions1.quota_order_number_origin_sid,
     quota_order_number_origin_exclusions1.excluded_geographical_area_sid,
     quota_order_number_origin_exclusions1.oid,
@@ -6216,9 +6203,9 @@ CREATE VIEW public.quota_order_number_origin_exclusions AS
     quota_order_number_origin_exclusions1.status,
     quota_order_number_origin_exclusions1.workbasket_id,
     quota_order_number_origin_exclusions1.workbasket_sequence_number
-   FROM public.quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions1
+   FROM quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions1
   WHERE ((quota_order_number_origin_exclusions1.oid IN ( SELECT max(quota_order_number_origin_exclusions2.oid) AS max
-           FROM public.quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions2
+           FROM quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions2
           WHERE ((quota_order_number_origin_exclusions1.quota_order_number_origin_sid = quota_order_number_origin_exclusions2.quota_order_number_origin_sid) AND (quota_order_number_origin_exclusions1.excluded_geographical_area_sid = quota_order_number_origin_exclusions2.excluded_geographical_area_sid)))) AND ((quota_order_number_origin_exclusions1.operation)::text <> 'D'::text));
 
 
@@ -6226,7 +6213,7 @@ CREATE VIEW public.quota_order_number_origin_exclusions AS
 -- Name: quota_order_number_origin_exclusions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_order_number_origin_exclusions_oid_seq
+CREATE SEQUENCE quota_order_number_origin_exclusions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6238,14 +6225,14 @@ CREATE SEQUENCE public.quota_order_number_origin_exclusions_oid_seq
 -- Name: quota_order_number_origin_exclusions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_order_number_origin_exclusions_oid_seq OWNED BY public.quota_order_number_origin_exclusions_oplog.oid;
+ALTER SEQUENCE quota_order_number_origin_exclusions_oid_seq OWNED BY quota_order_number_origin_exclusions_oplog.oid;
 
 
 --
 -- Name: quota_order_number_origins_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_order_number_origins_oplog (
+CREATE TABLE quota_order_number_origins_oplog (
     quota_order_number_origin_sid integer,
     quota_order_number_sid integer,
     geographical_area_id character varying(255),
@@ -6269,7 +6256,7 @@ CREATE TABLE public.quota_order_number_origins_oplog (
 -- Name: quota_order_number_origins; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_order_number_origins AS
+CREATE VIEW quota_order_number_origins AS
  SELECT quota_order_number_origins1.quota_order_number_origin_sid,
     quota_order_number_origins1.quota_order_number_sid,
     quota_order_number_origins1.geographical_area_id,
@@ -6285,9 +6272,9 @@ CREATE VIEW public.quota_order_number_origins AS
     quota_order_number_origins1.status,
     quota_order_number_origins1.workbasket_id,
     quota_order_number_origins1.workbasket_sequence_number
-   FROM public.quota_order_number_origins_oplog quota_order_number_origins1
+   FROM quota_order_number_origins_oplog quota_order_number_origins1
   WHERE ((quota_order_number_origins1.oid IN ( SELECT max(quota_order_number_origins2.oid) AS max
-           FROM public.quota_order_number_origins_oplog quota_order_number_origins2
+           FROM quota_order_number_origins_oplog quota_order_number_origins2
           WHERE (quota_order_number_origins1.quota_order_number_origin_sid = quota_order_number_origins2.quota_order_number_origin_sid))) AND ((quota_order_number_origins1.operation)::text <> 'D'::text));
 
 
@@ -6295,7 +6282,7 @@ CREATE VIEW public.quota_order_number_origins AS
 -- Name: quota_order_number_origins_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_order_number_origins_oid_seq
+CREATE SEQUENCE quota_order_number_origins_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6307,14 +6294,14 @@ CREATE SEQUENCE public.quota_order_number_origins_oid_seq
 -- Name: quota_order_number_origins_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_order_number_origins_oid_seq OWNED BY public.quota_order_number_origins_oplog.oid;
+ALTER SEQUENCE quota_order_number_origins_oid_seq OWNED BY quota_order_number_origins_oplog.oid;
 
 
 --
 -- Name: quota_order_numbers_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_order_numbers_oplog (
+CREATE TABLE quota_order_numbers_oplog (
     quota_order_number_sid integer,
     quota_order_number_id character varying(255),
     validity_start_date timestamp without time zone,
@@ -6336,7 +6323,7 @@ CREATE TABLE public.quota_order_numbers_oplog (
 -- Name: quota_order_numbers; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_order_numbers AS
+CREATE VIEW quota_order_numbers AS
  SELECT quota_order_numbers1.quota_order_number_sid,
     quota_order_numbers1.quota_order_number_id,
     quota_order_numbers1.validity_start_date,
@@ -6350,9 +6337,9 @@ CREATE VIEW public.quota_order_numbers AS
     quota_order_numbers1.status,
     quota_order_numbers1.workbasket_id,
     quota_order_numbers1.workbasket_sequence_number
-   FROM public.quota_order_numbers_oplog quota_order_numbers1
+   FROM quota_order_numbers_oplog quota_order_numbers1
   WHERE ((quota_order_numbers1.oid IN ( SELECT max(quota_order_numbers2.oid) AS max
-           FROM public.quota_order_numbers_oplog quota_order_numbers2
+           FROM quota_order_numbers_oplog quota_order_numbers2
           WHERE (quota_order_numbers1.quota_order_number_sid = quota_order_numbers2.quota_order_number_sid))) AND ((quota_order_numbers1.operation)::text <> 'D'::text));
 
 
@@ -6360,7 +6347,7 @@ CREATE VIEW public.quota_order_numbers AS
 -- Name: quota_order_numbers_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_order_numbers_oid_seq
+CREATE SEQUENCE quota_order_numbers_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6372,14 +6359,14 @@ CREATE SEQUENCE public.quota_order_numbers_oid_seq
 -- Name: quota_order_numbers_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_order_numbers_oid_seq OWNED BY public.quota_order_numbers_oplog.oid;
+ALTER SEQUENCE quota_order_numbers_oid_seq OWNED BY quota_order_numbers_oplog.oid;
 
 
 --
 -- Name: quota_reopening_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_reopening_events_oplog (
+CREATE TABLE quota_reopening_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     reopening_date date,
@@ -6397,7 +6384,7 @@ CREATE TABLE public.quota_reopening_events_oplog (
 -- Name: quota_reopening_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_reopening_events AS
+CREATE VIEW quota_reopening_events AS
  SELECT quota_reopening_events1.quota_definition_sid,
     quota_reopening_events1.occurrence_timestamp,
     quota_reopening_events1.reopening_date,
@@ -6407,9 +6394,9 @@ CREATE VIEW public.quota_reopening_events AS
     quota_reopening_events1.status,
     quota_reopening_events1.workbasket_id,
     quota_reopening_events1.workbasket_sequence_number
-   FROM public.quota_reopening_events_oplog quota_reopening_events1
+   FROM quota_reopening_events_oplog quota_reopening_events1
   WHERE ((quota_reopening_events1.oid IN ( SELECT max(quota_reopening_events2.oid) AS max
-           FROM public.quota_reopening_events_oplog quota_reopening_events2
+           FROM quota_reopening_events_oplog quota_reopening_events2
           WHERE (quota_reopening_events1.quota_definition_sid = quota_reopening_events2.quota_definition_sid))) AND ((quota_reopening_events1.operation)::text <> 'D'::text));
 
 
@@ -6417,7 +6404,7 @@ CREATE VIEW public.quota_reopening_events AS
 -- Name: quota_reopening_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_reopening_events_oid_seq
+CREATE SEQUENCE quota_reopening_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6429,14 +6416,14 @@ CREATE SEQUENCE public.quota_reopening_events_oid_seq
 -- Name: quota_reopening_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_reopening_events_oid_seq OWNED BY public.quota_reopening_events_oplog.oid;
+ALTER SEQUENCE quota_reopening_events_oid_seq OWNED BY quota_reopening_events_oplog.oid;
 
 
 --
 -- Name: quota_suspension_periods_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_suspension_periods_oplog (
+CREATE TABLE quota_suspension_periods_oplog (
     quota_suspension_period_sid integer,
     quota_definition_sid integer,
     suspension_start_date date,
@@ -6456,7 +6443,7 @@ CREATE TABLE public.quota_suspension_periods_oplog (
 -- Name: quota_suspension_periods; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_suspension_periods AS
+CREATE VIEW quota_suspension_periods AS
  SELECT quota_suspension_periods1.quota_suspension_period_sid,
     quota_suspension_periods1.quota_definition_sid,
     quota_suspension_periods1.suspension_start_date,
@@ -6468,9 +6455,9 @@ CREATE VIEW public.quota_suspension_periods AS
     quota_suspension_periods1.status,
     quota_suspension_periods1.workbasket_id,
     quota_suspension_periods1.workbasket_sequence_number
-   FROM public.quota_suspension_periods_oplog quota_suspension_periods1
+   FROM quota_suspension_periods_oplog quota_suspension_periods1
   WHERE ((quota_suspension_periods1.oid IN ( SELECT max(quota_suspension_periods2.oid) AS max
-           FROM public.quota_suspension_periods_oplog quota_suspension_periods2
+           FROM quota_suspension_periods_oplog quota_suspension_periods2
           WHERE (quota_suspension_periods1.quota_suspension_period_sid = quota_suspension_periods2.quota_suspension_period_sid))) AND ((quota_suspension_periods1.operation)::text <> 'D'::text));
 
 
@@ -6478,7 +6465,7 @@ CREATE VIEW public.quota_suspension_periods AS
 -- Name: quota_suspension_periods_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_suspension_periods_oid_seq
+CREATE SEQUENCE quota_suspension_periods_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6490,14 +6477,14 @@ CREATE SEQUENCE public.quota_suspension_periods_oid_seq
 -- Name: quota_suspension_periods_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_suspension_periods_oid_seq OWNED BY public.quota_suspension_periods_oplog.oid;
+ALTER SEQUENCE quota_suspension_periods_oid_seq OWNED BY quota_suspension_periods_oplog.oid;
 
 
 --
 -- Name: quota_unblocking_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_unblocking_events_oplog (
+CREATE TABLE quota_unblocking_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     unblocking_date date,
@@ -6515,7 +6502,7 @@ CREATE TABLE public.quota_unblocking_events_oplog (
 -- Name: quota_unblocking_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_unblocking_events AS
+CREATE VIEW quota_unblocking_events AS
  SELECT quota_unblocking_events1.quota_definition_sid,
     quota_unblocking_events1.occurrence_timestamp,
     quota_unblocking_events1.unblocking_date,
@@ -6525,9 +6512,9 @@ CREATE VIEW public.quota_unblocking_events AS
     quota_unblocking_events1.status,
     quota_unblocking_events1.workbasket_id,
     quota_unblocking_events1.workbasket_sequence_number
-   FROM public.quota_unblocking_events_oplog quota_unblocking_events1
+   FROM quota_unblocking_events_oplog quota_unblocking_events1
   WHERE ((quota_unblocking_events1.oid IN ( SELECT max(quota_unblocking_events2.oid) AS max
-           FROM public.quota_unblocking_events_oplog quota_unblocking_events2
+           FROM quota_unblocking_events_oplog quota_unblocking_events2
           WHERE (quota_unblocking_events1.quota_definition_sid = quota_unblocking_events2.quota_definition_sid))) AND ((quota_unblocking_events1.operation)::text <> 'D'::text));
 
 
@@ -6535,7 +6522,7 @@ CREATE VIEW public.quota_unblocking_events AS
 -- Name: quota_unblocking_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_unblocking_events_oid_seq
+CREATE SEQUENCE quota_unblocking_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6547,14 +6534,14 @@ CREATE SEQUENCE public.quota_unblocking_events_oid_seq
 -- Name: quota_unblocking_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_unblocking_events_oid_seq OWNED BY public.quota_unblocking_events_oplog.oid;
+ALTER SEQUENCE quota_unblocking_events_oid_seq OWNED BY quota_unblocking_events_oplog.oid;
 
 
 --
 -- Name: quota_unsuspension_events_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.quota_unsuspension_events_oplog (
+CREATE TABLE quota_unsuspension_events_oplog (
     quota_definition_sid integer,
     occurrence_timestamp timestamp without time zone,
     unsuspension_date date,
@@ -6572,7 +6559,7 @@ CREATE TABLE public.quota_unsuspension_events_oplog (
 -- Name: quota_unsuspension_events; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.quota_unsuspension_events AS
+CREATE VIEW quota_unsuspension_events AS
  SELECT quota_unsuspension_events1.quota_definition_sid,
     quota_unsuspension_events1.occurrence_timestamp,
     quota_unsuspension_events1.unsuspension_date,
@@ -6582,9 +6569,9 @@ CREATE VIEW public.quota_unsuspension_events AS
     quota_unsuspension_events1.status,
     quota_unsuspension_events1.workbasket_id,
     quota_unsuspension_events1.workbasket_sequence_number
-   FROM public.quota_unsuspension_events_oplog quota_unsuspension_events1
+   FROM quota_unsuspension_events_oplog quota_unsuspension_events1
   WHERE ((quota_unsuspension_events1.oid IN ( SELECT max(quota_unsuspension_events2.oid) AS max
-           FROM public.quota_unsuspension_events_oplog quota_unsuspension_events2
+           FROM quota_unsuspension_events_oplog quota_unsuspension_events2
           WHERE (quota_unsuspension_events1.quota_definition_sid = quota_unsuspension_events2.quota_definition_sid))) AND ((quota_unsuspension_events1.operation)::text <> 'D'::text));
 
 
@@ -6592,7 +6579,7 @@ CREATE VIEW public.quota_unsuspension_events AS
 -- Name: quota_unsuspension_events_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.quota_unsuspension_events_oid_seq
+CREATE SEQUENCE quota_unsuspension_events_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6604,14 +6591,14 @@ CREATE SEQUENCE public.quota_unsuspension_events_oid_seq
 -- Name: quota_unsuspension_events_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.quota_unsuspension_events_oid_seq OWNED BY public.quota_unsuspension_events_oplog.oid;
+ALTER SEQUENCE quota_unsuspension_events_oid_seq OWNED BY quota_unsuspension_events_oplog.oid;
 
 
 --
 -- Name: regulation_documents; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.regulation_documents (
+CREATE TABLE regulation_documents (
     id integer NOT NULL,
     regulation_id text,
     regulation_role text,
@@ -6628,7 +6615,7 @@ CREATE TABLE public.regulation_documents (
 -- Name: regulation_documents_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.regulation_documents_id_seq
+CREATE SEQUENCE regulation_documents_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6640,14 +6627,14 @@ CREATE SEQUENCE public.regulation_documents_id_seq
 -- Name: regulation_documents_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.regulation_documents_id_seq OWNED BY public.regulation_documents.id;
+ALTER SEQUENCE regulation_documents_id_seq OWNED BY regulation_documents.id;
 
 
 --
 -- Name: regulation_group_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.regulation_group_descriptions_oplog (
+CREATE TABLE regulation_group_descriptions_oplog (
     regulation_group_id character varying(255),
     language_id character varying(5),
     description text,
@@ -6666,7 +6653,7 @@ CREATE TABLE public.regulation_group_descriptions_oplog (
 -- Name: regulation_group_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.regulation_group_descriptions AS
+CREATE VIEW regulation_group_descriptions AS
  SELECT regulation_group_descriptions1.regulation_group_id,
     regulation_group_descriptions1.language_id,
     regulation_group_descriptions1.description,
@@ -6677,9 +6664,9 @@ CREATE VIEW public.regulation_group_descriptions AS
     regulation_group_descriptions1.status,
     regulation_group_descriptions1.workbasket_id,
     regulation_group_descriptions1.workbasket_sequence_number
-   FROM public.regulation_group_descriptions_oplog regulation_group_descriptions1
+   FROM regulation_group_descriptions_oplog regulation_group_descriptions1
   WHERE ((regulation_group_descriptions1.oid IN ( SELECT max(regulation_group_descriptions2.oid) AS max
-           FROM public.regulation_group_descriptions_oplog regulation_group_descriptions2
+           FROM regulation_group_descriptions_oplog regulation_group_descriptions2
           WHERE ((regulation_group_descriptions1.regulation_group_id)::text = (regulation_group_descriptions2.regulation_group_id)::text))) AND ((regulation_group_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -6687,7 +6674,7 @@ CREATE VIEW public.regulation_group_descriptions AS
 -- Name: regulation_group_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.regulation_group_descriptions_oid_seq
+CREATE SEQUENCE regulation_group_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6699,14 +6686,14 @@ CREATE SEQUENCE public.regulation_group_descriptions_oid_seq
 -- Name: regulation_group_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.regulation_group_descriptions_oid_seq OWNED BY public.regulation_group_descriptions_oplog.oid;
+ALTER SEQUENCE regulation_group_descriptions_oid_seq OWNED BY regulation_group_descriptions_oplog.oid;
 
 
 --
 -- Name: regulation_groups_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.regulation_groups_oplog (
+CREATE TABLE regulation_groups_oplog (
     regulation_group_id character varying(255),
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -6725,7 +6712,7 @@ CREATE TABLE public.regulation_groups_oplog (
 -- Name: regulation_groups; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.regulation_groups AS
+CREATE VIEW regulation_groups AS
  SELECT regulation_groups1.regulation_group_id,
     regulation_groups1.validity_start_date,
     regulation_groups1.validity_end_date,
@@ -6736,9 +6723,9 @@ CREATE VIEW public.regulation_groups AS
     regulation_groups1.status,
     regulation_groups1.workbasket_id,
     regulation_groups1.workbasket_sequence_number
-   FROM public.regulation_groups_oplog regulation_groups1
+   FROM regulation_groups_oplog regulation_groups1
   WHERE ((regulation_groups1.oid IN ( SELECT max(regulation_groups2.oid) AS max
-           FROM public.regulation_groups_oplog regulation_groups2
+           FROM regulation_groups_oplog regulation_groups2
           WHERE ((regulation_groups1.regulation_group_id)::text = (regulation_groups2.regulation_group_id)::text))) AND ((regulation_groups1.operation)::text <> 'D'::text));
 
 
@@ -6746,7 +6733,7 @@ CREATE VIEW public.regulation_groups AS
 -- Name: regulation_groups_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.regulation_groups_oid_seq
+CREATE SEQUENCE regulation_groups_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6758,14 +6745,14 @@ CREATE SEQUENCE public.regulation_groups_oid_seq
 -- Name: regulation_groups_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.regulation_groups_oid_seq OWNED BY public.regulation_groups_oplog.oid;
+ALTER SEQUENCE regulation_groups_oid_seq OWNED BY regulation_groups_oplog.oid;
 
 
 --
 -- Name: regulation_replacements_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.regulation_replacements_oplog (
+CREATE TABLE regulation_replacements_oplog (
     geographical_area_id character varying(255),
     chapter_heading character varying(255),
     replacing_regulation_role integer,
@@ -6787,7 +6774,7 @@ CREATE TABLE public.regulation_replacements_oplog (
 -- Name: regulation_replacements; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.regulation_replacements AS
+CREATE VIEW regulation_replacements AS
  SELECT regulation_replacements1.geographical_area_id,
     regulation_replacements1.chapter_heading,
     regulation_replacements1.replacing_regulation_role,
@@ -6801,9 +6788,9 @@ CREATE VIEW public.regulation_replacements AS
     regulation_replacements1.status,
     regulation_replacements1.workbasket_id,
     regulation_replacements1.workbasket_sequence_number
-   FROM public.regulation_replacements_oplog regulation_replacements1
+   FROM regulation_replacements_oplog regulation_replacements1
   WHERE ((regulation_replacements1.oid IN ( SELECT max(regulation_replacements2.oid) AS max
-           FROM public.regulation_replacements_oplog regulation_replacements2
+           FROM regulation_replacements_oplog regulation_replacements2
           WHERE (((regulation_replacements1.replacing_regulation_id)::text = (regulation_replacements2.replacing_regulation_id)::text) AND (regulation_replacements1.replacing_regulation_role = regulation_replacements2.replacing_regulation_role) AND ((regulation_replacements1.replaced_regulation_id)::text = (regulation_replacements2.replaced_regulation_id)::text) AND (regulation_replacements1.replaced_regulation_role = regulation_replacements2.replaced_regulation_role)))) AND ((regulation_replacements1.operation)::text <> 'D'::text));
 
 
@@ -6811,7 +6798,7 @@ CREATE VIEW public.regulation_replacements AS
 -- Name: regulation_replacements_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.regulation_replacements_oid_seq
+CREATE SEQUENCE regulation_replacements_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6823,14 +6810,14 @@ CREATE SEQUENCE public.regulation_replacements_oid_seq
 -- Name: regulation_replacements_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.regulation_replacements_oid_seq OWNED BY public.regulation_replacements_oplog.oid;
+ALTER SEQUENCE regulation_replacements_oid_seq OWNED BY regulation_replacements_oplog.oid;
 
 
 --
 -- Name: regulation_role_type_descriptions_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.regulation_role_type_descriptions_oplog (
+CREATE TABLE regulation_role_type_descriptions_oplog (
     regulation_role_type_id character varying(255),
     language_id character varying(5),
     description text,
@@ -6849,7 +6836,7 @@ CREATE TABLE public.regulation_role_type_descriptions_oplog (
 -- Name: regulation_role_type_descriptions; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.regulation_role_type_descriptions AS
+CREATE VIEW regulation_role_type_descriptions AS
  SELECT regulation_role_type_descriptions1.regulation_role_type_id,
     regulation_role_type_descriptions1.language_id,
     regulation_role_type_descriptions1.description,
@@ -6860,9 +6847,9 @@ CREATE VIEW public.regulation_role_type_descriptions AS
     regulation_role_type_descriptions1.status,
     regulation_role_type_descriptions1.workbasket_id,
     regulation_role_type_descriptions1.workbasket_sequence_number
-   FROM public.regulation_role_type_descriptions_oplog regulation_role_type_descriptions1
+   FROM regulation_role_type_descriptions_oplog regulation_role_type_descriptions1
   WHERE ((regulation_role_type_descriptions1.oid IN ( SELECT max(regulation_role_type_descriptions2.oid) AS max
-           FROM public.regulation_role_type_descriptions_oplog regulation_role_type_descriptions2
+           FROM regulation_role_type_descriptions_oplog regulation_role_type_descriptions2
           WHERE ((regulation_role_type_descriptions1.regulation_role_type_id)::text = (regulation_role_type_descriptions2.regulation_role_type_id)::text))) AND ((regulation_role_type_descriptions1.operation)::text <> 'D'::text));
 
 
@@ -6870,7 +6857,7 @@ CREATE VIEW public.regulation_role_type_descriptions AS
 -- Name: regulation_role_type_descriptions_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.regulation_role_type_descriptions_oid_seq
+CREATE SEQUENCE regulation_role_type_descriptions_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6882,14 +6869,14 @@ CREATE SEQUENCE public.regulation_role_type_descriptions_oid_seq
 -- Name: regulation_role_type_descriptions_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.regulation_role_type_descriptions_oid_seq OWNED BY public.regulation_role_type_descriptions_oplog.oid;
+ALTER SEQUENCE regulation_role_type_descriptions_oid_seq OWNED BY regulation_role_type_descriptions_oplog.oid;
 
 
 --
 -- Name: regulation_role_types_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.regulation_role_types_oplog (
+CREATE TABLE regulation_role_types_oplog (
     regulation_role_type_id integer,
     validity_start_date timestamp without time zone,
     validity_end_date timestamp without time zone,
@@ -6908,7 +6895,7 @@ CREATE TABLE public.regulation_role_types_oplog (
 -- Name: regulation_role_types; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.regulation_role_types AS
+CREATE VIEW regulation_role_types AS
  SELECT regulation_role_types1.regulation_role_type_id,
     regulation_role_types1.validity_start_date,
     regulation_role_types1.validity_end_date,
@@ -6919,9 +6906,9 @@ CREATE VIEW public.regulation_role_types AS
     regulation_role_types1.status,
     regulation_role_types1.workbasket_id,
     regulation_role_types1.workbasket_sequence_number
-   FROM public.regulation_role_types_oplog regulation_role_types1
+   FROM regulation_role_types_oplog regulation_role_types1
   WHERE ((regulation_role_types1.oid IN ( SELECT max(regulation_role_types2.oid) AS max
-           FROM public.regulation_role_types_oplog regulation_role_types2
+           FROM regulation_role_types_oplog regulation_role_types2
           WHERE (regulation_role_types1.regulation_role_type_id = regulation_role_types2.regulation_role_type_id))) AND ((regulation_role_types1.operation)::text <> 'D'::text));
 
 
@@ -6929,7 +6916,7 @@ CREATE VIEW public.regulation_role_types AS
 -- Name: regulation_role_types_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.regulation_role_types_oid_seq
+CREATE SEQUENCE regulation_role_types_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -6941,14 +6928,60 @@ CREATE SEQUENCE public.regulation_role_types_oid_seq
 -- Name: regulation_role_types_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.regulation_role_types_oid_seq OWNED BY public.regulation_role_types_oplog.oid;
+ALTER SEQUENCE regulation_role_types_oid_seq OWNED BY regulation_role_types_oplog.oid;
+
+
+--
+-- Name: regulations_lookup; Type: VIEW; Schema: public; Owner: -
+--
+
+CREATE VIEW regulations_lookup AS
+ SELECT base_regulations_oplog.base_regulation_id AS id,
+    base_regulations_oplog.base_regulation_role AS role,
+    base_regulations_oplog.information_text,
+    base_regulations_oplog.validity_start_date,
+    base_regulations_oplog.validity_end_date,
+    base_regulations_oplog.replacement_indicator
+   FROM base_regulations_oplog
+UNION
+ SELECT modification_regulations_oplog.modification_regulation_id AS id,
+    modification_regulations_oplog.modification_regulation_role AS role,
+    modification_regulations_oplog.information_text,
+    modification_regulations_oplog.validity_start_date,
+    modification_regulations_oplog.validity_end_date,
+    modification_regulations_oplog.replacement_indicator
+   FROM modification_regulations_oplog
+UNION
+ SELECT complete_abrogation_regulations_oplog.complete_abrogation_regulation_id AS id,
+    complete_abrogation_regulations_oplog.complete_abrogation_regulation_role AS role,
+    complete_abrogation_regulations_oplog.information_text,
+    complete_abrogation_regulations_oplog.published_date AS validity_start_date,
+    (COALESCE(NULL::text, NULL::text))::timestamp with time zone AS validity_end_date,
+    complete_abrogation_regulations_oplog.replacement_indicator
+   FROM complete_abrogation_regulations_oplog
+UNION
+ SELECT explicit_abrogation_regulations_oplog.explicit_abrogation_regulation_id AS id,
+    explicit_abrogation_regulations_oplog.explicit_abrogation_regulation_role AS role,
+    explicit_abrogation_regulations_oplog.information_text,
+    explicit_abrogation_regulations_oplog.published_date AS validity_start_date,
+    (COALESCE(NULL::text, NULL::text))::timestamp with time zone AS validity_end_date,
+    explicit_abrogation_regulations_oplog.replacement_indicator
+   FROM explicit_abrogation_regulations_oplog
+UNION
+ SELECT prorogation_regulations_oplog.prorogation_regulation_id AS id,
+    prorogation_regulations_oplog.prorogation_regulation_role AS role,
+    prorogation_regulations_oplog.information_text,
+    prorogation_regulations_oplog.published_date AS validity_start_date,
+    (COALESCE(NULL::text, NULL::text))::timestamp with time zone AS validity_end_date,
+    prorogation_regulations_oplog.replacement_indicator
+   FROM prorogation_regulations_oplog;
 
 
 --
 -- Name: regulations_search_pg_view; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.regulations_search_pg_view AS
+CREATE VIEW regulations_search_pg_view AS
  SELECT concat_ws('_'::text, base_regulations_oplog.oid, 'base_regulation') AS id,
     base_regulations_oplog.base_regulation_id AS regulation_id,
     base_regulations_oplog.base_regulation_role AS role,
@@ -6963,7 +6996,7 @@ CREATE VIEW public.regulations_search_pg_view AS
     base_regulations_oplog.regulation_group_id,
     base_regulations_oplog.replacement_indicator,
     base_regulations_oplog.information_text AS keywords
-   FROM public.base_regulations_oplog
+   FROM base_regulations_oplog
 UNION
  SELECT concat_ws('_'::text, modification_regulations_oplog.oid, 'modification_regulation') AS id,
     modification_regulations_oplog.modification_regulation_id AS regulation_id,
@@ -6979,7 +7012,7 @@ UNION
     NULL::character varying AS regulation_group_id,
     modification_regulations_oplog.replacement_indicator,
     modification_regulations_oplog.information_text AS keywords
-   FROM public.modification_regulations_oplog
+   FROM modification_regulations_oplog
 UNION
  SELECT concat_ws('_'::text, complete_abrogation_regulations_oplog.oid, 'complete_abrogation_regulation') AS id,
     complete_abrogation_regulations_oplog.complete_abrogation_regulation_id AS regulation_id,
@@ -6995,7 +7028,7 @@ UNION
     NULL::character varying AS regulation_group_id,
     complete_abrogation_regulations_oplog.replacement_indicator,
     complete_abrogation_regulations_oplog.information_text AS keywords
-   FROM public.complete_abrogation_regulations_oplog
+   FROM complete_abrogation_regulations_oplog
 UNION
  SELECT concat_ws('_'::text, explicit_abrogation_regulations_oplog.oid, 'explicit_abrogation_regulation') AS id,
     explicit_abrogation_regulations_oplog.explicit_abrogation_regulation_id AS regulation_id,
@@ -7011,7 +7044,7 @@ UNION
     NULL::character varying AS regulation_group_id,
     explicit_abrogation_regulations_oplog.replacement_indicator,
     explicit_abrogation_regulations_oplog.information_text AS keywords
-   FROM public.explicit_abrogation_regulations_oplog
+   FROM explicit_abrogation_regulations_oplog
 UNION
  SELECT concat_ws('_'::text, prorogation_regulations_oplog.oid, 'prorogation_regulation') AS id,
     prorogation_regulations_oplog.prorogation_regulation_id AS regulation_id,
@@ -7027,7 +7060,7 @@ UNION
     NULL::character varying AS regulation_group_id,
     prorogation_regulations_oplog.replacement_indicator,
     prorogation_regulations_oplog.information_text AS keywords
-   FROM public.prorogation_regulations_oplog
+   FROM prorogation_regulations_oplog
 UNION
  SELECT concat_ws('_'::text, full_temporary_stop_regulations_oplog.oid, 'full_temporary_stop_regulation') AS id,
     full_temporary_stop_regulations_oplog.full_temporary_stop_regulation_id AS regulation_id,
@@ -7043,14 +7076,14 @@ UNION
     NULL::character varying AS regulation_group_id,
     full_temporary_stop_regulations_oplog.replacement_indicator,
     full_temporary_stop_regulations_oplog.information_text AS keywords
-   FROM public.full_temporary_stop_regulations_oplog;
+   FROM full_temporary_stop_regulations_oplog;
 
 
 --
 -- Name: rollbacks; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.rollbacks (
+CREATE TABLE rollbacks (
     id integer NOT NULL,
     user_id integer,
     date date,
@@ -7064,7 +7097,7 @@ CREATE TABLE public.rollbacks (
 -- Name: rollbacks_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.rollbacks_id_seq
+CREATE SEQUENCE rollbacks_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7076,14 +7109,14 @@ CREATE SEQUENCE public.rollbacks_id_seq
 -- Name: rollbacks_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.rollbacks_id_seq OWNED BY public.rollbacks.id;
+ALTER SEQUENCE rollbacks_id_seq OWNED BY rollbacks.id;
 
 
 --
 -- Name: schema_migrations; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.schema_migrations (
+CREATE TABLE schema_migrations (
     filename text NOT NULL
 );
 
@@ -7092,7 +7125,7 @@ CREATE TABLE public.schema_migrations (
 -- Name: search_references; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.search_references (
+CREATE TABLE search_references (
     id integer NOT NULL,
     title text,
     referenced_id character varying(10),
@@ -7104,7 +7137,7 @@ CREATE TABLE public.search_references (
 -- Name: search_references_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.search_references_id_seq
+CREATE SEQUENCE search_references_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7116,14 +7149,14 @@ CREATE SEQUENCE public.search_references_id_seq
 -- Name: search_references_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.search_references_id_seq OWNED BY public.search_references.id;
+ALTER SEQUENCE search_references_id_seq OWNED BY search_references.id;
 
 
 --
 -- Name: section_notes; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.section_notes (
+CREATE TABLE section_notes (
     id integer NOT NULL,
     section_id integer,
     content text
@@ -7134,7 +7167,7 @@ CREATE TABLE public.section_notes (
 -- Name: section_notes_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.section_notes_id_seq
+CREATE SEQUENCE section_notes_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7146,14 +7179,14 @@ CREATE SEQUENCE public.section_notes_id_seq
 -- Name: section_notes_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.section_notes_id_seq OWNED BY public.section_notes.id;
+ALTER SEQUENCE section_notes_id_seq OWNED BY section_notes.id;
 
 
 --
 -- Name: sections; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.sections (
+CREATE TABLE sections (
     id integer NOT NULL,
     "position" integer,
     numeral character varying(255),
@@ -7166,7 +7199,7 @@ CREATE TABLE public.sections (
 -- Name: sections_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.sections_id_seq
+CREATE SEQUENCE sections_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7178,14 +7211,14 @@ CREATE SEQUENCE public.sections_id_seq
 -- Name: sections_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.sections_id_seq OWNED BY public.sections.id;
+ALTER SEQUENCE sections_id_seq OWNED BY sections.id;
 
 
 --
 -- Name: tariff_update_conformance_errors; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.tariff_update_conformance_errors (
+CREATE TABLE tariff_update_conformance_errors (
     id integer NOT NULL,
     tariff_update_filename text NOT NULL,
     model_name text NOT NULL,
@@ -7199,7 +7232,7 @@ CREATE TABLE public.tariff_update_conformance_errors (
 -- Name: tariff_update_conformance_errors_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.tariff_update_conformance_errors_id_seq
+CREATE SEQUENCE tariff_update_conformance_errors_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7211,14 +7244,14 @@ CREATE SEQUENCE public.tariff_update_conformance_errors_id_seq
 -- Name: tariff_update_conformance_errors_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.tariff_update_conformance_errors_id_seq OWNED BY public.tariff_update_conformance_errors.id;
+ALTER SEQUENCE tariff_update_conformance_errors_id_seq OWNED BY tariff_update_conformance_errors.id;
 
 
 --
 -- Name: tariff_updates; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.tariff_updates (
+CREATE TABLE tariff_updates (
     filename character varying(30) NOT NULL,
     update_type character varying(50),
     state character varying(1),
@@ -7239,7 +7272,7 @@ CREATE TABLE public.tariff_updates (
 -- Name: transmission_comments_oplog; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.transmission_comments_oplog (
+CREATE TABLE transmission_comments_oplog (
     comment_sid integer,
     language_id character varying(5),
     comment_text text,
@@ -7257,7 +7290,7 @@ CREATE TABLE public.transmission_comments_oplog (
 -- Name: transmission_comments; Type: VIEW; Schema: public; Owner: -
 --
 
-CREATE VIEW public.transmission_comments AS
+CREATE VIEW transmission_comments AS
  SELECT transmission_comments1.comment_sid,
     transmission_comments1.language_id,
     transmission_comments1.comment_text,
@@ -7267,9 +7300,9 @@ CREATE VIEW public.transmission_comments AS
     transmission_comments1.status,
     transmission_comments1.workbasket_id,
     transmission_comments1.workbasket_sequence_number
-   FROM public.transmission_comments_oplog transmission_comments1
+   FROM transmission_comments_oplog transmission_comments1
   WHERE ((transmission_comments1.oid IN ( SELECT max(transmission_comments2.oid) AS max
-           FROM public.transmission_comments_oplog transmission_comments2
+           FROM transmission_comments_oplog transmission_comments2
           WHERE ((transmission_comments1.comment_sid = transmission_comments2.comment_sid) AND ((transmission_comments1.language_id)::text = (transmission_comments2.language_id)::text)))) AND ((transmission_comments1.operation)::text <> 'D'::text));
 
 
@@ -7277,7 +7310,7 @@ CREATE VIEW public.transmission_comments AS
 -- Name: transmission_comments_oid_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.transmission_comments_oid_seq
+CREATE SEQUENCE transmission_comments_oid_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7289,14 +7322,14 @@ CREATE SEQUENCE public.transmission_comments_oid_seq
 -- Name: transmission_comments_oid_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.transmission_comments_oid_seq OWNED BY public.transmission_comments_oplog.oid;
+ALTER SEQUENCE transmission_comments_oid_seq OWNED BY transmission_comments_oplog.oid;
 
 
 --
 -- Name: users; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.users (
+CREATE TABLE users (
     id integer NOT NULL,
     uid text,
     name text,
@@ -7316,7 +7349,7 @@ CREATE TABLE public.users (
 -- Name: users_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.users_id_seq
+CREATE SEQUENCE users_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7328,14 +7361,14 @@ CREATE SEQUENCE public.users_id_seq
 -- Name: users_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.users_id_seq OWNED BY public.users.id;
+ALTER SEQUENCE users_id_seq OWNED BY users.id;
 
 
 --
 -- Name: workbasket_items; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.workbasket_items (
+CREATE TABLE workbasket_items (
     id integer NOT NULL,
     workbasket_id integer,
     record_id integer,
@@ -7355,7 +7388,7 @@ CREATE TABLE public.workbasket_items (
 -- Name: workbasket_items_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.workbasket_items_id_seq
+CREATE SEQUENCE workbasket_items_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7367,14 +7400,14 @@ CREATE SEQUENCE public.workbasket_items_id_seq
 -- Name: workbasket_items_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.workbasket_items_id_seq OWNED BY public.workbasket_items.id;
+ALTER SEQUENCE workbasket_items_id_seq OWNED BY workbasket_items.id;
 
 
 --
 -- Name: workbaskets; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.workbaskets (
+CREATE TABLE workbaskets (
     id integer NOT NULL,
     title text,
     type text,
@@ -7401,7 +7434,7 @@ CREATE TABLE public.workbaskets (
 -- Name: workbaskets_events; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.workbaskets_events (
+CREATE TABLE workbaskets_events (
     id integer NOT NULL,
     workbasket_id integer,
     user_id integer,
@@ -7416,7 +7449,7 @@ CREATE TABLE public.workbaskets_events (
 -- Name: workbaskets_events_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.workbaskets_events_id_seq
+CREATE SEQUENCE workbaskets_events_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7428,14 +7461,14 @@ CREATE SEQUENCE public.workbaskets_events_id_seq
 -- Name: workbaskets_events_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.workbaskets_events_id_seq OWNED BY public.workbaskets_events.id;
+ALTER SEQUENCE workbaskets_events_id_seq OWNED BY workbaskets_events.id;
 
 
 --
 -- Name: workbaskets_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.workbaskets_id_seq
+CREATE SEQUENCE workbaskets_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7447,14 +7480,14 @@ CREATE SEQUENCE public.workbaskets_id_seq
 -- Name: workbaskets_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.workbaskets_id_seq OWNED BY public.workbaskets.id;
+ALTER SEQUENCE workbaskets_id_seq OWNED BY workbaskets.id;
 
 
 --
 -- Name: xml_export_files; Type: TABLE; Schema: public; Owner: -
 --
 
-CREATE TABLE public.xml_export_files (
+CREATE TABLE xml_export_files (
     id integer NOT NULL,
     state character varying(1),
     updated_at timestamp without time zone,
@@ -7472,7 +7505,7 @@ CREATE TABLE public.xml_export_files (
 -- Name: xml_export_files_id_seq; Type: SEQUENCE; Schema: public; Owner: -
 --
 
-CREATE SEQUENCE public.xml_export_files_id_seq
+CREATE SEQUENCE xml_export_files_id_seq
     START WITH 1
     INCREMENT BY 1
     NO MINVALUE
@@ -7484,847 +7517,847 @@ CREATE SEQUENCE public.xml_export_files_id_seq
 -- Name: xml_export_files_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
 --
 
-ALTER SEQUENCE public.xml_export_files_id_seq OWNED BY public.xml_export_files.id;
+ALTER SEQUENCE xml_export_files_id_seq OWNED BY xml_export_files.id;
 
 
 --
 -- Name: additional_code_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY additional_code_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY additional_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY additional_code_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_type_measure_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_type_measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_type_measure_types_oid_seq'::regclass);
+ALTER TABLE ONLY additional_code_type_measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_type_measure_types_oid_seq'::regclass);
 
 
 --
 -- Name: additional_code_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_code_types_oid_seq'::regclass);
+ALTER TABLE ONLY additional_code_types_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_code_types_oid_seq'::regclass);
 
 
 --
 -- Name: additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.additional_codes_oid_seq'::regclass);
+ALTER TABLE ONLY additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('additional_codes_oid_seq'::regclass);
 
 
 --
 -- Name: audits id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.audits ALTER COLUMN id SET DEFAULT nextval('public.audits_id_seq'::regclass);
+ALTER TABLE ONLY audits ALTER COLUMN id SET DEFAULT nextval('audits_id_seq'::regclass);
 
 
 --
 -- Name: base_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.base_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.base_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY base_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('base_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY certificate_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY certificate_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY certificate_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: certificate_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificate_types_oid_seq'::regclass);
+ALTER TABLE ONLY certificate_types_oplog ALTER COLUMN oid SET DEFAULT nextval('certificate_types_oid_seq'::regclass);
 
 
 --
 -- Name: certificates_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificates_oplog ALTER COLUMN oid SET DEFAULT nextval('public.certificates_oid_seq'::regclass);
+ALTER TABLE ONLY certificates_oplog ALTER COLUMN oid SET DEFAULT nextval('certificates_oid_seq'::regclass);
 
 
 --
 -- Name: chapter_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chapter_notes ALTER COLUMN id SET DEFAULT nextval('public.chapter_notes_id_seq'::regclass);
+ALTER TABLE ONLY chapter_notes ALTER COLUMN id SET DEFAULT nextval('chapter_notes_id_seq'::regclass);
 
 
 --
 -- Name: chief_duty_expression id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chief_duty_expression ALTER COLUMN id SET DEFAULT nextval('public.chief_duty_expression_id_seq'::regclass);
+ALTER TABLE ONLY chief_duty_expression ALTER COLUMN id SET DEFAULT nextval('chief_duty_expression_id_seq'::regclass);
 
 
 --
 -- Name: chief_measure_type_footnote id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chief_measure_type_footnote ALTER COLUMN id SET DEFAULT nextval('public.chief_measure_type_footnote_id_seq'::regclass);
+ALTER TABLE ONLY chief_measure_type_footnote ALTER COLUMN id SET DEFAULT nextval('chief_measure_type_footnote_id_seq'::regclass);
 
 
 --
 -- Name: chief_measurement_unit id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chief_measurement_unit ALTER COLUMN id SET DEFAULT nextval('public.chief_measurement_unit_id_seq'::regclass);
+ALTER TABLE ONLY chief_measurement_unit ALTER COLUMN id SET DEFAULT nextval('chief_measurement_unit_id_seq'::regclass);
 
 
 --
 -- Name: complete_abrogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.complete_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.complete_abrogation_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY complete_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('complete_abrogation_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: create_measures_workbasket_settings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.create_measures_workbasket_settings ALTER COLUMN id SET DEFAULT nextval('public.create_measures_workbasket_settings_id_seq'::regclass);
+ALTER TABLE ONLY create_measures_workbasket_settings ALTER COLUMN id SET DEFAULT nextval('create_measures_workbasket_settings_id_seq'::regclass);
 
 
 --
 -- Name: create_quota_workbasket_settings id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.create_quota_workbasket_settings ALTER COLUMN id SET DEFAULT nextval('public.create_quota_workbasket_settings_id_seq'::regclass);
+ALTER TABLE ONLY create_quota_workbasket_settings ALTER COLUMN id SET DEFAULT nextval('create_quota_workbasket_settings_id_seq'::regclass);
 
 
 --
 -- Name: db_rollbacks id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.db_rollbacks ALTER COLUMN id SET DEFAULT nextval('public.db_rollbacks_id_seq'::regclass);
+ALTER TABLE ONLY db_rollbacks ALTER COLUMN id SET DEFAULT nextval('db_rollbacks_id_seq'::regclass);
 
 
 --
 -- Name: duty_expression_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.duty_expression_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.duty_expression_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY duty_expression_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('duty_expression_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: duty_expressions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.duty_expressions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.duty_expressions_oid_seq'::regclass);
+ALTER TABLE ONLY duty_expressions_oplog ALTER COLUMN oid SET DEFAULT nextval('duty_expressions_oid_seq'::regclass);
 
 
 --
 -- Name: explicit_abrogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.explicit_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.explicit_abrogation_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY explicit_abrogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('explicit_abrogation_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclature_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclature_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclature_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclature_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclature_indents_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclature_indents_oid_seq'::regclass);
+ALTER TABLE ONLY export_refund_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclature_indents_oid_seq'::regclass);
 
 
 --
 -- Name: export_refund_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.export_refund_nomenclatures_oid_seq'::regclass);
+ALTER TABLE ONLY export_refund_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('export_refund_nomenclatures_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_additional_codes_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_association_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_additional_codes_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_erns_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_erns_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_erns_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_association_erns_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_erns_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_goods_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_goods_nomenclatures_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_goods_nomenclatures_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_measures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_measures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_measures_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_association_measures_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_measures_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_association_meursing_headings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_association_meursing_headings_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_association_meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_association_meursing_headings_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: footnote_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnote_types_oid_seq'::regclass);
+ALTER TABLE ONLY footnote_types_oplog ALTER COLUMN oid SET DEFAULT nextval('footnote_types_oid_seq'::regclass);
 
 
 --
 -- Name: footnotes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnotes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.footnotes_oid_seq'::regclass);
+ALTER TABLE ONLY footnotes_oplog ALTER COLUMN oid SET DEFAULT nextval('footnotes_oid_seq'::regclass);
 
 
 --
 -- Name: fts_regulation_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.fts_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.fts_regulation_actions_oid_seq'::regclass);
+ALTER TABLE ONLY fts_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('fts_regulation_actions_oid_seq'::regclass);
 
 
 --
 -- Name: full_temporary_stop_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.full_temporary_stop_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.full_temporary_stop_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY full_temporary_stop_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('full_temporary_stop_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_area_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_area_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_area_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY geographical_area_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_area_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_area_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_area_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY geographical_area_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_area_memberships_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_area_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_area_memberships_oid_seq'::regclass);
+ALTER TABLE ONLY geographical_area_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_area_memberships_oid_seq'::regclass);
 
 
 --
 -- Name: geographical_areas_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('public.geographical_areas_oid_seq'::regclass);
+ALTER TABLE ONLY geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('geographical_areas_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_description_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_description_periods_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclature_description_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_description_periods_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclature_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_group_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_group_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_group_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_groups_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_groups_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclature_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_groups_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_indents_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_indents_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclature_indents_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_indents_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_origins_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_origins_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclature_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_origins_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclature_successors_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_successors_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclature_successors_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclature_successors_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclature_successors_oid_seq'::regclass);
 
 
 --
 -- Name: goods_nomenclatures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.goods_nomenclatures_oid_seq'::regclass);
+ALTER TABLE ONLY goods_nomenclatures_oplog ALTER COLUMN oid SET DEFAULT nextval('goods_nomenclatures_oid_seq'::regclass);
 
 
 --
 -- Name: language_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.language_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.language_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY language_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('language_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: languages_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.languages_oplog ALTER COLUMN oid SET DEFAULT nextval('public.languages_oid_seq'::regclass);
+ALTER TABLE ONLY languages_oplog ALTER COLUMN oid SET DEFAULT nextval('languages_oid_seq'::regclass);
 
 
 --
 -- Name: measure_action_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_action_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_action_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY measure_action_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_action_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_actions_oid_seq'::regclass);
+ALTER TABLE ONLY measure_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_actions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_components_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_components_oid_seq'::regclass);
+ALTER TABLE ONLY measure_components_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_components_oid_seq'::regclass);
 
 
 --
 -- Name: measure_condition_code_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_condition_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_condition_code_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY measure_condition_code_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_code_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_condition_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_condition_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_condition_codes_oid_seq'::regclass);
+ALTER TABLE ONLY measure_condition_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_codes_oid_seq'::regclass);
 
 
 --
 -- Name: measure_condition_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_condition_components_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_condition_components_oid_seq'::regclass);
+ALTER TABLE ONLY measure_condition_components_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_condition_components_oid_seq'::regclass);
 
 
 --
 -- Name: measure_conditions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_conditions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_conditions_oid_seq'::regclass);
+ALTER TABLE ONLY measure_conditions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_conditions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_excluded_geographical_areas_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_excluded_geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_excluded_geographical_areas_oid_seq'::regclass);
+ALTER TABLE ONLY measure_excluded_geographical_areas_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_excluded_geographical_areas_oid_seq'::regclass);
 
 
 --
 -- Name: measure_partial_temporary_stops_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_partial_temporary_stops_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_partial_temporary_stops_oid_seq'::regclass);
+ALTER TABLE ONLY measure_partial_temporary_stops_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_partial_temporary_stops_oid_seq'::regclass);
 
 
 --
 -- Name: measure_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY measure_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_type_series_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_type_series_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_type_series_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY measure_type_series_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_series_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measure_type_series_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_type_series_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_type_series_oid_seq'::regclass);
+ALTER TABLE ONLY measure_type_series_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_type_series_oid_seq'::regclass);
 
 
 --
 -- Name: measure_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measure_types_oid_seq'::regclass);
+ALTER TABLE ONLY measure_types_oplog ALTER COLUMN oid SET DEFAULT nextval('measure_types_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_abbreviations id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_abbreviations ALTER COLUMN id SET DEFAULT nextval('public.measurement_unit_abbreviations_id_seq'::regclass);
+ALTER TABLE ONLY measurement_unit_abbreviations ALTER COLUMN id SET DEFAULT nextval('measurement_unit_abbreviations_id_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_unit_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY measurement_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_qualifier_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_qualifier_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_unit_qualifier_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_qualifier_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_unit_qualifiers_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_qualifiers_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_unit_qualifiers_oid_seq'::regclass);
+ALTER TABLE ONLY measurement_unit_qualifiers_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_unit_qualifiers_oid_seq'::regclass);
 
 
 --
 -- Name: measurement_units_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_units_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurement_units_oid_seq'::regclass);
+ALTER TABLE ONLY measurement_units_oplog ALTER COLUMN oid SET DEFAULT nextval('measurement_units_oid_seq'::regclass);
 
 
 --
 -- Name: measurements_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurements_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measurements_oid_seq'::regclass);
+ALTER TABLE ONLY measurements_oplog ALTER COLUMN oid SET DEFAULT nextval('measurements_oid_seq'::regclass);
 
 
 --
 -- Name: measures_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measures_oplog ALTER COLUMN oid SET DEFAULT nextval('public.measures_oid_seq'::regclass);
+ALTER TABLE ONLY measures_oplog ALTER COLUMN oid SET DEFAULT nextval('measures_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_additional_codes_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_additional_codes_oid_seq'::regclass);
+ALTER TABLE ONLY meursing_additional_codes_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_additional_codes_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_heading_texts_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_heading_texts_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_heading_texts_oid_seq'::regclass);
+ALTER TABLE ONLY meursing_heading_texts_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_heading_texts_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_headings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_headings_oid_seq'::regclass);
+ALTER TABLE ONLY meursing_headings_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_headings_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_subheadings_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_subheadings_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_subheadings_oid_seq'::regclass);
+ALTER TABLE ONLY meursing_subheadings_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_subheadings_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_table_cell_components_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_table_cell_components_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_table_cell_components_oid_seq'::regclass);
+ALTER TABLE ONLY meursing_table_cell_components_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_table_cell_components_oid_seq'::regclass);
 
 
 --
 -- Name: meursing_table_plans_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_table_plans_oplog ALTER COLUMN oid SET DEFAULT nextval('public.meursing_table_plans_oid_seq'::regclass);
+ALTER TABLE ONLY meursing_table_plans_oplog ALTER COLUMN oid SET DEFAULT nextval('meursing_table_plans_oid_seq'::regclass);
 
 
 --
 -- Name: modification_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.modification_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.modification_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY modification_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('modification_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_exchange_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_exchange_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_exchange_periods_oid_seq'::regclass);
+ALTER TABLE ONLY monetary_exchange_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_exchange_periods_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_exchange_rates_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_exchange_rates_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_exchange_rates_oid_seq'::regclass);
+ALTER TABLE ONLY monetary_exchange_rates_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_exchange_rates_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_unit_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_unit_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY monetary_unit_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_unit_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: monetary_units_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_units_oplog ALTER COLUMN oid SET DEFAULT nextval('public.monetary_units_oid_seq'::regclass);
+ALTER TABLE ONLY monetary_units_oplog ALTER COLUMN oid SET DEFAULT nextval('monetary_units_oid_seq'::regclass);
 
 
 --
 -- Name: nomenclature_group_memberships_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.nomenclature_group_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('public.nomenclature_group_memberships_oid_seq'::regclass);
+ALTER TABLE ONLY nomenclature_group_memberships_oplog ALTER COLUMN oid SET DEFAULT nextval('nomenclature_group_memberships_oid_seq'::regclass);
 
 
 --
 -- Name: prorogation_regulation_actions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.prorogation_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.prorogation_regulation_actions_oid_seq'::regclass);
+ALTER TABLE ONLY prorogation_regulation_actions_oplog ALTER COLUMN oid SET DEFAULT nextval('prorogation_regulation_actions_oid_seq'::regclass);
 
 
 --
 -- Name: prorogation_regulations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.prorogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.prorogation_regulations_oid_seq'::regclass);
+ALTER TABLE ONLY prorogation_regulations_oplog ALTER COLUMN oid SET DEFAULT nextval('prorogation_regulations_oid_seq'::regclass);
 
 
 --
 -- Name: publication_sigles_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.publication_sigles_oplog ALTER COLUMN oid SET DEFAULT nextval('public.publication_sigles_oplog_oid_seq'::regclass);
+ALTER TABLE ONLY publication_sigles_oplog ALTER COLUMN oid SET DEFAULT nextval('publication_sigles_oplog_oid_seq'::regclass);
 
 
 --
 -- Name: quota_associations_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_associations_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_associations_oid_seq'::regclass);
+ALTER TABLE ONLY quota_associations_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_associations_oid_seq'::regclass);
 
 
 --
 -- Name: quota_balance_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_balance_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_balance_events_oid_seq'::regclass);
+ALTER TABLE ONLY quota_balance_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_balance_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_blocking_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_blocking_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_blocking_periods_oid_seq'::regclass);
+ALTER TABLE ONLY quota_blocking_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_blocking_periods_oid_seq'::regclass);
 
 
 --
 -- Name: quota_critical_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_critical_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_critical_events_oid_seq'::regclass);
+ALTER TABLE ONLY quota_critical_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_critical_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_definitions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_definitions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_definitions_oid_seq'::regclass);
+ALTER TABLE ONLY quota_definitions_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_definitions_oid_seq'::regclass);
 
 
 --
 -- Name: quota_exhaustion_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_exhaustion_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_exhaustion_events_oid_seq'::regclass);
+ALTER TABLE ONLY quota_exhaustion_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_exhaustion_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_order_number_origin_exclusions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_order_number_origin_exclusions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_order_number_origin_exclusions_oid_seq'::regclass);
+ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_number_origin_exclusions_oid_seq'::regclass);
 
 
 --
 -- Name: quota_order_number_origins_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_order_number_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_order_number_origins_oid_seq'::regclass);
+ALTER TABLE ONLY quota_order_number_origins_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_number_origins_oid_seq'::regclass);
 
 
 --
 -- Name: quota_order_numbers_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_order_numbers_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_order_numbers_oid_seq'::regclass);
+ALTER TABLE ONLY quota_order_numbers_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_order_numbers_oid_seq'::regclass);
 
 
 --
 -- Name: quota_reopening_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_reopening_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_reopening_events_oid_seq'::regclass);
+ALTER TABLE ONLY quota_reopening_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_reopening_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_suspension_periods_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_suspension_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_suspension_periods_oid_seq'::regclass);
+ALTER TABLE ONLY quota_suspension_periods_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_suspension_periods_oid_seq'::regclass);
 
 
 --
 -- Name: quota_unblocking_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_unblocking_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_unblocking_events_oid_seq'::regclass);
+ALTER TABLE ONLY quota_unblocking_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_unblocking_events_oid_seq'::regclass);
 
 
 --
 -- Name: quota_unsuspension_events_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_unsuspension_events_oplog ALTER COLUMN oid SET DEFAULT nextval('public.quota_unsuspension_events_oid_seq'::regclass);
+ALTER TABLE ONLY quota_unsuspension_events_oplog ALTER COLUMN oid SET DEFAULT nextval('quota_unsuspension_events_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_documents id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_documents ALTER COLUMN id SET DEFAULT nextval('public.regulation_documents_id_seq'::regclass);
+ALTER TABLE ONLY regulation_documents ALTER COLUMN id SET DEFAULT nextval('regulation_documents_id_seq'::regclass);
 
 
 --
 -- Name: regulation_group_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_group_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY regulation_group_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_group_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_groups_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_groups_oid_seq'::regclass);
+ALTER TABLE ONLY regulation_groups_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_groups_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_replacements_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_replacements_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_replacements_oid_seq'::regclass);
+ALTER TABLE ONLY regulation_replacements_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_replacements_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_role_type_descriptions_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_role_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_role_type_descriptions_oid_seq'::regclass);
+ALTER TABLE ONLY regulation_role_type_descriptions_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_role_type_descriptions_oid_seq'::regclass);
 
 
 --
 -- Name: regulation_role_types_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_role_types_oplog ALTER COLUMN oid SET DEFAULT nextval('public.regulation_role_types_oid_seq'::regclass);
+ALTER TABLE ONLY regulation_role_types_oplog ALTER COLUMN oid SET DEFAULT nextval('regulation_role_types_oid_seq'::regclass);
 
 
 --
 -- Name: rollbacks id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.rollbacks ALTER COLUMN id SET DEFAULT nextval('public.rollbacks_id_seq'::regclass);
+ALTER TABLE ONLY rollbacks ALTER COLUMN id SET DEFAULT nextval('rollbacks_id_seq'::regclass);
 
 
 --
 -- Name: search_references id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.search_references ALTER COLUMN id SET DEFAULT nextval('public.search_references_id_seq'::regclass);
+ALTER TABLE ONLY search_references ALTER COLUMN id SET DEFAULT nextval('search_references_id_seq'::regclass);
 
 
 --
 -- Name: section_notes id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.section_notes ALTER COLUMN id SET DEFAULT nextval('public.section_notes_id_seq'::regclass);
+ALTER TABLE ONLY section_notes ALTER COLUMN id SET DEFAULT nextval('section_notes_id_seq'::regclass);
 
 
 --
 -- Name: sections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.sections ALTER COLUMN id SET DEFAULT nextval('public.sections_id_seq'::regclass);
+ALTER TABLE ONLY sections ALTER COLUMN id SET DEFAULT nextval('sections_id_seq'::regclass);
 
 
 --
 -- Name: tariff_update_conformance_errors id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.tariff_update_conformance_errors ALTER COLUMN id SET DEFAULT nextval('public.tariff_update_conformance_errors_id_seq'::regclass);
+ALTER TABLE ONLY tariff_update_conformance_errors ALTER COLUMN id SET DEFAULT nextval('tariff_update_conformance_errors_id_seq'::regclass);
 
 
 --
 -- Name: transmission_comments_oplog oid; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.transmission_comments_oplog ALTER COLUMN oid SET DEFAULT nextval('public.transmission_comments_oid_seq'::regclass);
+ALTER TABLE ONLY transmission_comments_oplog ALTER COLUMN oid SET DEFAULT nextval('transmission_comments_oid_seq'::regclass);
 
 
 --
 -- Name: users id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.users ALTER COLUMN id SET DEFAULT nextval('public.users_id_seq'::regclass);
+ALTER TABLE ONLY users ALTER COLUMN id SET DEFAULT nextval('users_id_seq'::regclass);
 
 
 --
 -- Name: workbasket_items id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.workbasket_items ALTER COLUMN id SET DEFAULT nextval('public.workbasket_items_id_seq'::regclass);
+ALTER TABLE ONLY workbasket_items ALTER COLUMN id SET DEFAULT nextval('workbasket_items_id_seq'::regclass);
 
 
 --
 -- Name: workbaskets id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.workbaskets ALTER COLUMN id SET DEFAULT nextval('public.workbaskets_id_seq'::regclass);
+ALTER TABLE ONLY workbaskets ALTER COLUMN id SET DEFAULT nextval('workbaskets_id_seq'::regclass);
 
 
 --
 -- Name: workbaskets_events id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.workbaskets_events ALTER COLUMN id SET DEFAULT nextval('public.workbaskets_events_id_seq'::regclass);
+ALTER TABLE ONLY workbaskets_events ALTER COLUMN id SET DEFAULT nextval('workbaskets_events_id_seq'::regclass);
 
 
 --
 -- Name: xml_export_files id; Type: DEFAULT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.xml_export_files ALTER COLUMN id SET DEFAULT nextval('public.xml_export_files_id_seq'::regclass);
+ALTER TABLE ONLY xml_export_files ALTER COLUMN id SET DEFAULT nextval('xml_export_files_id_seq'::regclass);
 
 
 --
 -- Name: additional_code_description_periods_oplog additional_code_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_description_periods_oplog
+ALTER TABLE ONLY additional_code_description_periods_oplog
     ADD CONSTRAINT additional_code_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -8332,7 +8365,7 @@ ALTER TABLE ONLY public.additional_code_description_periods_oplog
 -- Name: additional_code_descriptions_oplog additional_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_descriptions_oplog
+ALTER TABLE ONLY additional_code_descriptions_oplog
     ADD CONSTRAINT additional_code_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8340,7 +8373,7 @@ ALTER TABLE ONLY public.additional_code_descriptions_oplog
 -- Name: additional_code_type_descriptions_oplog additional_code_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_type_descriptions_oplog
+ALTER TABLE ONLY additional_code_type_descriptions_oplog
     ADD CONSTRAINT additional_code_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8348,7 +8381,7 @@ ALTER TABLE ONLY public.additional_code_type_descriptions_oplog
 -- Name: additional_code_type_measure_types_oplog additional_code_type_measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_type_measure_types_oplog
+ALTER TABLE ONLY additional_code_type_measure_types_oplog
     ADD CONSTRAINT additional_code_type_measure_types_pkey PRIMARY KEY (oid);
 
 
@@ -8356,7 +8389,7 @@ ALTER TABLE ONLY public.additional_code_type_measure_types_oplog
 -- Name: additional_code_types_oplog additional_code_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_code_types_oplog
+ALTER TABLE ONLY additional_code_types_oplog
     ADD CONSTRAINT additional_code_types_pkey PRIMARY KEY (oid);
 
 
@@ -8364,7 +8397,7 @@ ALTER TABLE ONLY public.additional_code_types_oplog
 -- Name: additional_codes_oplog additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.additional_codes_oplog
+ALTER TABLE ONLY additional_codes_oplog
     ADD CONSTRAINT additional_codes_pkey PRIMARY KEY (oid);
 
 
@@ -8372,7 +8405,7 @@ ALTER TABLE ONLY public.additional_codes_oplog
 -- Name: audits audits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.audits
+ALTER TABLE ONLY audits
     ADD CONSTRAINT audits_pkey PRIMARY KEY (id);
 
 
@@ -8380,7 +8413,7 @@ ALTER TABLE ONLY public.audits
 -- Name: base_regulations_oplog base_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.base_regulations_oplog
+ALTER TABLE ONLY base_regulations_oplog
     ADD CONSTRAINT base_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -8388,7 +8421,7 @@ ALTER TABLE ONLY public.base_regulations_oplog
 -- Name: certificate_description_periods_oplog certificate_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_description_periods_oplog
+ALTER TABLE ONLY certificate_description_periods_oplog
     ADD CONSTRAINT certificate_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -8396,7 +8429,7 @@ ALTER TABLE ONLY public.certificate_description_periods_oplog
 -- Name: certificate_descriptions_oplog certificate_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_descriptions_oplog
+ALTER TABLE ONLY certificate_descriptions_oplog
     ADD CONSTRAINT certificate_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8404,7 +8437,7 @@ ALTER TABLE ONLY public.certificate_descriptions_oplog
 -- Name: certificate_type_descriptions_oplog certificate_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_type_descriptions_oplog
+ALTER TABLE ONLY certificate_type_descriptions_oplog
     ADD CONSTRAINT certificate_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8412,7 +8445,7 @@ ALTER TABLE ONLY public.certificate_type_descriptions_oplog
 -- Name: certificate_types_oplog certificate_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificate_types_oplog
+ALTER TABLE ONLY certificate_types_oplog
     ADD CONSTRAINT certificate_types_pkey PRIMARY KEY (oid);
 
 
@@ -8420,7 +8453,7 @@ ALTER TABLE ONLY public.certificate_types_oplog
 -- Name: certificates_oplog certificates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.certificates_oplog
+ALTER TABLE ONLY certificates_oplog
     ADD CONSTRAINT certificates_pkey PRIMARY KEY (oid);
 
 
@@ -8428,7 +8461,7 @@ ALTER TABLE ONLY public.certificates_oplog
 -- Name: chapter_notes chapter_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chapter_notes
+ALTER TABLE ONLY chapter_notes
     ADD CONSTRAINT chapter_notes_pkey PRIMARY KEY (id);
 
 
@@ -8436,7 +8469,7 @@ ALTER TABLE ONLY public.chapter_notes
 -- Name: chief_duty_expression chief_duty_expression_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chief_duty_expression
+ALTER TABLE ONLY chief_duty_expression
     ADD CONSTRAINT chief_duty_expression_pkey PRIMARY KEY (id);
 
 
@@ -8444,7 +8477,7 @@ ALTER TABLE ONLY public.chief_duty_expression
 -- Name: chief_measure_type_footnote chief_measure_type_footnote_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chief_measure_type_footnote
+ALTER TABLE ONLY chief_measure_type_footnote
     ADD CONSTRAINT chief_measure_type_footnote_pkey PRIMARY KEY (id);
 
 
@@ -8452,7 +8485,7 @@ ALTER TABLE ONLY public.chief_measure_type_footnote
 -- Name: chief_measurement_unit chief_measurement_unit_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.chief_measurement_unit
+ALTER TABLE ONLY chief_measurement_unit
     ADD CONSTRAINT chief_measurement_unit_pkey PRIMARY KEY (id);
 
 
@@ -8460,7 +8493,7 @@ ALTER TABLE ONLY public.chief_measurement_unit
 -- Name: complete_abrogation_regulations_oplog complete_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.complete_abrogation_regulations_oplog
+ALTER TABLE ONLY complete_abrogation_regulations_oplog
     ADD CONSTRAINT complete_abrogation_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -8468,7 +8501,7 @@ ALTER TABLE ONLY public.complete_abrogation_regulations_oplog
 -- Name: create_measures_workbasket_settings create_measures_workbasket_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.create_measures_workbasket_settings
+ALTER TABLE ONLY create_measures_workbasket_settings
     ADD CONSTRAINT create_measures_workbasket_settings_pkey PRIMARY KEY (id);
 
 
@@ -8476,7 +8509,7 @@ ALTER TABLE ONLY public.create_measures_workbasket_settings
 -- Name: create_quota_workbasket_settings create_quota_workbasket_settings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.create_quota_workbasket_settings
+ALTER TABLE ONLY create_quota_workbasket_settings
     ADD CONSTRAINT create_quota_workbasket_settings_pkey PRIMARY KEY (id);
 
 
@@ -8484,7 +8517,7 @@ ALTER TABLE ONLY public.create_quota_workbasket_settings
 -- Name: data_migrations data_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.data_migrations
+ALTER TABLE ONLY data_migrations
     ADD CONSTRAINT data_migrations_pkey PRIMARY KEY (filename);
 
 
@@ -8492,7 +8525,7 @@ ALTER TABLE ONLY public.data_migrations
 -- Name: db_rollbacks db_rollbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.db_rollbacks
+ALTER TABLE ONLY db_rollbacks
     ADD CONSTRAINT db_rollbacks_pkey PRIMARY KEY (id);
 
 
@@ -8500,7 +8533,7 @@ ALTER TABLE ONLY public.db_rollbacks
 -- Name: duty_expression_descriptions_oplog duty_expression_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.duty_expression_descriptions_oplog
+ALTER TABLE ONLY duty_expression_descriptions_oplog
     ADD CONSTRAINT duty_expression_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8508,7 +8541,7 @@ ALTER TABLE ONLY public.duty_expression_descriptions_oplog
 -- Name: duty_expressions_oplog duty_expressions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.duty_expressions_oplog
+ALTER TABLE ONLY duty_expressions_oplog
     ADD CONSTRAINT duty_expressions_pkey PRIMARY KEY (oid);
 
 
@@ -8516,7 +8549,7 @@ ALTER TABLE ONLY public.duty_expressions_oplog
 -- Name: explicit_abrogation_regulations_oplog explicit_abrogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.explicit_abrogation_regulations_oplog
+ALTER TABLE ONLY explicit_abrogation_regulations_oplog
     ADD CONSTRAINT explicit_abrogation_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -8524,7 +8557,7 @@ ALTER TABLE ONLY public.explicit_abrogation_regulations_oplog
 -- Name: export_refund_nomenclature_description_periods_oplog export_refund_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclature_description_periods_oplog
+ALTER TABLE ONLY export_refund_nomenclature_description_periods_oplog
     ADD CONSTRAINT export_refund_nomenclature_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -8532,7 +8565,7 @@ ALTER TABLE ONLY public.export_refund_nomenclature_description_periods_oplog
 -- Name: export_refund_nomenclature_descriptions_oplog export_refund_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclature_descriptions_oplog
+ALTER TABLE ONLY export_refund_nomenclature_descriptions_oplog
     ADD CONSTRAINT export_refund_nomenclature_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8540,7 +8573,7 @@ ALTER TABLE ONLY public.export_refund_nomenclature_descriptions_oplog
 -- Name: export_refund_nomenclature_indents_oplog export_refund_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclature_indents_oplog
+ALTER TABLE ONLY export_refund_nomenclature_indents_oplog
     ADD CONSTRAINT export_refund_nomenclature_indents_pkey PRIMARY KEY (oid);
 
 
@@ -8548,7 +8581,7 @@ ALTER TABLE ONLY public.export_refund_nomenclature_indents_oplog
 -- Name: export_refund_nomenclatures_oplog export_refund_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.export_refund_nomenclatures_oplog
+ALTER TABLE ONLY export_refund_nomenclatures_oplog
     ADD CONSTRAINT export_refund_nomenclatures_pkey PRIMARY KEY (oid);
 
 
@@ -8556,7 +8589,7 @@ ALTER TABLE ONLY public.export_refund_nomenclatures_oplog
 -- Name: footnote_association_additional_codes_oplog footnote_association_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_additional_codes_oplog
+ALTER TABLE ONLY footnote_association_additional_codes_oplog
     ADD CONSTRAINT footnote_association_additional_codes_pkey PRIMARY KEY (oid);
 
 
@@ -8564,7 +8597,7 @@ ALTER TABLE ONLY public.footnote_association_additional_codes_oplog
 -- Name: footnote_association_erns_oplog footnote_association_erns_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_erns_oplog
+ALTER TABLE ONLY footnote_association_erns_oplog
     ADD CONSTRAINT footnote_association_erns_pkey PRIMARY KEY (oid);
 
 
@@ -8572,7 +8605,7 @@ ALTER TABLE ONLY public.footnote_association_erns_oplog
 -- Name: footnote_association_goods_nomenclatures_oplog footnote_association_goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_goods_nomenclatures_oplog
+ALTER TABLE ONLY footnote_association_goods_nomenclatures_oplog
     ADD CONSTRAINT footnote_association_goods_nomenclatures_pkey PRIMARY KEY (oid);
 
 
@@ -8580,7 +8613,7 @@ ALTER TABLE ONLY public.footnote_association_goods_nomenclatures_oplog
 -- Name: footnote_association_measures_oplog footnote_association_measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_measures_oplog
+ALTER TABLE ONLY footnote_association_measures_oplog
     ADD CONSTRAINT footnote_association_measures_pkey PRIMARY KEY (oid);
 
 
@@ -8588,7 +8621,7 @@ ALTER TABLE ONLY public.footnote_association_measures_oplog
 -- Name: footnote_association_meursing_headings_oplog footnote_association_meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_association_meursing_headings_oplog
+ALTER TABLE ONLY footnote_association_meursing_headings_oplog
     ADD CONSTRAINT footnote_association_meursing_headings_pkey PRIMARY KEY (oid);
 
 
@@ -8596,7 +8629,7 @@ ALTER TABLE ONLY public.footnote_association_meursing_headings_oplog
 -- Name: footnote_description_periods_oplog footnote_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_description_periods_oplog
+ALTER TABLE ONLY footnote_description_periods_oplog
     ADD CONSTRAINT footnote_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -8604,7 +8637,7 @@ ALTER TABLE ONLY public.footnote_description_periods_oplog
 -- Name: footnote_descriptions_oplog footnote_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_descriptions_oplog
+ALTER TABLE ONLY footnote_descriptions_oplog
     ADD CONSTRAINT footnote_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8612,7 +8645,7 @@ ALTER TABLE ONLY public.footnote_descriptions_oplog
 -- Name: footnote_type_descriptions_oplog footnote_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_type_descriptions_oplog
+ALTER TABLE ONLY footnote_type_descriptions_oplog
     ADD CONSTRAINT footnote_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8620,7 +8653,7 @@ ALTER TABLE ONLY public.footnote_type_descriptions_oplog
 -- Name: footnote_types_oplog footnote_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnote_types_oplog
+ALTER TABLE ONLY footnote_types_oplog
     ADD CONSTRAINT footnote_types_pkey PRIMARY KEY (oid);
 
 
@@ -8628,7 +8661,7 @@ ALTER TABLE ONLY public.footnote_types_oplog
 -- Name: footnotes_oplog footnotes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.footnotes_oplog
+ALTER TABLE ONLY footnotes_oplog
     ADD CONSTRAINT footnotes_pkey PRIMARY KEY (oid);
 
 
@@ -8636,7 +8669,7 @@ ALTER TABLE ONLY public.footnotes_oplog
 -- Name: fts_regulation_actions_oplog fts_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.fts_regulation_actions_oplog
+ALTER TABLE ONLY fts_regulation_actions_oplog
     ADD CONSTRAINT fts_regulation_actions_pkey PRIMARY KEY (oid);
 
 
@@ -8644,7 +8677,7 @@ ALTER TABLE ONLY public.fts_regulation_actions_oplog
 -- Name: full_temporary_stop_regulations_oplog full_temporary_stop_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.full_temporary_stop_regulations_oplog
+ALTER TABLE ONLY full_temporary_stop_regulations_oplog
     ADD CONSTRAINT full_temporary_stop_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -8652,7 +8685,7 @@ ALTER TABLE ONLY public.full_temporary_stop_regulations_oplog
 -- Name: geographical_area_description_periods_oplog geographical_area_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_area_description_periods_oplog
+ALTER TABLE ONLY geographical_area_description_periods_oplog
     ADD CONSTRAINT geographical_area_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -8660,7 +8693,7 @@ ALTER TABLE ONLY public.geographical_area_description_periods_oplog
 -- Name: geographical_area_descriptions_oplog geographical_area_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_area_descriptions_oplog
+ALTER TABLE ONLY geographical_area_descriptions_oplog
     ADD CONSTRAINT geographical_area_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8668,7 +8701,7 @@ ALTER TABLE ONLY public.geographical_area_descriptions_oplog
 -- Name: geographical_area_memberships_oplog geographical_area_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_area_memberships_oplog
+ALTER TABLE ONLY geographical_area_memberships_oplog
     ADD CONSTRAINT geographical_area_memberships_pkey PRIMARY KEY (oid);
 
 
@@ -8676,7 +8709,7 @@ ALTER TABLE ONLY public.geographical_area_memberships_oplog
 -- Name: geographical_areas_oplog geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.geographical_areas_oplog
+ALTER TABLE ONLY geographical_areas_oplog
     ADD CONSTRAINT geographical_areas_pkey PRIMARY KEY (oid);
 
 
@@ -8684,7 +8717,7 @@ ALTER TABLE ONLY public.geographical_areas_oplog
 -- Name: goods_nomenclature_description_periods_oplog goods_nomenclature_description_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_description_periods_oplog
+ALTER TABLE ONLY goods_nomenclature_description_periods_oplog
     ADD CONSTRAINT goods_nomenclature_description_periods_pkey PRIMARY KEY (oid);
 
 
@@ -8692,7 +8725,7 @@ ALTER TABLE ONLY public.goods_nomenclature_description_periods_oplog
 -- Name: goods_nomenclature_descriptions_oplog goods_nomenclature_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_descriptions_oplog
+ALTER TABLE ONLY goods_nomenclature_descriptions_oplog
     ADD CONSTRAINT goods_nomenclature_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8700,7 +8733,7 @@ ALTER TABLE ONLY public.goods_nomenclature_descriptions_oplog
 -- Name: goods_nomenclature_group_descriptions_oplog goods_nomenclature_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_group_descriptions_oplog
+ALTER TABLE ONLY goods_nomenclature_group_descriptions_oplog
     ADD CONSTRAINT goods_nomenclature_group_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8708,7 +8741,7 @@ ALTER TABLE ONLY public.goods_nomenclature_group_descriptions_oplog
 -- Name: goods_nomenclature_groups_oplog goods_nomenclature_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_groups_oplog
+ALTER TABLE ONLY goods_nomenclature_groups_oplog
     ADD CONSTRAINT goods_nomenclature_groups_pkey PRIMARY KEY (oid);
 
 
@@ -8716,7 +8749,7 @@ ALTER TABLE ONLY public.goods_nomenclature_groups_oplog
 -- Name: goods_nomenclature_indents_oplog goods_nomenclature_indents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_indents_oplog
+ALTER TABLE ONLY goods_nomenclature_indents_oplog
     ADD CONSTRAINT goods_nomenclature_indents_pkey PRIMARY KEY (oid);
 
 
@@ -8724,7 +8757,7 @@ ALTER TABLE ONLY public.goods_nomenclature_indents_oplog
 -- Name: goods_nomenclature_origins_oplog goods_nomenclature_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_origins_oplog
+ALTER TABLE ONLY goods_nomenclature_origins_oplog
     ADD CONSTRAINT goods_nomenclature_origins_pkey PRIMARY KEY (oid);
 
 
@@ -8732,7 +8765,7 @@ ALTER TABLE ONLY public.goods_nomenclature_origins_oplog
 -- Name: goods_nomenclature_successors_oplog goods_nomenclature_successors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclature_successors_oplog
+ALTER TABLE ONLY goods_nomenclature_successors_oplog
     ADD CONSTRAINT goods_nomenclature_successors_pkey PRIMARY KEY (oid);
 
 
@@ -8740,7 +8773,7 @@ ALTER TABLE ONLY public.goods_nomenclature_successors_oplog
 -- Name: goods_nomenclatures_oplog goods_nomenclatures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.goods_nomenclatures_oplog
+ALTER TABLE ONLY goods_nomenclatures_oplog
     ADD CONSTRAINT goods_nomenclatures_pkey PRIMARY KEY (oid);
 
 
@@ -8748,7 +8781,7 @@ ALTER TABLE ONLY public.goods_nomenclatures_oplog
 -- Name: language_descriptions_oplog language_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.language_descriptions_oplog
+ALTER TABLE ONLY language_descriptions_oplog
     ADD CONSTRAINT language_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8756,7 +8789,7 @@ ALTER TABLE ONLY public.language_descriptions_oplog
 -- Name: languages_oplog languages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.languages_oplog
+ALTER TABLE ONLY languages_oplog
     ADD CONSTRAINT languages_pkey PRIMARY KEY (oid);
 
 
@@ -8764,7 +8797,7 @@ ALTER TABLE ONLY public.languages_oplog
 -- Name: measure_action_descriptions_oplog measure_action_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_action_descriptions_oplog
+ALTER TABLE ONLY measure_action_descriptions_oplog
     ADD CONSTRAINT measure_action_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8772,7 +8805,7 @@ ALTER TABLE ONLY public.measure_action_descriptions_oplog
 -- Name: measure_actions_oplog measure_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_actions_oplog
+ALTER TABLE ONLY measure_actions_oplog
     ADD CONSTRAINT measure_actions_pkey PRIMARY KEY (oid);
 
 
@@ -8780,7 +8813,7 @@ ALTER TABLE ONLY public.measure_actions_oplog
 -- Name: measure_components_oplog measure_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_components_oplog
+ALTER TABLE ONLY measure_components_oplog
     ADD CONSTRAINT measure_components_pkey PRIMARY KEY (oid);
 
 
@@ -8788,7 +8821,7 @@ ALTER TABLE ONLY public.measure_components_oplog
 -- Name: measure_condition_code_descriptions_oplog measure_condition_code_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_condition_code_descriptions_oplog
+ALTER TABLE ONLY measure_condition_code_descriptions_oplog
     ADD CONSTRAINT measure_condition_code_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8796,7 +8829,7 @@ ALTER TABLE ONLY public.measure_condition_code_descriptions_oplog
 -- Name: measure_condition_codes_oplog measure_condition_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_condition_codes_oplog
+ALTER TABLE ONLY measure_condition_codes_oplog
     ADD CONSTRAINT measure_condition_codes_pkey PRIMARY KEY (oid);
 
 
@@ -8804,7 +8837,7 @@ ALTER TABLE ONLY public.measure_condition_codes_oplog
 -- Name: measure_condition_components_oplog measure_condition_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_condition_components_oplog
+ALTER TABLE ONLY measure_condition_components_oplog
     ADD CONSTRAINT measure_condition_components_pkey PRIMARY KEY (oid);
 
 
@@ -8812,7 +8845,7 @@ ALTER TABLE ONLY public.measure_condition_components_oplog
 -- Name: measure_conditions_oplog measure_conditions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_conditions_oplog
+ALTER TABLE ONLY measure_conditions_oplog
     ADD CONSTRAINT measure_conditions_pkey PRIMARY KEY (oid);
 
 
@@ -8820,7 +8853,7 @@ ALTER TABLE ONLY public.measure_conditions_oplog
 -- Name: measure_excluded_geographical_areas_oplog measure_excluded_geographical_areas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_excluded_geographical_areas_oplog
+ALTER TABLE ONLY measure_excluded_geographical_areas_oplog
     ADD CONSTRAINT measure_excluded_geographical_areas_pkey PRIMARY KEY (oid);
 
 
@@ -8828,7 +8861,7 @@ ALTER TABLE ONLY public.measure_excluded_geographical_areas_oplog
 -- Name: measure_partial_temporary_stops_oplog measure_partial_temporary_stops_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_partial_temporary_stops_oplog
+ALTER TABLE ONLY measure_partial_temporary_stops_oplog
     ADD CONSTRAINT measure_partial_temporary_stops_pkey PRIMARY KEY (oid);
 
 
@@ -8836,7 +8869,7 @@ ALTER TABLE ONLY public.measure_partial_temporary_stops_oplog
 -- Name: measure_type_descriptions_oplog measure_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_type_descriptions_oplog
+ALTER TABLE ONLY measure_type_descriptions_oplog
     ADD CONSTRAINT measure_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8844,7 +8877,7 @@ ALTER TABLE ONLY public.measure_type_descriptions_oplog
 -- Name: measure_type_series_descriptions_oplog measure_type_series_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_type_series_descriptions_oplog
+ALTER TABLE ONLY measure_type_series_descriptions_oplog
     ADD CONSTRAINT measure_type_series_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8852,7 +8885,7 @@ ALTER TABLE ONLY public.measure_type_series_descriptions_oplog
 -- Name: measure_type_series_oplog measure_type_series_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_type_series_oplog
+ALTER TABLE ONLY measure_type_series_oplog
     ADD CONSTRAINT measure_type_series_pkey PRIMARY KEY (oid);
 
 
@@ -8860,7 +8893,7 @@ ALTER TABLE ONLY public.measure_type_series_oplog
 -- Name: measure_types_oplog measure_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measure_types_oplog
+ALTER TABLE ONLY measure_types_oplog
     ADD CONSTRAINT measure_types_pkey PRIMARY KEY (oid);
 
 
@@ -8868,7 +8901,7 @@ ALTER TABLE ONLY public.measure_types_oplog
 -- Name: measurement_unit_abbreviations measurement_unit_abbreviations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_abbreviations
+ALTER TABLE ONLY measurement_unit_abbreviations
     ADD CONSTRAINT measurement_unit_abbreviations_pkey PRIMARY KEY (id);
 
 
@@ -8876,7 +8909,7 @@ ALTER TABLE ONLY public.measurement_unit_abbreviations
 -- Name: measurement_unit_descriptions_oplog measurement_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_descriptions_oplog
+ALTER TABLE ONLY measurement_unit_descriptions_oplog
     ADD CONSTRAINT measurement_unit_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8884,7 +8917,7 @@ ALTER TABLE ONLY public.measurement_unit_descriptions_oplog
 -- Name: measurement_unit_qualifier_descriptions_oplog measurement_unit_qualifier_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_qualifier_descriptions_oplog
+ALTER TABLE ONLY measurement_unit_qualifier_descriptions_oplog
     ADD CONSTRAINT measurement_unit_qualifier_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -8892,7 +8925,7 @@ ALTER TABLE ONLY public.measurement_unit_qualifier_descriptions_oplog
 -- Name: measurement_unit_qualifiers_oplog measurement_unit_qualifiers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_unit_qualifiers_oplog
+ALTER TABLE ONLY measurement_unit_qualifiers_oplog
     ADD CONSTRAINT measurement_unit_qualifiers_pkey PRIMARY KEY (oid);
 
 
@@ -8900,7 +8933,7 @@ ALTER TABLE ONLY public.measurement_unit_qualifiers_oplog
 -- Name: measurement_units_oplog measurement_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurement_units_oplog
+ALTER TABLE ONLY measurement_units_oplog
     ADD CONSTRAINT measurement_units_pkey PRIMARY KEY (oid);
 
 
@@ -8908,7 +8941,7 @@ ALTER TABLE ONLY public.measurement_units_oplog
 -- Name: measurements_oplog measurements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measurements_oplog
+ALTER TABLE ONLY measurements_oplog
     ADD CONSTRAINT measurements_pkey PRIMARY KEY (oid);
 
 
@@ -8916,7 +8949,7 @@ ALTER TABLE ONLY public.measurements_oplog
 -- Name: measures_oplog measures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.measures_oplog
+ALTER TABLE ONLY measures_oplog
     ADD CONSTRAINT measures_pkey PRIMARY KEY (oid);
 
 
@@ -8924,7 +8957,7 @@ ALTER TABLE ONLY public.measures_oplog
 -- Name: meursing_additional_codes_oplog meursing_additional_codes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_additional_codes_oplog
+ALTER TABLE ONLY meursing_additional_codes_oplog
     ADD CONSTRAINT meursing_additional_codes_pkey PRIMARY KEY (oid);
 
 
@@ -8932,7 +8965,7 @@ ALTER TABLE ONLY public.meursing_additional_codes_oplog
 -- Name: meursing_heading_texts_oplog meursing_heading_texts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_heading_texts_oplog
+ALTER TABLE ONLY meursing_heading_texts_oplog
     ADD CONSTRAINT meursing_heading_texts_pkey PRIMARY KEY (oid);
 
 
@@ -8940,7 +8973,7 @@ ALTER TABLE ONLY public.meursing_heading_texts_oplog
 -- Name: meursing_headings_oplog meursing_headings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_headings_oplog
+ALTER TABLE ONLY meursing_headings_oplog
     ADD CONSTRAINT meursing_headings_pkey PRIMARY KEY (oid);
 
 
@@ -8948,7 +8981,7 @@ ALTER TABLE ONLY public.meursing_headings_oplog
 -- Name: meursing_subheadings_oplog meursing_subheadings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_subheadings_oplog
+ALTER TABLE ONLY meursing_subheadings_oplog
     ADD CONSTRAINT meursing_subheadings_pkey PRIMARY KEY (oid);
 
 
@@ -8956,7 +8989,7 @@ ALTER TABLE ONLY public.meursing_subheadings_oplog
 -- Name: meursing_table_cell_components_oplog meursing_table_cell_components_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_table_cell_components_oplog
+ALTER TABLE ONLY meursing_table_cell_components_oplog
     ADD CONSTRAINT meursing_table_cell_components_pkey PRIMARY KEY (oid);
 
 
@@ -8964,7 +8997,7 @@ ALTER TABLE ONLY public.meursing_table_cell_components_oplog
 -- Name: meursing_table_plans_oplog meursing_table_plans_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.meursing_table_plans_oplog
+ALTER TABLE ONLY meursing_table_plans_oplog
     ADD CONSTRAINT meursing_table_plans_pkey PRIMARY KEY (oid);
 
 
@@ -8972,7 +9005,7 @@ ALTER TABLE ONLY public.meursing_table_plans_oplog
 -- Name: modification_regulations_oplog modification_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.modification_regulations_oplog
+ALTER TABLE ONLY modification_regulations_oplog
     ADD CONSTRAINT modification_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -8980,7 +9013,7 @@ ALTER TABLE ONLY public.modification_regulations_oplog
 -- Name: monetary_exchange_periods_oplog monetary_exchange_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_exchange_periods_oplog
+ALTER TABLE ONLY monetary_exchange_periods_oplog
     ADD CONSTRAINT monetary_exchange_periods_pkey PRIMARY KEY (oid);
 
 
@@ -8988,7 +9021,7 @@ ALTER TABLE ONLY public.monetary_exchange_periods_oplog
 -- Name: monetary_exchange_rates_oplog monetary_exchange_rates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_exchange_rates_oplog
+ALTER TABLE ONLY monetary_exchange_rates_oplog
     ADD CONSTRAINT monetary_exchange_rates_pkey PRIMARY KEY (oid);
 
 
@@ -8996,7 +9029,7 @@ ALTER TABLE ONLY public.monetary_exchange_rates_oplog
 -- Name: monetary_unit_descriptions_oplog monetary_unit_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_unit_descriptions_oplog
+ALTER TABLE ONLY monetary_unit_descriptions_oplog
     ADD CONSTRAINT monetary_unit_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -9004,7 +9037,7 @@ ALTER TABLE ONLY public.monetary_unit_descriptions_oplog
 -- Name: monetary_units_oplog monetary_units_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.monetary_units_oplog
+ALTER TABLE ONLY monetary_units_oplog
     ADD CONSTRAINT monetary_units_pkey PRIMARY KEY (oid);
 
 
@@ -9012,7 +9045,7 @@ ALTER TABLE ONLY public.monetary_units_oplog
 -- Name: nomenclature_group_memberships_oplog nomenclature_group_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.nomenclature_group_memberships_oplog
+ALTER TABLE ONLY nomenclature_group_memberships_oplog
     ADD CONSTRAINT nomenclature_group_memberships_pkey PRIMARY KEY (oid);
 
 
@@ -9020,7 +9053,7 @@ ALTER TABLE ONLY public.nomenclature_group_memberships_oplog
 -- Name: prorogation_regulation_actions_oplog prorogation_regulation_actions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.prorogation_regulation_actions_oplog
+ALTER TABLE ONLY prorogation_regulation_actions_oplog
     ADD CONSTRAINT prorogation_regulation_actions_pkey PRIMARY KEY (oid);
 
 
@@ -9028,7 +9061,7 @@ ALTER TABLE ONLY public.prorogation_regulation_actions_oplog
 -- Name: prorogation_regulations_oplog prorogation_regulations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.prorogation_regulations_oplog
+ALTER TABLE ONLY prorogation_regulations_oplog
     ADD CONSTRAINT prorogation_regulations_pkey PRIMARY KEY (oid);
 
 
@@ -9036,7 +9069,7 @@ ALTER TABLE ONLY public.prorogation_regulations_oplog
 -- Name: publication_sigles_oplog publication_sigles_oplog_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.publication_sigles_oplog
+ALTER TABLE ONLY publication_sigles_oplog
     ADD CONSTRAINT publication_sigles_oplog_pkey PRIMARY KEY (oid);
 
 
@@ -9044,7 +9077,7 @@ ALTER TABLE ONLY public.publication_sigles_oplog
 -- Name: quota_associations_oplog quota_associations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_associations_oplog
+ALTER TABLE ONLY quota_associations_oplog
     ADD CONSTRAINT quota_associations_pkey PRIMARY KEY (oid);
 
 
@@ -9052,7 +9085,7 @@ ALTER TABLE ONLY public.quota_associations_oplog
 -- Name: quota_balance_events_oplog quota_balance_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_balance_events_oplog
+ALTER TABLE ONLY quota_balance_events_oplog
     ADD CONSTRAINT quota_balance_events_pkey PRIMARY KEY (oid);
 
 
@@ -9060,7 +9093,7 @@ ALTER TABLE ONLY public.quota_balance_events_oplog
 -- Name: quota_blocking_periods_oplog quota_blocking_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_blocking_periods_oplog
+ALTER TABLE ONLY quota_blocking_periods_oplog
     ADD CONSTRAINT quota_blocking_periods_pkey PRIMARY KEY (oid);
 
 
@@ -9068,7 +9101,7 @@ ALTER TABLE ONLY public.quota_blocking_periods_oplog
 -- Name: quota_critical_events_oplog quota_critical_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_critical_events_oplog
+ALTER TABLE ONLY quota_critical_events_oplog
     ADD CONSTRAINT quota_critical_events_pkey PRIMARY KEY (oid);
 
 
@@ -9076,7 +9109,7 @@ ALTER TABLE ONLY public.quota_critical_events_oplog
 -- Name: quota_definitions_oplog quota_definitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_definitions_oplog
+ALTER TABLE ONLY quota_definitions_oplog
     ADD CONSTRAINT quota_definitions_pkey PRIMARY KEY (oid);
 
 
@@ -9084,7 +9117,7 @@ ALTER TABLE ONLY public.quota_definitions_oplog
 -- Name: quota_exhaustion_events_oplog quota_exhaustion_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_exhaustion_events_oplog
+ALTER TABLE ONLY quota_exhaustion_events_oplog
     ADD CONSTRAINT quota_exhaustion_events_pkey PRIMARY KEY (oid);
 
 
@@ -9092,7 +9125,7 @@ ALTER TABLE ONLY public.quota_exhaustion_events_oplog
 -- Name: quota_order_number_origin_exclusions_oplog quota_order_number_origin_exclusions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_order_number_origin_exclusions_oplog
+ALTER TABLE ONLY quota_order_number_origin_exclusions_oplog
     ADD CONSTRAINT quota_order_number_origin_exclusions_pkey PRIMARY KEY (oid);
 
 
@@ -9100,7 +9133,7 @@ ALTER TABLE ONLY public.quota_order_number_origin_exclusions_oplog
 -- Name: quota_order_number_origins_oplog quota_order_number_origins_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_order_number_origins_oplog
+ALTER TABLE ONLY quota_order_number_origins_oplog
     ADD CONSTRAINT quota_order_number_origins_pkey PRIMARY KEY (oid);
 
 
@@ -9108,7 +9141,7 @@ ALTER TABLE ONLY public.quota_order_number_origins_oplog
 -- Name: quota_order_numbers_oplog quota_order_numbers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_order_numbers_oplog
+ALTER TABLE ONLY quota_order_numbers_oplog
     ADD CONSTRAINT quota_order_numbers_pkey PRIMARY KEY (oid);
 
 
@@ -9116,7 +9149,7 @@ ALTER TABLE ONLY public.quota_order_numbers_oplog
 -- Name: quota_reopening_events_oplog quota_reopening_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_reopening_events_oplog
+ALTER TABLE ONLY quota_reopening_events_oplog
     ADD CONSTRAINT quota_reopening_events_pkey PRIMARY KEY (oid);
 
 
@@ -9124,7 +9157,7 @@ ALTER TABLE ONLY public.quota_reopening_events_oplog
 -- Name: quota_suspension_periods_oplog quota_suspension_periods_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_suspension_periods_oplog
+ALTER TABLE ONLY quota_suspension_periods_oplog
     ADD CONSTRAINT quota_suspension_periods_pkey PRIMARY KEY (oid);
 
 
@@ -9132,7 +9165,7 @@ ALTER TABLE ONLY public.quota_suspension_periods_oplog
 -- Name: quota_unblocking_events_oplog quota_unblocking_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_unblocking_events_oplog
+ALTER TABLE ONLY quota_unblocking_events_oplog
     ADD CONSTRAINT quota_unblocking_events_pkey PRIMARY KEY (oid);
 
 
@@ -9140,7 +9173,7 @@ ALTER TABLE ONLY public.quota_unblocking_events_oplog
 -- Name: quota_unsuspension_events_oplog quota_unsuspension_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.quota_unsuspension_events_oplog
+ALTER TABLE ONLY quota_unsuspension_events_oplog
     ADD CONSTRAINT quota_unsuspension_events_pkey PRIMARY KEY (oid);
 
 
@@ -9148,7 +9181,7 @@ ALTER TABLE ONLY public.quota_unsuspension_events_oplog
 -- Name: regulation_documents regulation_documents_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_documents
+ALTER TABLE ONLY regulation_documents
     ADD CONSTRAINT regulation_documents_pkey PRIMARY KEY (id);
 
 
@@ -9156,7 +9189,7 @@ ALTER TABLE ONLY public.regulation_documents
 -- Name: regulation_group_descriptions_oplog regulation_group_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_group_descriptions_oplog
+ALTER TABLE ONLY regulation_group_descriptions_oplog
     ADD CONSTRAINT regulation_group_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -9164,7 +9197,7 @@ ALTER TABLE ONLY public.regulation_group_descriptions_oplog
 -- Name: regulation_groups_oplog regulation_groups_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_groups_oplog
+ALTER TABLE ONLY regulation_groups_oplog
     ADD CONSTRAINT regulation_groups_pkey PRIMARY KEY (oid);
 
 
@@ -9172,7 +9205,7 @@ ALTER TABLE ONLY public.regulation_groups_oplog
 -- Name: regulation_replacements_oplog regulation_replacements_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_replacements_oplog
+ALTER TABLE ONLY regulation_replacements_oplog
     ADD CONSTRAINT regulation_replacements_pkey PRIMARY KEY (oid);
 
 
@@ -9180,7 +9213,7 @@ ALTER TABLE ONLY public.regulation_replacements_oplog
 -- Name: regulation_role_type_descriptions_oplog regulation_role_type_descriptions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_role_type_descriptions_oplog
+ALTER TABLE ONLY regulation_role_type_descriptions_oplog
     ADD CONSTRAINT regulation_role_type_descriptions_pkey PRIMARY KEY (oid);
 
 
@@ -9188,7 +9221,7 @@ ALTER TABLE ONLY public.regulation_role_type_descriptions_oplog
 -- Name: regulation_role_types_oplog regulation_role_types_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.regulation_role_types_oplog
+ALTER TABLE ONLY regulation_role_types_oplog
     ADD CONSTRAINT regulation_role_types_pkey PRIMARY KEY (oid);
 
 
@@ -9196,7 +9229,7 @@ ALTER TABLE ONLY public.regulation_role_types_oplog
 -- Name: rollbacks rollbacks_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.rollbacks
+ALTER TABLE ONLY rollbacks
     ADD CONSTRAINT rollbacks_pkey PRIMARY KEY (id);
 
 
@@ -9204,7 +9237,7 @@ ALTER TABLE ONLY public.rollbacks
 -- Name: schema_migrations schema_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.schema_migrations
+ALTER TABLE ONLY schema_migrations
     ADD CONSTRAINT schema_migrations_pkey PRIMARY KEY (filename);
 
 
@@ -9212,7 +9245,7 @@ ALTER TABLE ONLY public.schema_migrations
 -- Name: search_references search_references_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.search_references
+ALTER TABLE ONLY search_references
     ADD CONSTRAINT search_references_pkey PRIMARY KEY (id);
 
 
@@ -9220,7 +9253,7 @@ ALTER TABLE ONLY public.search_references
 -- Name: section_notes section_notes_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.section_notes
+ALTER TABLE ONLY section_notes
     ADD CONSTRAINT section_notes_pkey PRIMARY KEY (id);
 
 
@@ -9228,7 +9261,7 @@ ALTER TABLE ONLY public.section_notes
 -- Name: sections sections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.sections
+ALTER TABLE ONLY sections
     ADD CONSTRAINT sections_pkey PRIMARY KEY (id);
 
 
@@ -9236,7 +9269,7 @@ ALTER TABLE ONLY public.sections
 -- Name: tariff_update_conformance_errors tariff_update_conformance_errors_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.tariff_update_conformance_errors
+ALTER TABLE ONLY tariff_update_conformance_errors
     ADD CONSTRAINT tariff_update_conformance_errors_pkey PRIMARY KEY (id);
 
 
@@ -9244,7 +9277,7 @@ ALTER TABLE ONLY public.tariff_update_conformance_errors
 -- Name: tariff_updates tariff_updates_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.tariff_updates
+ALTER TABLE ONLY tariff_updates
     ADD CONSTRAINT tariff_updates_pkey PRIMARY KEY (filename);
 
 
@@ -9252,7 +9285,7 @@ ALTER TABLE ONLY public.tariff_updates
 -- Name: transmission_comments_oplog transmission_comments_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.transmission_comments_oplog
+ALTER TABLE ONLY transmission_comments_oplog
     ADD CONSTRAINT transmission_comments_pkey PRIMARY KEY (oid);
 
 
@@ -9260,7 +9293,7 @@ ALTER TABLE ONLY public.transmission_comments_oplog
 -- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.users
+ALTER TABLE ONLY users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
 
@@ -9268,7 +9301,7 @@ ALTER TABLE ONLY public.users
 -- Name: workbasket_items workbasket_items_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.workbasket_items
+ALTER TABLE ONLY workbasket_items
     ADD CONSTRAINT workbasket_items_pkey PRIMARY KEY (id);
 
 
@@ -9276,7 +9309,7 @@ ALTER TABLE ONLY public.workbasket_items
 -- Name: workbaskets_events workbaskets_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.workbaskets_events
+ALTER TABLE ONLY workbaskets_events
     ADD CONSTRAINT workbaskets_events_pkey PRIMARY KEY (id);
 
 
@@ -9284,7 +9317,7 @@ ALTER TABLE ONLY public.workbaskets_events
 -- Name: workbaskets workbaskets_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.workbaskets
+ALTER TABLE ONLY workbaskets
     ADD CONSTRAINT workbaskets_pkey PRIMARY KEY (id);
 
 
@@ -9292,7 +9325,7 @@ ALTER TABLE ONLY public.workbaskets
 -- Name: xml_export_files xml_export_files_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
-ALTER TABLE ONLY public.xml_export_files
+ALTER TABLE ONLY xml_export_files
     ADD CONSTRAINT xml_export_files_pkey PRIMARY KEY (id);
 
 
@@ -9300,2016 +9333,2016 @@ ALTER TABLE ONLY public.xml_export_files
 -- Name: abrogation_regulation_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX abrogation_regulation_id ON public.measure_partial_temporary_stops_oplog USING btree (abrogation_regulation_id);
+CREATE INDEX abrogation_regulation_id ON measure_partial_temporary_stops_oplog USING btree (abrogation_regulation_id);
 
 
 --
 -- Name: acdo_addcoddesopl_nalodeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX acdo_addcoddesopl_nalodeonslog_operation_date ON public.additional_code_descriptions_oplog USING btree (operation_date);
+CREATE INDEX acdo_addcoddesopl_nalodeonslog_operation_date ON additional_code_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: acdpo_addcoddesperopl_nalodeionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX acdpo_addcoddesperopl_nalodeionodslog_operation_date ON public.additional_code_description_periods_oplog USING btree (operation_date);
+CREATE INDEX acdpo_addcoddesperopl_nalodeionodslog_operation_date ON additional_code_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: aco_addcodopl_naldeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX aco_addcodopl_naldeslog_operation_date ON public.additional_codes_oplog USING btree (operation_date);
+CREATE INDEX aco_addcodopl_naldeslog_operation_date ON additional_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: actdo_addcodtypdesopl_nalodeypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX actdo_addcodtypdesopl_nalodeypeonslog_operation_date ON public.additional_code_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX actdo_addcodtypdesopl_nalodeypeonslog_operation_date ON additional_code_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: actmto_addcodtypmeatypopl_nalodeypeurepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX actmto_addcodtypmeatypopl_nalodeypeurepeslog_operation_date ON public.additional_code_type_measure_types_oplog USING btree (operation_date);
+CREATE INDEX actmto_addcodtypmeatypopl_nalodeypeurepeslog_operation_date ON additional_code_type_measure_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: acto_addcodtypopl_nalodepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX acto_addcodtypopl_nalodepeslog_operation_date ON public.additional_code_types_oplog USING btree (operation_date);
+CREATE INDEX acto_addcodtypopl_nalodepeslog_operation_date ON additional_code_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: adco_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_desc_pk ON public.additional_code_descriptions_oplog USING btree (additional_code_description_period_sid, additional_code_type_id, additional_code_sid);
+CREATE INDEX adco_desc_pk ON additional_code_descriptions_oplog USING btree (additional_code_description_period_sid, additional_code_type_id, additional_code_sid);
 
 
 --
 -- Name: adco_periods_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_periods_pk ON public.additional_code_description_periods_oplog USING btree (additional_code_description_period_sid, additional_code_sid, additional_code_type_id);
+CREATE INDEX adco_periods_pk ON additional_code_description_periods_oplog USING btree (additional_code_description_period_sid, additional_code_sid, additional_code_type_id);
 
 
 --
 -- Name: adco_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_pk ON public.additional_codes_oplog USING btree (additional_code_sid);
+CREATE INDEX adco_pk ON additional_codes_oplog USING btree (additional_code_sid);
 
 
 --
 -- Name: adco_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_type_desc_pk ON public.additional_code_type_descriptions_oplog USING btree (additional_code_type_id);
+CREATE INDEX adco_type_desc_pk ON additional_code_type_descriptions_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: adco_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_type_id ON public.additional_codes_oplog USING btree (additional_code_type_id);
+CREATE INDEX adco_type_id ON additional_codes_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: adco_type_measure_type_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_type_measure_type_pk ON public.additional_code_type_measure_types_oplog USING btree (measure_type_id, additional_code_type_id);
+CREATE INDEX adco_type_measure_type_pk ON additional_code_type_measure_types_oplog USING btree (measure_type_id, additional_code_type_id);
 
 
 --
 -- Name: adco_types_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX adco_types_pk ON public.additional_code_types_oplog USING btree (additional_code_type_id);
+CREATE INDEX adco_types_pk ON additional_code_types_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: additional_code_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX additional_code_type ON public.footnote_association_additional_codes_oplog USING btree (additional_code_type_id);
+CREATE INDEX additional_code_type ON footnote_association_additional_codes_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: antidumping_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX antidumping_regulation ON public.base_regulations_oplog USING btree (antidumping_regulation_role, related_antidumping_regulation_id);
+CREATE INDEX antidumping_regulation ON base_regulations_oplog USING btree (antidumping_regulation_role, related_antidumping_regulation_id);
 
 
 --
 -- Name: base_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX base_regulation ON public.modification_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
+CREATE INDEX base_regulation ON modification_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
 
 
 --
 -- Name: base_regulations_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX base_regulations_pk ON public.base_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
+CREATE INDEX base_regulations_pk ON base_regulations_oplog USING btree (base_regulation_id, base_regulation_role);
 
 
 --
 -- Name: bro_basregopl_aseonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX bro_basregopl_aseonslog_operation_date ON public.base_regulations_oplog USING btree (operation_date);
+CREATE INDEX bro_basregopl_aseonslog_operation_date ON base_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: caro_comabrregopl_eteiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX caro_comabrregopl_eteiononslog_operation_date ON public.complete_abrogation_regulations_oplog USING btree (operation_date);
+CREATE INDEX caro_comabrregopl_eteiononslog_operation_date ON complete_abrogation_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: cdo_cerdesopl_ateonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cdo_cerdesopl_ateonslog_operation_date ON public.certificate_descriptions_oplog USING btree (operation_date);
+CREATE INDEX cdo_cerdesopl_ateonslog_operation_date ON certificate_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: cdpo_cerdesperopl_ateionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cdpo_cerdesperopl_ateionodslog_operation_date ON public.certificate_description_periods_oplog USING btree (operation_date);
+CREATE INDEX cdpo_cerdesperopl_ateionodslog_operation_date ON certificate_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: cert_desc_certificate; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_desc_certificate ON public.certificate_descriptions_oplog USING btree (certificate_code, certificate_type_code);
+CREATE INDEX cert_desc_certificate ON certificate_descriptions_oplog USING btree (certificate_code, certificate_type_code);
 
 
 --
 -- Name: cert_desc_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_desc_period_pk ON public.certificate_description_periods_oplog USING btree (certificate_description_period_sid);
+CREATE INDEX cert_desc_period_pk ON certificate_description_periods_oplog USING btree (certificate_description_period_sid);
 
 
 --
 -- Name: cert_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_desc_pk ON public.certificate_descriptions_oplog USING btree (certificate_description_period_sid);
+CREATE INDEX cert_desc_pk ON certificate_descriptions_oplog USING btree (certificate_description_period_sid);
 
 
 --
 -- Name: cert_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_pk ON public.certificates_oplog USING btree (certificate_code, certificate_type_code, validity_start_date);
+CREATE INDEX cert_pk ON certificates_oplog USING btree (certificate_code, certificate_type_code, validity_start_date);
 
 
 --
 -- Name: cert_type_code_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_type_code_pk ON public.certificate_type_descriptions_oplog USING btree (certificate_type_code);
+CREATE INDEX cert_type_code_pk ON certificate_type_descriptions_oplog USING btree (certificate_type_code);
 
 
 --
 -- Name: cert_types_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cert_types_pk ON public.certificate_types_oplog USING btree (certificate_type_code, validity_start_date);
+CREATE INDEX cert_types_pk ON certificate_types_oplog USING btree (certificate_type_code, validity_start_date);
 
 
 --
 -- Name: certificate; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX certificate ON public.certificate_description_periods_oplog USING btree (certificate_code, certificate_type_code);
+CREATE INDEX certificate ON certificate_description_periods_oplog USING btree (certificate_code, certificate_type_code);
 
 
 --
 -- Name: chapter_notes_chapter_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chapter_notes_chapter_id_index ON public.chapter_notes USING btree (chapter_id);
+CREATE INDEX chapter_notes_chapter_id_index ON chapter_notes USING btree (chapter_id);
 
 
 --
 -- Name: chapter_notes_section_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chapter_notes_section_id_index ON public.chapter_notes USING btree (section_id);
+CREATE INDEX chapter_notes_section_id_index ON chapter_notes USING btree (section_id);
 
 
 --
 -- Name: chief_country_cd_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chief_country_cd_pk ON public.chief_country_code USING btree (chief_country_cd);
+CREATE INDEX chief_country_cd_pk ON chief_country_code USING btree (chief_country_cd);
 
 
 --
 -- Name: chief_country_grp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chief_country_grp_pk ON public.chief_country_group USING btree (chief_country_grp);
+CREATE INDEX chief_country_grp_pk ON chief_country_group USING btree (chief_country_grp);
 
 
 --
 -- Name: chief_mfcm_msrgp_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX chief_mfcm_msrgp_code_index ON public.chief_mfcm USING btree (msrgp_code);
+CREATE INDEX chief_mfcm_msrgp_code_index ON chief_mfcm USING btree (msrgp_code);
 
 
 --
 -- Name: cmdty_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cmdty_code_index ON public.chief_comm USING btree (cmdty_code);
+CREATE INDEX cmdty_code_index ON chief_comm USING btree (cmdty_code);
 
 
 --
 -- Name: cmpl_abrg_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cmpl_abrg_reg_pk ON public.complete_abrogation_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
+CREATE INDEX cmpl_abrg_reg_pk ON complete_abrogation_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
 
 
 --
 -- Name: co_ceropl_teslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX co_ceropl_teslog_operation_date ON public.certificates_oplog USING btree (operation_date);
+CREATE INDEX co_ceropl_teslog_operation_date ON certificates_oplog USING btree (operation_date);
 
 
 --
 -- Name: code_type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX code_type_id ON public.additional_code_description_periods_oplog USING btree (additional_code_type_id);
+CREATE INDEX code_type_id ON additional_code_description_periods_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: complete_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX complete_abrogation_regulation ON public.base_regulations_oplog USING btree (complete_abrogation_regulation_role, complete_abrogation_regulation_id);
+CREATE INDEX complete_abrogation_regulation ON base_regulations_oplog USING btree (complete_abrogation_regulation_role, complete_abrogation_regulation_id);
 
 
 --
 -- Name: condition_measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX condition_measurement_unit_qualifier_code ON public.measure_conditions_oplog USING btree (condition_measurement_unit_qualifier_code);
+CREATE INDEX condition_measurement_unit_qualifier_code ON measure_conditions_oplog USING btree (condition_measurement_unit_qualifier_code);
 
 
 --
 -- Name: ctdo_certypdesopl_ateypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ctdo_certypdesopl_ateypeonslog_operation_date ON public.certificate_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX ctdo_certypdesopl_ateypeonslog_operation_date ON certificate_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: cto_certypopl_atepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX cto_certypopl_atepeslog_operation_date ON public.certificate_types_oplog USING btree (operation_date);
+CREATE INDEX cto_certypopl_atepeslog_operation_date ON certificate_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: data_migrations_filename_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX data_migrations_filename_index ON public.data_migrations USING btree (filename);
+CREATE INDEX data_migrations_filename_index ON data_migrations USING btree (filename);
 
 
 --
 -- Name: dedo_dutexpdesopl_utyiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX dedo_dutexpdesopl_utyiononslog_operation_date ON public.duty_expression_descriptions_oplog USING btree (operation_date);
+CREATE INDEX dedo_dutexpdesopl_utyiononslog_operation_date ON duty_expression_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: deo_dutexpopl_utyonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX deo_dutexpopl_utyonslog_operation_date ON public.duty_expressions_oplog USING btree (operation_date);
+CREATE INDEX deo_dutexpopl_utyonslog_operation_date ON duty_expressions_oplog USING btree (operation_date);
 
 
 --
 -- Name: description_period_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX description_period_sid ON public.additional_code_description_periods_oplog USING btree (additional_code_description_period_sid);
+CREATE INDEX description_period_sid ON additional_code_description_periods_oplog USING btree (additional_code_description_period_sid);
 
 
 --
 -- Name: duty_exp_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX duty_exp_desc_pk ON public.duty_expression_descriptions_oplog USING btree (duty_expression_id);
+CREATE INDEX duty_exp_desc_pk ON duty_expression_descriptions_oplog USING btree (duty_expression_id);
 
 
 --
 -- Name: duty_exp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX duty_exp_pk ON public.duty_expressions_oplog USING btree (duty_expression_id, validity_start_date);
+CREATE INDEX duty_exp_pk ON duty_expressions_oplog USING btree (duty_expression_id, validity_start_date);
 
 
 --
 -- Name: earo_expabrregopl_citiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX earo_expabrregopl_citiononslog_operation_date ON public.explicit_abrogation_regulations_oplog USING btree (operation_date);
+CREATE INDEX earo_expabrregopl_citiononslog_operation_date ON explicit_abrogation_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: erndo_exprefnomdesopl_ortundureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX erndo_exprefnomdesopl_ortundureonslog_operation_date ON public.export_refund_nomenclature_descriptions_oplog USING btree (operation_date);
+CREATE INDEX erndo_exprefnomdesopl_ortundureonslog_operation_date ON export_refund_nomenclature_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: erndpo_exprefnomdesperopl_ortundureionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX erndpo_exprefnomdesperopl_ortundureionodslog_operation_date ON public.export_refund_nomenclature_description_periods_oplog USING btree (operation_date);
+CREATE INDEX erndpo_exprefnomdesperopl_ortundureionodslog_operation_date ON export_refund_nomenclature_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: ernio_exprefnomindopl_ortundurentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ernio_exprefnomindopl_ortundurentslog_operation_date ON public.export_refund_nomenclature_indents_oplog USING btree (operation_date);
+CREATE INDEX ernio_exprefnomindopl_ortundurentslog_operation_date ON export_refund_nomenclature_indents_oplog USING btree (operation_date);
 
 
 --
 -- Name: erno_exprefnomopl_ortundreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX erno_exprefnomopl_ortundreslog_operation_date ON public.export_refund_nomenclatures_oplog USING btree (operation_date);
+CREATE INDEX erno_exprefnomopl_ortundreslog_operation_date ON export_refund_nomenclatures_oplog USING btree (operation_date);
 
 
 --
 -- Name: exp_abrg_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_abrg_reg_pk ON public.explicit_abrogation_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
+CREATE INDEX exp_abrg_reg_pk ON explicit_abrogation_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
 
 
 --
 -- Name: exp_rfnd_desc_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_desc_period_pk ON public.export_refund_nomenclature_description_periods_oplog USING btree (export_refund_nomenclature_sid, export_refund_nomenclature_description_period_sid);
+CREATE INDEX exp_rfnd_desc_period_pk ON export_refund_nomenclature_description_periods_oplog USING btree (export_refund_nomenclature_sid, export_refund_nomenclature_description_period_sid);
 
 
 --
 -- Name: exp_rfnd_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_desc_pk ON public.export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_description_period_sid);
+CREATE INDEX exp_rfnd_desc_pk ON export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_description_period_sid);
 
 
 --
 -- Name: exp_rfnd_indent_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_indent_pk ON public.export_refund_nomenclature_indents_oplog USING btree (export_refund_nomenclature_indents_sid);
+CREATE INDEX exp_rfnd_indent_pk ON export_refund_nomenclature_indents_oplog USING btree (export_refund_nomenclature_indents_sid);
 
 
 --
 -- Name: exp_rfnd_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX exp_rfnd_pk ON public.export_refund_nomenclatures_oplog USING btree (export_refund_nomenclature_sid);
+CREATE INDEX exp_rfnd_pk ON export_refund_nomenclatures_oplog USING btree (export_refund_nomenclature_sid);
 
 
 --
 -- Name: explicit_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX explicit_abrogation_regulation ON public.base_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
+CREATE INDEX explicit_abrogation_regulation ON base_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
 
 
 --
 -- Name: export_refund_nomenclature; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX export_refund_nomenclature ON public.export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_sid);
+CREATE INDEX export_refund_nomenclature ON export_refund_nomenclature_descriptions_oplog USING btree (export_refund_nomenclature_sid);
 
 
 --
 -- Name: faaco_fooassaddcodopl_oteionnaldeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX faaco_fooassaddcodopl_oteionnaldeslog_operation_date ON public.footnote_association_additional_codes_oplog USING btree (operation_date);
+CREATE INDEX faaco_fooassaddcodopl_oteionnaldeslog_operation_date ON footnote_association_additional_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: faeo_fooassernopl_oteionrnslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX faeo_fooassernopl_oteionrnslog_operation_date ON public.footnote_association_erns_oplog USING btree (operation_date);
+CREATE INDEX faeo_fooassernopl_oteionrnslog_operation_date ON footnote_association_erns_oplog USING btree (operation_date);
 
 
 --
 -- Name: fagno_fooassgoonomopl_oteionodsreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fagno_fooassgoonomopl_oteionodsreslog_operation_date ON public.footnote_association_goods_nomenclatures_oplog USING btree (operation_date);
+CREATE INDEX fagno_fooassgoonomopl_oteionodsreslog_operation_date ON footnote_association_goods_nomenclatures_oplog USING btree (operation_date);
 
 
 --
 -- Name: famho_fooassmeuheaopl_oteioningngslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX famho_fooassmeuheaopl_oteioningngslog_operation_date ON public.footnote_association_meursing_headings_oplog USING btree (operation_date);
+CREATE INDEX famho_fooassmeuheaopl_oteioningngslog_operation_date ON footnote_association_meursing_headings_oplog USING btree (operation_date);
 
 
 --
 -- Name: famo_fooassmeaopl_oteionreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX famo_fooassmeaopl_oteionreslog_operation_date ON public.footnote_association_measures_oplog USING btree (operation_date);
+CREATE INDEX famo_fooassmeaopl_oteionreslog_operation_date ON footnote_association_measures_oplog USING btree (operation_date);
 
 
 --
 -- Name: fdo_foodesopl_oteonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fdo_foodesopl_oteonslog_operation_date ON public.footnote_descriptions_oplog USING btree (operation_date);
+CREATE INDEX fdo_foodesopl_oteonslog_operation_date ON footnote_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: fdpo_foodesperopl_oteionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fdpo_foodesperopl_oteionodslog_operation_date ON public.footnote_description_periods_oplog USING btree (operation_date);
+CREATE INDEX fdpo_foodesperopl_oteionodslog_operation_date ON footnote_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: fo_fooopl_teslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fo_fooopl_teslog_operation_date ON public.footnotes_oplog USING btree (operation_date);
+CREATE INDEX fo_fooopl_teslog_operation_date ON footnotes_oplog USING btree (operation_date);
 
 
 --
 -- Name: footnote_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX footnote_id ON public.footnote_association_measures_oplog USING btree (footnote_id);
+CREATE INDEX footnote_id ON footnote_association_measures_oplog USING btree (footnote_id);
 
 
 --
 -- Name: frao_ftsregactopl_ftsiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX frao_ftsregactopl_ftsiononslog_operation_date ON public.fts_regulation_actions_oplog USING btree (operation_date);
+CREATE INDEX frao_ftsregactopl_ftsiononslog_operation_date ON fts_regulation_actions_oplog USING btree (operation_date);
 
 
 --
 -- Name: ftdo_footypdesopl_oteypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftdo_footypdesopl_oteypeonslog_operation_date ON public.footnote_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX ftdo_footypdesopl_oteypeonslog_operation_date ON footnote_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: ftn_assoc_adco_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_adco_pk ON public.footnote_association_additional_codes_oplog USING btree (footnote_id, footnote_type_id, additional_code_sid);
+CREATE INDEX ftn_assoc_adco_pk ON footnote_association_additional_codes_oplog USING btree (footnote_id, footnote_type_id, additional_code_sid);
 
 
 --
 -- Name: ftn_assoc_ern_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_ern_pk ON public.footnote_association_erns_oplog USING btree (export_refund_nomenclature_sid, footnote_id, footnote_type, validity_start_date);
+CREATE INDEX ftn_assoc_ern_pk ON footnote_association_erns_oplog USING btree (export_refund_nomenclature_sid, footnote_id, footnote_type, validity_start_date);
 
 
 --
 -- Name: ftn_assoc_gono_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_gono_pk ON public.footnote_association_goods_nomenclatures_oplog USING btree (footnote_id, footnote_type, goods_nomenclature_sid, validity_start_date);
+CREATE INDEX ftn_assoc_gono_pk ON footnote_association_goods_nomenclatures_oplog USING btree (footnote_id, footnote_type, goods_nomenclature_sid, validity_start_date);
 
 
 --
 -- Name: ftn_assoc_meurs_head_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_assoc_meurs_head_pk ON public.footnote_association_meursing_headings_oplog USING btree (footnote_id, meursing_table_plan_id);
+CREATE INDEX ftn_assoc_meurs_head_pk ON footnote_association_meursing_headings_oplog USING btree (footnote_id, meursing_table_plan_id);
 
 
 --
 -- Name: ftn_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_desc ON public.footnote_descriptions_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
+CREATE INDEX ftn_desc ON footnote_descriptions_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
 
 
 --
 -- Name: ftn_desc_period; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_desc_period ON public.footnote_description_periods_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
+CREATE INDEX ftn_desc_period ON footnote_description_periods_oplog USING btree (footnote_id, footnote_type_id, footnote_description_period_sid);
 
 
 --
 -- Name: ftn_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_pk ON public.footnotes_oplog USING btree (footnote_id, footnote_type_id);
+CREATE INDEX ftn_pk ON footnotes_oplog USING btree (footnote_id, footnote_type_id);
 
 
 --
 -- Name: ftn_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_type_desc_pk ON public.footnote_type_descriptions_oplog USING btree (footnote_type_id);
+CREATE INDEX ftn_type_desc_pk ON footnote_type_descriptions_oplog USING btree (footnote_type_id);
 
 
 --
 -- Name: ftn_types_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftn_types_pk ON public.footnote_types_oplog USING btree (footnote_type_id);
+CREATE INDEX ftn_types_pk ON footnote_types_oplog USING btree (footnote_type_id);
 
 
 --
 -- Name: fto_footypopl_otepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fto_footypopl_otepeslog_operation_date ON public.footnote_types_oplog USING btree (operation_date);
+CREATE INDEX fto_footypopl_otepeslog_operation_date ON footnote_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: fts_reg_act_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX fts_reg_act_pk ON public.fts_regulation_actions_oplog USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role);
+CREATE INDEX fts_reg_act_pk ON fts_regulation_actions_oplog USING btree (fts_regulation_id, fts_regulation_role, stopped_regulation_id, stopped_regulation_role);
 
 
 --
 -- Name: ftsro_fultemstoregopl_ullarytoponslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ftsro_fultemstoregopl_ullarytoponslog_operation_date ON public.full_temporary_stop_regulations_oplog USING btree (operation_date);
+CREATE INDEX ftsro_fultemstoregopl_ullarytoponslog_operation_date ON full_temporary_stop_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: full_temp_explicit_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX full_temp_explicit_abrogation_regulation ON public.full_temporary_stop_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
+CREATE INDEX full_temp_explicit_abrogation_regulation ON full_temporary_stop_regulations_oplog USING btree (explicit_abrogation_regulation_role, explicit_abrogation_regulation_id);
 
 
 --
 -- Name: full_temp_stop_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX full_temp_stop_reg_pk ON public.full_temporary_stop_regulations_oplog USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role);
+CREATE INDEX full_temp_stop_reg_pk ON full_temporary_stop_regulations_oplog USING btree (full_temporary_stop_regulation_id, full_temporary_stop_regulation_role);
 
 
 --
 -- Name: gado_geoaredesopl_calreaonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gado_geoaredesopl_calreaonslog_operation_date ON public.geographical_area_descriptions_oplog USING btree (operation_date);
+CREATE INDEX gado_geoaredesopl_calreaonslog_operation_date ON geographical_area_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: gadpo_geoaredesperopl_calreaionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gadpo_geoaredesperopl_calreaionodslog_operation_date ON public.geographical_area_description_periods_oplog USING btree (operation_date);
+CREATE INDEX gadpo_geoaredesperopl_calreaionodslog_operation_date ON geographical_area_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: gamo_geoarememopl_calreaipslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gamo_geoarememopl_calreaipslog_operation_date ON public.geographical_area_memberships_oplog USING btree (operation_date);
+CREATE INDEX gamo_geoarememopl_calreaipslog_operation_date ON geographical_area_memberships_oplog USING btree (operation_date);
 
 
 --
 -- Name: gao_geoareopl_caleaslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gao_geoareopl_caleaslog_operation_date ON public.geographical_areas_oplog USING btree (operation_date);
+CREATE INDEX gao_geoareopl_caleaslog_operation_date ON geographical_areas_oplog USING btree (operation_date);
 
 
 --
 -- Name: geo_area_member_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geo_area_member_pk ON public.geographical_area_memberships_oplog USING btree (geographical_area_sid, geographical_area_group_sid, validity_start_date);
+CREATE INDEX geo_area_member_pk ON geographical_area_memberships_oplog USING btree (geographical_area_sid, geographical_area_group_sid, validity_start_date);
 
 
 --
 -- Name: geog_area_desc_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geog_area_desc_period_pk ON public.geographical_area_description_periods_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
+CREATE INDEX geog_area_desc_period_pk ON geographical_area_description_periods_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
 
 
 --
 -- Name: geog_area_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geog_area_desc_pk ON public.geographical_area_descriptions_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
+CREATE INDEX geog_area_desc_pk ON geographical_area_descriptions_oplog USING btree (geographical_area_description_period_sid, geographical_area_sid);
 
 
 --
 -- Name: geog_area_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX geog_area_pk ON public.geographical_areas_oplog USING btree (geographical_area_id);
+CREATE INDEX geog_area_pk ON geographical_areas_oplog USING btree (geographical_area_id);
 
 
 --
 -- Name: gndo_goonomdesopl_odsureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gndo_goonomdesopl_odsureonslog_operation_date ON public.goods_nomenclature_descriptions_oplog USING btree (operation_date);
+CREATE INDEX gndo_goonomdesopl_odsureonslog_operation_date ON goods_nomenclature_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: gndpo_goonomdesperopl_odsureionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gndpo_goonomdesperopl_odsureionodslog_operation_date ON public.goods_nomenclature_description_periods_oplog USING btree (operation_date);
+CREATE INDEX gndpo_goonomdesperopl_odsureionodslog_operation_date ON goods_nomenclature_description_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: gngdo_goonomgrodesopl_odsureouponslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gngdo_goonomgrodesopl_odsureouponslog_operation_date ON public.goods_nomenclature_group_descriptions_oplog USING btree (operation_date);
+CREATE INDEX gngdo_goonomgrodesopl_odsureouponslog_operation_date ON goods_nomenclature_group_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: gngo_goonomgroopl_odsureupslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gngo_goonomgroopl_odsureupslog_operation_date ON public.goods_nomenclature_groups_oplog USING btree (operation_date);
+CREATE INDEX gngo_goonomgroopl_odsureupslog_operation_date ON goods_nomenclature_groups_oplog USING btree (operation_date);
 
 
 --
 -- Name: gnio_goonomindopl_odsurentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gnio_goonomindopl_odsurentslog_operation_date ON public.goods_nomenclature_indents_oplog USING btree (operation_date);
+CREATE INDEX gnio_goonomindopl_odsurentslog_operation_date ON goods_nomenclature_indents_oplog USING btree (operation_date);
 
 
 --
 -- Name: gno_goonomopl_odsreslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gno_goonomopl_odsreslog_operation_date ON public.goods_nomenclatures_oplog USING btree (operation_date);
+CREATE INDEX gno_goonomopl_odsreslog_operation_date ON goods_nomenclatures_oplog USING btree (operation_date);
 
 
 --
 -- Name: gnoo_goonomoriopl_odsureinslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gnoo_goonomoriopl_odsureinslog_operation_date ON public.goods_nomenclature_origins_oplog USING btree (operation_date);
+CREATE INDEX gnoo_goonomoriopl_odsureinslog_operation_date ON goods_nomenclature_origins_oplog USING btree (operation_date);
 
 
 --
 -- Name: gnso_goonomsucopl_odsureorslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gnso_goonomsucopl_odsureorslog_operation_date ON public.goods_nomenclature_successors_oplog USING btree (operation_date);
+CREATE INDEX gnso_goonomsucopl_odsureorslog_operation_date ON goods_nomenclature_successors_oplog USING btree (operation_date);
 
 
 --
 -- Name: gono_desc_periods_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_desc_periods_pk ON public.goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_sid, validity_start_date, validity_end_date);
+CREATE INDEX gono_desc_periods_pk ON goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_sid, validity_start_date, validity_end_date);
 
 
 --
 -- Name: gono_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_desc_pk ON public.goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid);
+CREATE INDEX gono_desc_pk ON goods_nomenclature_descriptions_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_description_period_sid);
 
 
 --
 -- Name: gono_desc_primary_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_desc_primary_key ON public.goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_description_period_sid);
+CREATE INDEX gono_desc_primary_key ON goods_nomenclature_description_periods_oplog USING btree (goods_nomenclature_description_period_sid);
 
 
 --
 -- Name: gono_grp_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_grp_desc_pk ON public.goods_nomenclature_group_descriptions_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
+CREATE INDEX gono_grp_desc_pk ON goods_nomenclature_group_descriptions_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
 
 
 --
 -- Name: gono_grp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_grp_pk ON public.goods_nomenclature_groups_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
+CREATE INDEX gono_grp_pk ON goods_nomenclature_groups_oplog USING btree (goods_nomenclature_group_id, goods_nomenclature_group_type);
 
 
 --
 -- Name: gono_indent_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_indent_pk ON public.goods_nomenclature_indents_oplog USING btree (goods_nomenclature_indent_sid);
+CREATE INDEX gono_indent_pk ON goods_nomenclature_indents_oplog USING btree (goods_nomenclature_indent_sid);
 
 
 --
 -- Name: gono_origin_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_origin_pk ON public.goods_nomenclature_origins_oplog USING btree (goods_nomenclature_sid, derived_goods_nomenclature_item_id, derived_productline_suffix, goods_nomenclature_item_id, productline_suffix);
+CREATE INDEX gono_origin_pk ON goods_nomenclature_origins_oplog USING btree (goods_nomenclature_sid, derived_goods_nomenclature_item_id, derived_productline_suffix, goods_nomenclature_item_id, productline_suffix);
 
 
 --
 -- Name: gono_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_pk ON public.goods_nomenclatures_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX gono_pk ON goods_nomenclatures_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: gono_succ_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX gono_succ_pk ON public.goods_nomenclature_successors_oplog USING btree (goods_nomenclature_sid, absorbed_goods_nomenclature_item_id, absorbed_productline_suffix, goods_nomenclature_item_id, productline_suffix);
+CREATE INDEX gono_succ_pk ON goods_nomenclature_successors_oplog USING btree (goods_nomenclature_sid, absorbed_goods_nomenclature_item_id, absorbed_productline_suffix, goods_nomenclature_item_id, productline_suffix);
 
 
 --
 -- Name: goods_nomenclature_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX goods_nomenclature_sid ON public.goods_nomenclature_indents_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX goods_nomenclature_sid ON goods_nomenclature_indents_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: goods_nomenclature_validity_dates; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX goods_nomenclature_validity_dates ON public.goods_nomenclature_indents_oplog USING btree (validity_start_date, validity_end_date);
+CREATE INDEX goods_nomenclature_validity_dates ON goods_nomenclature_indents_oplog USING btree (validity_start_date, validity_end_date);
 
 
 --
 -- Name: index_additional_code_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_additional_code_type_descriptions_on_language_id ON public.additional_code_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_additional_code_type_descriptions_on_language_id ON additional_code_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_additional_code_types_on_meursing_table_plan_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_additional_code_types_on_meursing_table_plan_id ON public.additional_code_types_oplog USING btree (meursing_table_plan_id);
+CREATE INDEX index_additional_code_types_on_meursing_table_plan_id ON additional_code_types_oplog USING btree (meursing_table_plan_id);
 
 
 --
 -- Name: index_base_regulations_on_regulation_group_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_base_regulations_on_regulation_group_id ON public.base_regulations_oplog USING btree (regulation_group_id);
+CREATE INDEX index_base_regulations_on_regulation_group_id ON base_regulations_oplog USING btree (regulation_group_id);
 
 
 --
 -- Name: index_certificate_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_certificate_descriptions_on_language_id ON public.certificate_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_certificate_descriptions_on_language_id ON certificate_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_certificate_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_certificate_type_descriptions_on_language_id ON public.certificate_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_certificate_type_descriptions_on_language_id ON certificate_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_chapters_sections_on_goods_nomenclature_sid_and_section_i; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_chapters_sections_on_goods_nomenclature_sid_and_section_i ON public.chapters_sections USING btree (goods_nomenclature_sid, section_id);
+CREATE INDEX index_chapters_sections_on_goods_nomenclature_sid_and_section_i ON chapters_sections USING btree (goods_nomenclature_sid, section_id);
 
 
 --
 -- Name: index_chief_tame; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_chief_tame ON public.chief_tame USING btree (msrgp_code, msr_type, tty_code, tar_msr_no, fe_tsmp);
+CREATE INDEX index_chief_tame ON chief_tame USING btree (msrgp_code, msr_type, tty_code, tar_msr_no, fe_tsmp);
 
 
 --
 -- Name: index_chief_tamf; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_chief_tamf ON public.chief_tamf USING btree (fe_tsmp, msrgp_code, msr_type, tty_code, tar_msr_no, amend_indicator);
+CREATE INDEX index_chief_tamf ON chief_tamf USING btree (fe_tsmp, msrgp_code, msr_type, tty_code, tar_msr_no, amend_indicator);
 
 
 --
 -- Name: index_duty_expression_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_duty_expression_descriptions_on_language_id ON public.duty_expression_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_duty_expression_descriptions_on_language_id ON duty_expression_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_export_refund_nomenclature_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_export_refund_nomenclature_descriptions_on_language_id ON public.export_refund_nomenclature_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_export_refund_nomenclature_descriptions_on_language_id ON export_refund_nomenclature_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_export_refund_nomenclatures_on_goods_nomenclature_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_export_refund_nomenclatures_on_goods_nomenclature_sid ON public.export_refund_nomenclatures_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX index_export_refund_nomenclatures_on_goods_nomenclature_sid ON export_refund_nomenclatures_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: index_footnote_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_footnote_descriptions_on_language_id ON public.footnote_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_footnote_descriptions_on_language_id ON footnote_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_footnote_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_footnote_type_descriptions_on_language_id ON public.footnote_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_footnote_type_descriptions_on_language_id ON footnote_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_geographical_area_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_geographical_area_descriptions_on_language_id ON public.geographical_area_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_geographical_area_descriptions_on_language_id ON geographical_area_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_geographical_areas_on_parent_geographical_area_group_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_geographical_areas_on_parent_geographical_area_group_sid ON public.geographical_areas_oplog USING btree (parent_geographical_area_group_sid);
+CREATE INDEX index_geographical_areas_on_parent_geographical_area_group_sid ON geographical_areas_oplog USING btree (parent_geographical_area_group_sid);
 
 
 --
 -- Name: index_goods_nomenclature_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_goods_nomenclature_descriptions_on_language_id ON public.goods_nomenclature_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_goods_nomenclature_descriptions_on_language_id ON goods_nomenclature_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_goods_nomenclature_group_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_goods_nomenclature_group_descriptions_on_language_id ON public.goods_nomenclature_group_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_goods_nomenclature_group_descriptions_on_language_id ON goods_nomenclature_group_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measure_components_on_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_components_on_measurement_unit_code ON public.measure_components_oplog USING btree (measurement_unit_code);
+CREATE INDEX index_measure_components_on_measurement_unit_code ON measure_components_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: index_measure_components_on_measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_components_on_measurement_unit_qualifier_code ON public.measure_components_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX index_measure_components_on_measurement_unit_qualifier_code ON measure_components_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: index_measure_components_on_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_components_on_monetary_unit_code ON public.measure_components_oplog USING btree (monetary_unit_code);
+CREATE INDEX index_measure_components_on_monetary_unit_code ON measure_components_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: index_measure_condition_components_on_duty_expression_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_condition_components_on_duty_expression_id ON public.measure_condition_components_oplog USING btree (duty_expression_id);
+CREATE INDEX index_measure_condition_components_on_duty_expression_id ON measure_condition_components_oplog USING btree (duty_expression_id);
 
 
 --
 -- Name: index_measure_condition_components_on_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_condition_components_on_measurement_unit_code ON public.measure_condition_components_oplog USING btree (measurement_unit_code);
+CREATE INDEX index_measure_condition_components_on_measurement_unit_code ON measure_condition_components_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: index_measure_condition_components_on_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_condition_components_on_monetary_unit_code ON public.measure_condition_components_oplog USING btree (monetary_unit_code);
+CREATE INDEX index_measure_condition_components_on_monetary_unit_code ON measure_condition_components_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: index_measure_conditions_on_action_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_action_code ON public.measure_conditions_oplog USING btree (action_code);
+CREATE INDEX index_measure_conditions_on_action_code ON measure_conditions_oplog USING btree (action_code);
 
 
 --
 -- Name: index_measure_conditions_on_condition_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_condition_measurement_unit_code ON public.measure_conditions_oplog USING btree (condition_measurement_unit_code);
+CREATE INDEX index_measure_conditions_on_condition_measurement_unit_code ON measure_conditions_oplog USING btree (condition_measurement_unit_code);
 
 
 --
 -- Name: index_measure_conditions_on_condition_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_condition_monetary_unit_code ON public.measure_conditions_oplog USING btree (condition_monetary_unit_code);
+CREATE INDEX index_measure_conditions_on_condition_monetary_unit_code ON measure_conditions_oplog USING btree (condition_monetary_unit_code);
 
 
 --
 -- Name: index_measure_conditions_on_measure_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_conditions_on_measure_sid ON public.measure_conditions_oplog USING btree (measure_sid);
+CREATE INDEX index_measure_conditions_on_measure_sid ON measure_conditions_oplog USING btree (measure_sid);
 
 
 --
 -- Name: index_measure_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_type_descriptions_on_language_id ON public.measure_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_measure_type_descriptions_on_language_id ON measure_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measure_type_series_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_type_series_descriptions_on_language_id ON public.measure_type_series_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_measure_type_series_descriptions_on_language_id ON measure_type_series_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measure_types_on_measure_type_series_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measure_types_on_measure_type_series_id ON public.measure_types_oplog USING btree (measure_type_series_id);
+CREATE INDEX index_measure_types_on_measure_type_series_id ON measure_types_oplog USING btree (measure_type_series_id);
 
 
 --
 -- Name: index_measurement_unit_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measurement_unit_descriptions_on_language_id ON public.measurement_unit_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_measurement_unit_descriptions_on_language_id ON measurement_unit_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_measures_on_additional_code_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_additional_code_sid ON public.measures_oplog USING btree (additional_code_sid);
+CREATE INDEX index_measures_on_additional_code_sid ON measures_oplog USING btree (additional_code_sid);
 
 
 --
 -- Name: index_measures_on_geographical_area_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_geographical_area_sid ON public.measures_oplog USING btree (geographical_area_sid);
+CREATE INDEX index_measures_on_geographical_area_sid ON measures_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: index_measures_on_goods_nomenclature_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_goods_nomenclature_sid ON public.measures_oplog USING btree (goods_nomenclature_sid);
+CREATE INDEX index_measures_on_goods_nomenclature_sid ON measures_oplog USING btree (goods_nomenclature_sid);
 
 
 --
 -- Name: index_measures_on_measure_type; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_measures_on_measure_type ON public.measures_oplog USING btree (measure_type_id);
+CREATE INDEX index_measures_on_measure_type ON measures_oplog USING btree (measure_type_id);
 
 
 --
 -- Name: index_monetary_unit_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_monetary_unit_descriptions_on_language_id ON public.monetary_unit_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_monetary_unit_descriptions_on_language_id ON monetary_unit_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_quota_definitions_on_measurement_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_measurement_unit_code ON public.quota_definitions_oplog USING btree (measurement_unit_code);
+CREATE INDEX index_quota_definitions_on_measurement_unit_code ON quota_definitions_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: index_quota_definitions_on_measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_measurement_unit_qualifier_code ON public.quota_definitions_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX index_quota_definitions_on_measurement_unit_qualifier_code ON quota_definitions_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: index_quota_definitions_on_monetary_unit_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_monetary_unit_code ON public.quota_definitions_oplog USING btree (monetary_unit_code);
+CREATE INDEX index_quota_definitions_on_monetary_unit_code ON quota_definitions_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: index_quota_definitions_on_quota_order_number_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_definitions_on_quota_order_number_id ON public.quota_definitions_oplog USING btree (quota_order_number_id);
+CREATE INDEX index_quota_definitions_on_quota_order_number_id ON quota_definitions_oplog USING btree (quota_order_number_id);
 
 
 --
 -- Name: index_quota_order_number_origins_on_geographical_area_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_order_number_origins_on_geographical_area_sid ON public.quota_order_number_origins_oplog USING btree (geographical_area_sid);
+CREATE INDEX index_quota_order_number_origins_on_geographical_area_sid ON quota_order_number_origins_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: index_quota_suspension_periods_on_quota_definition_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_quota_suspension_periods_on_quota_definition_sid ON public.quota_suspension_periods_oplog USING btree (quota_definition_sid);
+CREATE INDEX index_quota_suspension_periods_on_quota_definition_sid ON quota_suspension_periods_oplog USING btree (quota_definition_sid);
 
 
 --
 -- Name: index_regulation_group_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_regulation_group_descriptions_on_language_id ON public.regulation_group_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_regulation_group_descriptions_on_language_id ON regulation_group_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: index_regulation_role_type_descriptions_on_language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX index_regulation_role_type_descriptions_on_language_id ON public.regulation_role_type_descriptions_oplog USING btree (language_id);
+CREATE INDEX index_regulation_role_type_descriptions_on_language_id ON regulation_role_type_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: item_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX item_id ON public.goods_nomenclatures_oplog USING btree (goods_nomenclature_item_id, producline_suffix);
+CREATE INDEX item_id ON goods_nomenclatures_oplog USING btree (goods_nomenclature_item_id, producline_suffix);
 
 
 --
 -- Name: justification_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX justification_regulation ON public.measures_oplog USING btree (justification_regulation_role, justification_regulation_id);
+CREATE INDEX justification_regulation ON measures_oplog USING btree (justification_regulation_role, justification_regulation_id);
 
 
 --
 -- Name: lang_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX lang_desc_pk ON public.language_descriptions_oplog USING btree (language_id, language_code_id);
+CREATE INDEX lang_desc_pk ON language_descriptions_oplog USING btree (language_id, language_code_id);
 
 
 --
 -- Name: language_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX language_id ON public.additional_code_descriptions_oplog USING btree (language_id);
+CREATE INDEX language_id ON additional_code_descriptions_oplog USING btree (language_id);
 
 
 --
 -- Name: ldo_landesopl_ageonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ldo_landesopl_ageonslog_operation_date ON public.language_descriptions_oplog USING btree (operation_date);
+CREATE INDEX ldo_landesopl_ageonslog_operation_date ON language_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: lo_lanopl_geslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX lo_lanopl_geslog_operation_date ON public.languages_oplog USING btree (operation_date);
+CREATE INDEX lo_lanopl_geslog_operation_date ON languages_oplog USING btree (operation_date);
 
 
 --
 -- Name: maco_meuaddcodopl_ingnaldeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX maco_meuaddcodopl_ingnaldeslog_operation_date ON public.meursing_additional_codes_oplog USING btree (operation_date);
+CREATE INDEX maco_meuaddcodopl_ingnaldeslog_operation_date ON meursing_additional_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: mado_meaactdesopl_ureiononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mado_meaactdesopl_ureiononslog_operation_date ON public.measure_action_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mado_meaactdesopl_ureiononslog_operation_date ON measure_action_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mao_meaactopl_ureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mao_meaactopl_ureonslog_operation_date ON public.measure_actions_oplog USING btree (operation_date);
+CREATE INDEX mao_meaactopl_ureonslog_operation_date ON measure_actions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mccdo_meaconcoddesopl_ureionodeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mccdo_meaconcoddesopl_ureionodeonslog_operation_date ON public.measure_condition_code_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mccdo_meaconcoddesopl_ureionodeonslog_operation_date ON measure_condition_code_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mcco_meaconcodopl_ureiondeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mcco_meaconcodopl_ureiondeslog_operation_date ON public.measure_condition_codes_oplog USING btree (operation_date);
+CREATE INDEX mcco_meaconcodopl_ureiondeslog_operation_date ON measure_condition_codes_oplog USING btree (operation_date);
 
 
 --
 -- Name: mcco_meaconcomopl_ureionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mcco_meaconcomopl_ureionntslog_operation_date ON public.measure_condition_components_oplog USING btree (operation_date);
+CREATE INDEX mcco_meaconcomopl_ureionntslog_operation_date ON measure_condition_components_oplog USING btree (operation_date);
 
 
 --
 -- Name: mco_meacomopl_urentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mco_meacomopl_urentslog_operation_date ON public.measure_components_oplog USING btree (operation_date);
+CREATE INDEX mco_meacomopl_urentslog_operation_date ON measure_components_oplog USING btree (operation_date);
 
 
 --
 -- Name: mco_meaconopl_ureonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mco_meaconopl_ureonslog_operation_date ON public.measure_conditions_oplog USING btree (operation_date);
+CREATE INDEX mco_meaconopl_ureonslog_operation_date ON measure_conditions_oplog USING btree (operation_date);
 
 
 --
 -- Name: meas_act_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_act_desc_pk ON public.measure_action_descriptions_oplog USING btree (action_code);
+CREATE INDEX meas_act_desc_pk ON measure_action_descriptions_oplog USING btree (action_code);
 
 
 --
 -- Name: meas_act_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_act_pk ON public.measure_actions_oplog USING btree (action_code, validity_start_date);
+CREATE INDEX meas_act_pk ON measure_actions_oplog USING btree (action_code, validity_start_date);
 
 
 --
 -- Name: meas_comp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_comp_pk ON public.measure_components_oplog USING btree (measure_sid, duty_expression_id);
+CREATE INDEX meas_comp_pk ON measure_components_oplog USING btree (measure_sid, duty_expression_id);
 
 
 --
 -- Name: meas_cond_cd_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_cd_desc_pk ON public.measure_condition_code_descriptions_oplog USING btree (condition_code);
+CREATE INDEX meas_cond_cd_desc_pk ON measure_condition_code_descriptions_oplog USING btree (condition_code);
 
 
 --
 -- Name: meas_cond_cd_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_cd_pk ON public.measure_condition_codes_oplog USING btree (condition_code, validity_start_date);
+CREATE INDEX meas_cond_cd_pk ON measure_condition_codes_oplog USING btree (condition_code, validity_start_date);
 
 
 --
 -- Name: meas_cond_certificate; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_certificate ON public.measure_conditions_oplog USING btree (certificate_code, certificate_type_code);
+CREATE INDEX meas_cond_certificate ON measure_conditions_oplog USING btree (certificate_code, certificate_type_code);
 
 
 --
 -- Name: meas_cond_comp_cd; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_comp_cd ON public.measure_condition_components_oplog USING btree (measure_condition_sid, duty_expression_id);
+CREATE INDEX meas_cond_comp_cd ON measure_condition_components_oplog USING btree (measure_condition_sid, duty_expression_id);
 
 
 --
 -- Name: meas_cond_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_cond_pk ON public.measure_conditions_oplog USING btree (measure_condition_sid);
+CREATE INDEX meas_cond_pk ON measure_conditions_oplog USING btree (measure_condition_sid);
 
 
 --
 -- Name: meas_excl_geog_area_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_excl_geog_area_pk ON public.measure_excluded_geographical_areas_oplog USING btree (geographical_area_sid);
+CREATE INDEX meas_excl_geog_area_pk ON measure_excluded_geographical_areas_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: meas_excl_geog_primary_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_excl_geog_primary_key ON public.measure_excluded_geographical_areas_oplog USING btree (measure_sid, excluded_geographical_area, geographical_area_sid);
+CREATE INDEX meas_excl_geog_primary_key ON measure_excluded_geographical_areas_oplog USING btree (measure_sid, excluded_geographical_area, geographical_area_sid);
 
 
 --
 -- Name: meas_part_temp_stop_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_part_temp_stop_pk ON public.measure_partial_temporary_stops_oplog USING btree (measure_sid, partial_temporary_stop_regulation_id);
+CREATE INDEX meas_part_temp_stop_pk ON measure_partial_temporary_stops_oplog USING btree (measure_sid, partial_temporary_stop_regulation_id);
 
 
 --
 -- Name: meas_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_pk ON public.measures_oplog USING btree (measure_sid);
+CREATE INDEX meas_pk ON measures_oplog USING btree (measure_sid);
 
 
 --
 -- Name: meas_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_desc_pk ON public.measure_type_descriptions_oplog USING btree (measure_type_id);
+CREATE INDEX meas_type_desc_pk ON measure_type_descriptions_oplog USING btree (measure_type_id);
 
 
 --
 -- Name: meas_type_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_pk ON public.measure_types_oplog USING btree (measure_type_id, validity_start_date);
+CREATE INDEX meas_type_pk ON measure_types_oplog USING btree (measure_type_id, validity_start_date);
 
 
 --
 -- Name: meas_type_series_desc; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_series_desc ON public.measure_type_series_descriptions_oplog USING btree (measure_type_series_id);
+CREATE INDEX meas_type_series_desc ON measure_type_series_descriptions_oplog USING btree (measure_type_series_id);
 
 
 --
 -- Name: meas_type_series_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_type_series_pk ON public.measure_type_series_oplog USING btree (measure_type_series_id);
+CREATE INDEX meas_type_series_pk ON measure_type_series_oplog USING btree (measure_type_series_id);
 
 
 --
 -- Name: meas_unit_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_desc_pk ON public.measurement_unit_descriptions_oplog USING btree (measurement_unit_code);
+CREATE INDEX meas_unit_desc_pk ON measurement_unit_descriptions_oplog USING btree (measurement_unit_code);
 
 
 --
 -- Name: meas_unit_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_pk ON public.measurement_units_oplog USING btree (measurement_unit_code, validity_start_date);
+CREATE INDEX meas_unit_pk ON measurement_units_oplog USING btree (measurement_unit_code, validity_start_date);
 
 
 --
 -- Name: meas_unit_qual_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_qual_desc_pk ON public.measurement_unit_qualifier_descriptions_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX meas_unit_qual_desc_pk ON measurement_unit_qualifier_descriptions_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: meas_unit_qual_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meas_unit_qual_pk ON public.measurement_unit_qualifiers_oplog USING btree (measurement_unit_qualifier_code, validity_start_date);
+CREATE INDEX meas_unit_qual_pk ON measurement_unit_qualifiers_oplog USING btree (measurement_unit_qualifier_code, validity_start_date);
 
 
 --
 -- Name: measrm_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measrm_pk ON public.measurements_oplog USING btree (measurement_unit_code, measurement_unit_qualifier_code);
+CREATE INDEX measrm_pk ON measurements_oplog USING btree (measurement_unit_code, measurement_unit_qualifier_code);
 
 
 --
 -- Name: measure_generating_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measure_generating_regulation ON public.measures_oplog USING btree (measure_generating_regulation_id);
+CREATE INDEX measure_generating_regulation ON measures_oplog USING btree (measure_generating_regulation_id);
 
 
 --
 -- Name: measure_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measure_sid ON public.footnote_association_measures_oplog USING btree (measure_sid);
+CREATE INDEX measure_sid ON footnote_association_measures_oplog USING btree (measure_sid);
 
 
 --
 -- Name: measurement_unit_code_qualifier; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measurement_unit_code_qualifier ON public.measurement_unit_abbreviations USING btree (measurement_unit_code, measurement_unit_qualifier);
+CREATE INDEX measurement_unit_code_qualifier ON measurement_unit_abbreviations USING btree (measurement_unit_code, measurement_unit_qualifier);
 
 
 --
 -- Name: measurement_unit_qualifier_code; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measurement_unit_qualifier_code ON public.measure_condition_components_oplog USING btree (measurement_unit_qualifier_code);
+CREATE INDEX measurement_unit_qualifier_code ON measure_condition_components_oplog USING btree (measurement_unit_qualifier_code);
 
 
 --
 -- Name: measures_export_refund_nomenclature_sid_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measures_export_refund_nomenclature_sid_index ON public.measures_oplog USING btree (export_refund_nomenclature_sid);
+CREATE INDEX measures_export_refund_nomenclature_sid_index ON measures_oplog USING btree (export_refund_nomenclature_sid);
 
 
 --
 -- Name: measures_goods_nomenclature_item_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX measures_goods_nomenclature_item_id_index ON public.measures_oplog USING btree (goods_nomenclature_item_id);
+CREATE INDEX measures_goods_nomenclature_item_id_index ON measures_oplog USING btree (goods_nomenclature_item_id);
 
 
 --
 -- Name: megao_meaexcgeoareopl_urededcaleaslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX megao_meaexcgeoareopl_urededcaleaslog_operation_date ON public.measure_excluded_geographical_areas_oplog USING btree (operation_date);
+CREATE INDEX megao_meaexcgeoareopl_urededcaleaslog_operation_date ON measure_excluded_geographical_areas_oplog USING btree (operation_date);
 
 
 --
 -- Name: mepo_monexcperopl_aryngeodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mepo_monexcperopl_aryngeodslog_operation_date ON public.monetary_exchange_periods_oplog USING btree (operation_date);
+CREATE INDEX mepo_monexcperopl_aryngeodslog_operation_date ON monetary_exchange_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: mero_monexcratopl_aryngeteslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mero_monexcratopl_aryngeteslog_operation_date ON public.monetary_exchange_rates_oplog USING btree (operation_date);
+CREATE INDEX mero_monexcratopl_aryngeteslog_operation_date ON monetary_exchange_rates_oplog USING btree (operation_date);
 
 
 --
 -- Name: meurs_adco_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_adco_pk ON public.meursing_additional_codes_oplog USING btree (meursing_additional_code_sid);
+CREATE INDEX meurs_adco_pk ON meursing_additional_codes_oplog USING btree (meursing_additional_code_sid);
 
 
 --
 -- Name: meurs_head_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_head_pk ON public.meursing_headings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
+CREATE INDEX meurs_head_pk ON meursing_headings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
 
 
 --
 -- Name: meurs_head_txt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_head_txt_pk ON public.meursing_heading_texts_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
+CREATE INDEX meurs_head_txt_pk ON meursing_heading_texts_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code);
 
 
 --
 -- Name: meurs_subhead_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_subhead_pk ON public.meursing_subheadings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code, subheading_sequence_number);
+CREATE INDEX meurs_subhead_pk ON meursing_subheadings_oplog USING btree (meursing_table_plan_id, meursing_heading_number, row_column_code, subheading_sequence_number);
 
 
 --
 -- Name: meurs_tbl_cell_comp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_tbl_cell_comp_pk ON public.meursing_table_cell_components_oplog USING btree (meursing_table_plan_id, heading_number, row_column_code, meursing_additional_code_sid);
+CREATE INDEX meurs_tbl_cell_comp_pk ON meursing_table_cell_components_oplog USING btree (meursing_table_plan_id, heading_number, row_column_code, meursing_additional_code_sid);
 
 
 --
 -- Name: meurs_tbl_plan_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX meurs_tbl_plan_pk ON public.meursing_table_plans_oplog USING btree (meursing_table_plan_id);
+CREATE INDEX meurs_tbl_plan_pk ON meursing_table_plans_oplog USING btree (meursing_table_plan_id);
 
 
 --
 -- Name: mho_meuheaopl_ingngslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mho_meuheaopl_ingngslog_operation_date ON public.meursing_headings_oplog USING btree (operation_date);
+CREATE INDEX mho_meuheaopl_ingngslog_operation_date ON meursing_headings_oplog USING btree (operation_date);
 
 
 --
 -- Name: mhto_meuheatexopl_ingingxtslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mhto_meuheatexopl_ingingxtslog_operation_date ON public.meursing_heading_texts_oplog USING btree (operation_date);
+CREATE INDEX mhto_meuheatexopl_ingingxtslog_operation_date ON meursing_heading_texts_oplog USING btree (operation_date);
 
 
 --
 -- Name: mo_meaopl_ntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mo_meaopl_ntslog_operation_date ON public.measurements_oplog USING btree (operation_date);
+CREATE INDEX mo_meaopl_ntslog_operation_date ON measurements_oplog USING btree (operation_date);
 
 
 --
 -- Name: mo_meaopl_reslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mo_meaopl_reslog_operation_date ON public.measures_oplog USING btree (operation_date);
+CREATE INDEX mo_meaopl_reslog_operation_date ON measures_oplog USING btree (operation_date);
 
 
 --
 -- Name: mod_reg_complete_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mod_reg_complete_abrogation_regulation ON public.modification_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
+CREATE INDEX mod_reg_complete_abrogation_regulation ON modification_regulations_oplog USING btree (complete_abrogation_regulation_id, complete_abrogation_regulation_role);
 
 
 --
 -- Name: mod_reg_explicit_abrogation_regulation; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mod_reg_explicit_abrogation_regulation ON public.modification_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
+CREATE INDEX mod_reg_explicit_abrogation_regulation ON modification_regulations_oplog USING btree (explicit_abrogation_regulation_id, explicit_abrogation_regulation_role);
 
 
 --
 -- Name: mod_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mod_reg_pk ON public.modification_regulations_oplog USING btree (modification_regulation_id, modification_regulation_role);
+CREATE INDEX mod_reg_pk ON modification_regulations_oplog USING btree (modification_regulation_id, modification_regulation_role);
 
 
 --
 -- Name: mon_exch_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_exch_period_pk ON public.monetary_exchange_periods_oplog USING btree (monetary_exchange_period_sid, parent_monetary_unit_code);
+CREATE INDEX mon_exch_period_pk ON monetary_exchange_periods_oplog USING btree (monetary_exchange_period_sid, parent_monetary_unit_code);
 
 
 --
 -- Name: mon_exch_rate_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_exch_rate_pk ON public.monetary_exchange_rates_oplog USING btree (monetary_exchange_period_sid, child_monetary_unit_code);
+CREATE INDEX mon_exch_rate_pk ON monetary_exchange_rates_oplog USING btree (monetary_exchange_period_sid, child_monetary_unit_code);
 
 
 --
 -- Name: mon_unit_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_unit_desc_pk ON public.monetary_unit_descriptions_oplog USING btree (monetary_unit_code);
+CREATE INDEX mon_unit_desc_pk ON monetary_unit_descriptions_oplog USING btree (monetary_unit_code);
 
 
 --
 -- Name: mon_unit_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mon_unit_pk ON public.monetary_units_oplog USING btree (monetary_unit_code, validity_start_date);
+CREATE INDEX mon_unit_pk ON monetary_units_oplog USING btree (monetary_unit_code, validity_start_date);
 
 
 --
 -- Name: mptso_meapartemstoopl_ureialaryopslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mptso_meapartemstoopl_ureialaryopslog_operation_date ON public.measure_partial_temporary_stops_oplog USING btree (operation_date);
+CREATE INDEX mptso_meapartemstoopl_ureialaryopslog_operation_date ON measure_partial_temporary_stops_oplog USING btree (operation_date);
 
 
 --
 -- Name: mro_modregopl_iononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mro_modregopl_iononslog_operation_date ON public.modification_regulations_oplog USING btree (operation_date);
+CREATE INDEX mro_modregopl_iononslog_operation_date ON modification_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: mso_meusubopl_ingngslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mso_meusubopl_ingngslog_operation_date ON public.meursing_subheadings_oplog USING btree (operation_date);
+CREATE INDEX mso_meusubopl_ingngslog_operation_date ON meursing_subheadings_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtcco_meutabcelcomopl_ingbleellntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtcco_meutabcelcomopl_ingbleellntslog_operation_date ON public.meursing_table_cell_components_oplog USING btree (operation_date);
+CREATE INDEX mtcco_meutabcelcomopl_ingbleellntslog_operation_date ON meursing_table_cell_components_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtdo_meatypdesopl_ureypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtdo_meatypdesopl_ureypeonslog_operation_date ON public.measure_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mtdo_meatypdesopl_ureypeonslog_operation_date ON measure_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mto_meatypopl_urepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mto_meatypopl_urepeslog_operation_date ON public.measure_types_oplog USING btree (operation_date);
+CREATE INDEX mto_meatypopl_urepeslog_operation_date ON measure_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtpo_meutabplaopl_ingbleanslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtpo_meutabplaopl_ingbleanslog_operation_date ON public.meursing_table_plans_oplog USING btree (operation_date);
+CREATE INDEX mtpo_meutabplaopl_ingbleanslog_operation_date ON meursing_table_plans_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtsdo_meatypserdesopl_ureypeiesonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtsdo_meatypserdesopl_ureypeiesonslog_operation_date ON public.measure_type_series_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mtsdo_meatypserdesopl_ureypeiesonslog_operation_date ON measure_type_series_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mtso_meatypseropl_ureypeieslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mtso_meatypseropl_ureypeieslog_operation_date ON public.measure_type_series_oplog USING btree (operation_date);
+CREATE INDEX mtso_meatypseropl_ureypeieslog_operation_date ON measure_type_series_oplog USING btree (operation_date);
 
 
 --
 -- Name: mudo_meaunidesopl_entnitonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mudo_meaunidesopl_entnitonslog_operation_date ON public.measurement_unit_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mudo_meaunidesopl_entnitonslog_operation_date ON measurement_unit_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: mudo_monunidesopl_arynitonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX mudo_monunidesopl_arynitonslog_operation_date ON public.monetary_unit_descriptions_oplog USING btree (operation_date);
+CREATE INDEX mudo_monunidesopl_arynitonslog_operation_date ON monetary_unit_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: muo_meauniopl_entitslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muo_meauniopl_entitslog_operation_date ON public.measurement_units_oplog USING btree (operation_date);
+CREATE INDEX muo_meauniopl_entitslog_operation_date ON measurement_units_oplog USING btree (operation_date);
 
 
 --
 -- Name: muo_monuniopl_aryitslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muo_monuniopl_aryitslog_operation_date ON public.monetary_units_oplog USING btree (operation_date);
+CREATE INDEX muo_monuniopl_aryitslog_operation_date ON monetary_units_oplog USING btree (operation_date);
 
 
 --
 -- Name: muqdo_meauniquadesopl_entnitieronslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muqdo_meauniquadesopl_entnitieronslog_operation_date ON public.measurement_unit_qualifier_descriptions_oplog USING btree (operation_date);
+CREATE INDEX muqdo_meauniquadesopl_entnitieronslog_operation_date ON measurement_unit_qualifier_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: muqo_meauniquaopl_entniterslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX muqo_meauniquaopl_entniterslog_operation_date ON public.measurement_unit_qualifiers_oplog USING btree (operation_date);
+CREATE INDEX muqo_meauniquaopl_entniterslog_operation_date ON measurement_unit_qualifiers_oplog USING btree (operation_date);
 
 
 --
 -- Name: ngmo_nomgromemopl_ureoupipslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX ngmo_nomgromemopl_ureoupipslog_operation_date ON public.nomenclature_group_memberships_oplog USING btree (operation_date);
+CREATE INDEX ngmo_nomgromemopl_ureoupipslog_operation_date ON nomenclature_group_memberships_oplog USING btree (operation_date);
 
 
 --
 -- Name: nom_grp_member_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX nom_grp_member_pk ON public.nomenclature_group_memberships_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_group_id, goods_nomenclature_group_type, goods_nomenclature_item_id, validity_start_date);
+CREATE INDEX nom_grp_member_pk ON nomenclature_group_memberships_oplog USING btree (goods_nomenclature_sid, goods_nomenclature_group_id, goods_nomenclature_group_type, goods_nomenclature_item_id, validity_start_date);
 
 
 --
 -- Name: period_sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX period_sid ON public.additional_code_descriptions_oplog USING btree (additional_code_description_period_sid);
+CREATE INDEX period_sid ON additional_code_descriptions_oplog USING btree (additional_code_description_period_sid);
 
 
 --
 -- Name: prao_proregactopl_ioniononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX prao_proregactopl_ioniononslog_operation_date ON public.prorogation_regulation_actions_oplog USING btree (operation_date);
+CREATE INDEX prao_proregactopl_ioniononslog_operation_date ON prorogation_regulation_actions_oplog USING btree (operation_date);
 
 
 --
 -- Name: primary_key; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX primary_key ON public.geographical_areas_oplog USING btree (geographical_area_sid);
+CREATE INDEX primary_key ON geographical_areas_oplog USING btree (geographical_area_sid);
 
 
 --
 -- Name: pro_proregopl_iononslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX pro_proregopl_iononslog_operation_date ON public.prorogation_regulations_oplog USING btree (operation_date);
+CREATE INDEX pro_proregopl_iononslog_operation_date ON prorogation_regulations_oplog USING btree (operation_date);
 
 
 --
 -- Name: prorog_reg_act_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX prorog_reg_act_pk ON public.prorogation_regulation_actions_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role, prorogated_regulation_id, prorogated_regulation_role);
+CREATE INDEX prorog_reg_act_pk ON prorogation_regulation_actions_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role, prorogated_regulation_id, prorogated_regulation_role);
 
 
 --
 -- Name: prorog_reg_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX prorog_reg_pk ON public.prorogation_regulations_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role);
+CREATE INDEX prorog_reg_pk ON prorogation_regulations_oplog USING btree (prorogation_regulation_id, prorogation_regulation_role);
 
 
 --
 -- Name: qao_quoassopl_otaonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qao_quoassopl_otaonslog_operation_date ON public.quota_associations_oplog USING btree (operation_date);
+CREATE INDEX qao_quoassopl_otaonslog_operation_date ON quota_associations_oplog USING btree (operation_date);
 
 
 --
 -- Name: qbeo_quobaleveopl_otancentslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qbeo_quobaleveopl_otancentslog_operation_date ON public.quota_balance_events_oplog USING btree (operation_date);
+CREATE INDEX qbeo_quobaleveopl_otancentslog_operation_date ON quota_balance_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qbpo_quobloperopl_otaingodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qbpo_quobloperopl_otaingodslog_operation_date ON public.quota_blocking_periods_oplog USING btree (operation_date);
+CREATE INDEX qbpo_quobloperopl_otaingodslog_operation_date ON quota_blocking_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: qceo_quocrieveopl_otacalntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qceo_quocrieveopl_otacalntslog_operation_date ON public.quota_critical_events_oplog USING btree (operation_date);
+CREATE INDEX qceo_quocrieveopl_otacalntslog_operation_date ON quota_critical_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qdo_quodefopl_otaonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qdo_quodefopl_otaonslog_operation_date ON public.quota_definitions_oplog USING btree (operation_date);
+CREATE INDEX qdo_quodefopl_otaonslog_operation_date ON quota_definitions_oplog USING btree (operation_date);
 
 
 --
 -- Name: qeeo_quoexheveopl_otaionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qeeo_quoexheveopl_otaionntslog_operation_date ON public.quota_exhaustion_events_oplog USING btree (operation_date);
+CREATE INDEX qeeo_quoexheveopl_otaionntslog_operation_date ON quota_exhaustion_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qono_quoordnumopl_otadererslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qono_quoordnumopl_otadererslog_operation_date ON public.quota_order_numbers_oplog USING btree (operation_date);
+CREATE INDEX qono_quoordnumopl_otadererslog_operation_date ON quota_order_numbers_oplog USING btree (operation_date);
 
 
 --
 -- Name: qonoeo_quoordnumoriexcopl_otaderberginonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qonoeo_quoordnumoriexcopl_otaderberginonslog_operation_date ON public.quota_order_number_origin_exclusions_oplog USING btree (operation_date);
+CREATE INDEX qonoeo_quoordnumoriexcopl_otaderberginonslog_operation_date ON quota_order_number_origin_exclusions_oplog USING btree (operation_date);
 
 
 --
 -- Name: qonoo_quoordnumoriopl_otaderberinslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qonoo_quoordnumoriopl_otaderberinslog_operation_date ON public.quota_order_number_origins_oplog USING btree (operation_date);
+CREATE INDEX qonoo_quoordnumoriopl_otaderberinslog_operation_date ON quota_order_number_origins_oplog USING btree (operation_date);
 
 
 --
 -- Name: qreo_quoreoeveopl_otaingntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qreo_quoreoeveopl_otaingntslog_operation_date ON public.quota_reopening_events_oplog USING btree (operation_date);
+CREATE INDEX qreo_quoreoeveopl_otaingntslog_operation_date ON quota_reopening_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: qspo_quosusperopl_otaionodslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX qspo_quosusperopl_otaionodslog_operation_date ON public.quota_suspension_periods_oplog USING btree (operation_date);
+CREATE INDEX qspo_quosusperopl_otaionodslog_operation_date ON quota_suspension_periods_oplog USING btree (operation_date);
 
 
 --
 -- Name: queo_quounbeveopl_otaingntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX queo_quounbeveopl_otaingntslog_operation_date ON public.quota_unblocking_events_oplog USING btree (operation_date);
+CREATE INDEX queo_quounbeveopl_otaingntslog_operation_date ON quota_unblocking_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: queo_quounseveopl_otaionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX queo_quounseveopl_otaionntslog_operation_date ON public.quota_unsuspension_events_oplog USING btree (operation_date);
+CREATE INDEX queo_quounseveopl_otaionntslog_operation_date ON quota_unsuspension_events_oplog USING btree (operation_date);
 
 
 --
 -- Name: quota_assoc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_assoc_pk ON public.quota_associations_oplog USING btree (main_quota_definition_sid, sub_quota_definition_sid);
+CREATE INDEX quota_assoc_pk ON quota_associations_oplog USING btree (main_quota_definition_sid, sub_quota_definition_sid);
 
 
 --
 -- Name: quota_balance_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_balance_evt_pk ON public.quota_balance_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_balance_evt_pk ON quota_balance_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_block_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_block_period_pk ON public.quota_blocking_periods_oplog USING btree (quota_blocking_period_sid);
+CREATE INDEX quota_block_period_pk ON quota_blocking_periods_oplog USING btree (quota_blocking_period_sid);
 
 
 --
 -- Name: quota_crit_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_crit_evt_pk ON public.quota_critical_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_crit_evt_pk ON quota_critical_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_def_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_def_pk ON public.quota_definitions_oplog USING btree (quota_definition_sid);
+CREATE INDEX quota_def_pk ON quota_definitions_oplog USING btree (quota_definition_sid);
 
 
 --
 -- Name: quota_exhaus_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_exhaus_evt_pk ON public.quota_exhaustion_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_exhaus_evt_pk ON quota_exhaustion_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_ord_num_excl_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_ord_num_excl_pk ON public.quota_order_number_origin_exclusions_oplog USING btree (quota_order_number_origin_sid, excluded_geographical_area_sid);
+CREATE INDEX quota_ord_num_excl_pk ON quota_order_number_origin_exclusions_oplog USING btree (quota_order_number_origin_sid, excluded_geographical_area_sid);
 
 
 --
 -- Name: quota_ord_num_orig_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_ord_num_orig_pk ON public.quota_order_number_origins_oplog USING btree (quota_order_number_origin_sid);
+CREATE INDEX quota_ord_num_orig_pk ON quota_order_number_origins_oplog USING btree (quota_order_number_origin_sid);
 
 
 --
 -- Name: quota_ord_num_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_ord_num_pk ON public.quota_order_numbers_oplog USING btree (quota_order_number_sid);
+CREATE INDEX quota_ord_num_pk ON quota_order_numbers_oplog USING btree (quota_order_number_sid);
 
 
 --
 -- Name: quota_reopen_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_reopen_evt_pk ON public.quota_reopening_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_reopen_evt_pk ON quota_reopening_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_susp_period_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_susp_period_pk ON public.quota_suspension_periods_oplog USING btree (quota_suspension_period_sid);
+CREATE INDEX quota_susp_period_pk ON quota_suspension_periods_oplog USING btree (quota_suspension_period_sid);
 
 
 --
 -- Name: quota_unblock_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_unblock_evt_pk ON public.quota_unblocking_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_unblock_evt_pk ON quota_unblocking_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: quota_unsusp_evt_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX quota_unsusp_evt_pk ON public.quota_unsuspension_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
+CREATE INDEX quota_unsusp_evt_pk ON quota_unsuspension_events_oplog USING btree (quota_definition_sid, occurrence_timestamp);
 
 
 --
 -- Name: reg_grp_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_grp_desc_pk ON public.regulation_group_descriptions_oplog USING btree (regulation_group_id);
+CREATE INDEX reg_grp_desc_pk ON regulation_group_descriptions_oplog USING btree (regulation_group_id);
 
 
 --
 -- Name: reg_grp_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_grp_pk ON public.regulation_groups_oplog USING btree (regulation_group_id);
+CREATE INDEX reg_grp_pk ON regulation_groups_oplog USING btree (regulation_group_id);
 
 
 --
 -- Name: reg_role_type_desc_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_role_type_desc_pk ON public.regulation_role_type_descriptions_oplog USING btree (regulation_role_type_id);
+CREATE INDEX reg_role_type_desc_pk ON regulation_role_type_descriptions_oplog USING btree (regulation_role_type_id);
 
 
 --
 -- Name: reg_role_type_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX reg_role_type_pk ON public.regulation_role_types_oplog USING btree (regulation_role_type_id);
+CREATE INDEX reg_role_type_pk ON regulation_role_types_oplog USING btree (regulation_role_type_id);
 
 
 --
 -- Name: rgdo_reggrodesopl_ionouponslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rgdo_reggrodesopl_ionouponslog_operation_date ON public.regulation_group_descriptions_oplog USING btree (operation_date);
+CREATE INDEX rgdo_reggrodesopl_ionouponslog_operation_date ON regulation_group_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: rgo_reggroopl_ionupslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rgo_reggroopl_ionupslog_operation_date ON public.regulation_groups_oplog USING btree (operation_date);
+CREATE INDEX rgo_reggroopl_ionupslog_operation_date ON regulation_groups_oplog USING btree (operation_date);
 
 
 --
 -- Name: rr_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rr_pk ON public.regulation_replacements_oplog USING btree (replaced_regulation_role, replaced_regulation_id);
+CREATE INDEX rr_pk ON regulation_replacements_oplog USING btree (replaced_regulation_role, replaced_regulation_id);
 
 
 --
 -- Name: rro_regrepopl_ionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rro_regrepopl_ionntslog_operation_date ON public.regulation_replacements_oplog USING btree (operation_date);
+CREATE INDEX rro_regrepopl_ionntslog_operation_date ON regulation_replacements_oplog USING btree (operation_date);
 
 
 --
 -- Name: rrtdo_regroltypdesopl_ionoleypeonslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rrtdo_regroltypdesopl_ionoleypeonslog_operation_date ON public.regulation_role_type_descriptions_oplog USING btree (operation_date);
+CREATE INDEX rrtdo_regroltypdesopl_ionoleypeonslog_operation_date ON regulation_role_type_descriptions_oplog USING btree (operation_date);
 
 
 --
 -- Name: rrto_regroltypopl_ionolepeslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX rrto_regroltypopl_ionolepeslog_operation_date ON public.regulation_role_types_oplog USING btree (operation_date);
+CREATE INDEX rrto_regroltypopl_ionolepeslog_operation_date ON regulation_role_types_oplog USING btree (operation_date);
 
 
 --
 -- Name: search_references_referenced_id_referenced_class_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX search_references_referenced_id_referenced_class_index ON public.search_references USING btree (referenced_id, referenced_class);
+CREATE INDEX search_references_referenced_id_referenced_class_index ON search_references USING btree (referenced_id, referenced_class);
 
 
 --
 -- Name: section_notes_section_id_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX section_notes_section_id_index ON public.section_notes USING btree (section_id);
+CREATE INDEX section_notes_section_id_index ON section_notes USING btree (section_id);
 
 
 --
 -- Name: sid; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX sid ON public.additional_code_descriptions_oplog USING btree (additional_code_sid);
+CREATE INDEX sid ON additional_code_descriptions_oplog USING btree (additional_code_sid);
 
 
 --
 -- Name: tariff_update_conformance_errors_tariff_update_filename_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tariff_update_conformance_errors_tariff_update_filename_index ON public.tariff_update_conformance_errors USING btree (tariff_update_filename);
+CREATE INDEX tariff_update_conformance_errors_tariff_update_filename_index ON tariff_update_conformance_errors USING btree (tariff_update_filename);
 
 
 --
 -- Name: tbl_code_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tbl_code_index ON public.chief_tbl9 USING btree (tbl_code);
+CREATE INDEX tbl_code_index ON chief_tbl9 USING btree (tbl_code);
 
 
 --
 -- Name: tbl_type_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tbl_type_index ON public.chief_tbl9 USING btree (tbl_type);
+CREATE INDEX tbl_type_index ON chief_tbl9 USING btree (tbl_type);
 
 
 --
 -- Name: tco_tracomopl_ionntslog_operation_date; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX tco_tracomopl_ionntslog_operation_date ON public.transmission_comments_oplog USING btree (operation_date);
+CREATE INDEX tco_tracomopl_ionntslog_operation_date ON transmission_comments_oplog USING btree (operation_date);
 
 
 --
 -- Name: trans_comm_pk; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX trans_comm_pk ON public.transmission_comments_oplog USING btree (comment_sid, language_id);
+CREATE INDEX trans_comm_pk ON transmission_comments_oplog USING btree (comment_sid, language_id);
 
 
 --
 -- Name: type_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX type_id ON public.additional_code_descriptions_oplog USING btree (additional_code_type_id);
+CREATE INDEX type_id ON additional_code_descriptions_oplog USING btree (additional_code_type_id);
 
 
 --
 -- Name: uoq_code_cdu2_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX uoq_code_cdu2_index ON public.chief_comm USING btree (uoq_code_cdu2);
+CREATE INDEX uoq_code_cdu2_index ON chief_comm USING btree (uoq_code_cdu2);
 
 
 --
 -- Name: uoq_code_cdu3_index; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX uoq_code_cdu3_index ON public.chief_comm USING btree (uoq_code_cdu3);
+CREATE INDEX uoq_code_cdu3_index ON chief_comm USING btree (uoq_code_cdu3);
 
 
 --
 -- Name: user_id; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE INDEX user_id ON public.rollbacks USING btree (user_id);
+CREATE INDEX user_id ON rollbacks USING btree (user_id);
 
 
 --
@@ -11325,6 +11358,52 @@ CREATE EVENT TRIGGER reassign_owned ON ddl_command_end
 --
 
 SET search_path TO "$user", public;
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180212145253_create_initial_schema.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180228181242_create_xml_exports.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180301160928_add_xml_data_to_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180305221434_remove_filename_from_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180305224610_add_relevant_date_to_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180305224900_add_issue_date_in_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180328135527_create_node_envelopes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180328144030_create_node_transactions.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180328144132_create_node_messages.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180402091320_remove_type_from_xml_nodes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180402142849_add_record_to_node_messages.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180402154232_change_record_id_to_record_filter_ops_in_node_messages.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180406152439_remove_xml_nodes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180410100532_create_db_rollbacks.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180417135500_change_relevant_date_in_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180417141804_change_clear_date_in_db_rollbacks.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180423062256_create_regulation_documents.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180423084717_add_added_by_id_and_added_at_to_managing_tables.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180423085320_update_regulation_related_bd_views.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180425165312_add_national_flag_to_regulation_related_db_tables.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180425171028_add_national_flag_to_regulation_documents.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180425171418_add_national_flag_to_measure_related_db_tables.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180504143240_add_added_by_id_and_added_at_to_measures.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180505084755_add_added_at_and_added_by_id_to_footnotes.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180505091501_add_added_at_and_added_by_to_footnote_association_measures.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180505092846_add_added_at_and_added_by_id_to_footnote_descriptions.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180509152938_add_regulations_search_pg_view.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180516133210_add_base_64_data_to_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180516133707_add_zip_data_to_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180516164658_add_meta_data_to_xml_export_files.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180521132612_add_status_to_measures.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180521160953_add_some_tracking_fields_to_measures.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180521170635_create_measure_groups.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180521171648_add_measure_group_id_to_measures.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180522084958_add_searchable_data_to_measures_oplog.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180607071508_add_searchable_data_updated_at_to_measures.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180618144957_create_workbaskets.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180618150316_remove_measure_groups.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180619082412_add_some_fields_to_workbasket.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180619083622_create_workbaskets_events.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180619083954_rename_title_to_event_type_in_workbaskets_events.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180626120716_add_workbasket_items.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180626133140_add_data_to_workbasket_items.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180626133556_add_record_key_to_workbasket_items.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180626154859_add_initial_items_populated_to_workbaskets.rb');
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180626174214_add_batches_loaded_to_workbaskets.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('1342519058_create_schema.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20120726092749_duty_amount_expressed_in_float.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20120726162358_measure_sid_to_be_unsigned.rb');
@@ -11377,52 +11456,6 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20130220094325_add_index_f
 INSERT INTO "schema_migrations" ("filename") VALUES ('20130221132447_make_effective_end_dates_timestamps.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20130221140444_change_export_refund_nomenclature_indent_type.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20130417135357_add_users_table.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180212145253_create_initial_schema.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180228181242_create_xml_exports.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180301160928_add_xml_data_to_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180305221434_remove_filename_from_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180305224610_add_relevant_date_to_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180305224900_add_issue_date_in_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180328135527_create_node_envelopes.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180328144030_create_node_transactions.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180328144132_create_node_messages.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180402091320_remove_type_from_xml_nodes.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180402142849_add_record_to_node_messages.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180402154232_change_record_id_to_record_filter_ops_in_node_messages.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180406152439_remove_xml_nodes.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180410100532_create_db_rollbacks.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180417135500_change_relevant_date_in_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180417141804_change_clear_date_in_db_rollbacks.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180423062256_create_regulation_documents.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180423084717_add_added_by_id_and_added_at_to_managing_tables.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180423085320_update_regulation_related_bd_views.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180425165312_add_national_flag_to_regulation_related_db_tables.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180425171028_add_national_flag_to_regulation_documents.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180425171418_add_national_flag_to_measure_related_db_tables.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180504143240_add_added_by_id_and_added_at_to_measures.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180505084755_add_added_at_and_added_by_id_to_footnotes.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180505091501_add_added_at_and_added_by_to_footnote_association_measures.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180505092846_add_added_at_and_added_by_id_to_footnote_descriptions.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180509152938_add_regulations_search_pg_view.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180516133210_add_base_64_data_to_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180516133707_add_zip_data_to_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180516164658_add_meta_data_to_xml_export_files.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180521132612_add_status_to_measures.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180521160953_add_some_tracking_fields_to_measures.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180521170635_create_measure_groups.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180521171648_add_measure_group_id_to_measures.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180522084958_add_searchable_data_to_measures_oplog.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180607071508_add_searchable_data_updated_at_to_measures.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180618144957_create_workbaskets.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180618150316_remove_measure_groups.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180619082412_add_some_fields_to_workbasket.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180619083622_create_workbaskets_events.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180619083954_rename_title_to_event_type_in_workbaskets_events.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180626120716_add_workbasket_items.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180626133140_add_data_to_workbasket_items.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180626133556_add_record_key_to_workbasket_items.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180626154859_add_initial_items_populated_to_workbaskets.rb');
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180626174214_add_batches_loaded_to_workbaskets.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20130418073137_rename_permission_column.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20130801074451_increase_quota_balance_events_precision.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20130808103859_extend_user_table_with_additional_fields.rb');
@@ -11466,9 +11499,5 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180727173036_add_more_fi
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180730134551_add_more_fields_to_create_quota_settings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180802084730_add_fields_to_full_temporary_stop_regulations.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180807180500_add_initial_search_results_code_to_workbaskets.rb');
-<<<<<<< HEAD
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180820092723_add_internal_fields_to_duty_expressions.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180823124148_add_workbasket_type_of_quota_to_quota_definitions.rb');
-=======
-INSERT INTO "schema_migrations" ("filename") VALUES ('20180820092723_add_internal_fields_to_duty_expressions.rb');
->>>>>>> 5c8e09ab... [NEW CONDITIONS MECHANIC] added internal columns for related database tables

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -11466,5 +11466,9 @@ INSERT INTO "schema_migrations" ("filename") VALUES ('20180727173036_add_more_fi
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180730134551_add_more_fields_to_create_quota_settings.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180802084730_add_fields_to_full_temporary_stop_regulations.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180807180500_add_initial_search_results_code_to_workbaskets.rb');
+<<<<<<< HEAD
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180820092723_add_internal_fields_to_duty_expressions.rb');
 INSERT INTO "schema_migrations" ("filename") VALUES ('20180823124148_add_workbasket_type_of_quota_to_quota_definitions.rb');
+=======
+INSERT INTO "schema_migrations" ("filename") VALUES ('20180820092723_add_internal_fields_to_duty_expressions.rb');
+>>>>>>> 5c8e09ab... [NEW CONDITIONS MECHANIC] added internal columns for related database tables


### PR DESCRIPTION
This PR implements new conditions & duty expressions mechanics.

- There were design changes, making the selects less wide
- Some conditions were split
- "Holes" in UI for measure condition components now propagate across conditions
- Fixed save buttons
- Fixed double saving
- FIxed issue of VueJS reusing custom-select component, making selections from, for example, certificate types appear for measurement units

Thanks @rusllonrails for the extra columns on tables to make this possible.

PS: one thing noted in card, but worth repeating here, is that for conditions M1 and M2, for new records it will be possible to distinguish them, but not when editing old measures.

![screen shot 2018-08-30 at 09 17 27](https://user-images.githubusercontent.com/758001/44851257-16786300-ac36-11e8-9a40-90b7704f978a.png)
