### PR TITLE
[BULK EDIT OF MEASURES] added JS variables for data from first step form

### DIFF
--- a/app/views/measures/bulks/edit.html.slim
+++ b/app/views/measures/bulks/edit.html.slim
@@ -18,6 +18,8 @@ h2.heading-large
 script
   == "window.__workbasket_id = #{workbasket.id};"
   == "window.__pagination_metadata = #{pagination_metadata.to_json};"
+  == "window.all_settings = #{workbasket_settings.settings.to_json};"
+  == "window.current_step_settings = #{workbasket_settings.main_step_settings.to_json};"
 
 - cache [ "measure_form_js_variabless", expires_in: 8.hours ] do
   = render "workbaskets/shared/js_variables", form: ::WorkbasketForms::CreateMeasuresForm.new(Measure.new)


### PR DESCRIPTION
Now there are 2 variables available:

`window.all_settings`

Example of output:

```
{title: "TEST BRO", reason: "TEST REASONS", start_date: "30/09/2018", regulation_id: "C1402160", regulation_role: "1"}
```

and `window.current_step_settings`, which is alias for `window.all_settings`.

[TRELLO CARD](https://trello.com/c/qzcmmsQ0/484-dit-bulk-edit-of-measures-update-system-to-work-with-updated-ui-new-step-with-extra-data-for-workbasket)