### PR TITLE
Adding errors back on when pressing save progress

### DIFF
--- a/app/assets/stylesheets/components/layout.scss
+++ b/app/assets/stylesheets/components/layout.scss
@@ -25,6 +25,10 @@ html {
   background: #fff !important;
 }
 
+[v-cloak] {
+  display: none;
+}
+
 #global-header-bar,
 #global-cookie-message p,
 #footer .footer-wrapper,

--- a/app/views/workbaskets/create_measures/_form.html.slim
+++ b/app/views/workbaskets/create_measures/_form.html.slim
@@ -12,6 +12,7 @@
 
   = render "workbaskets/create_measures/steps/#{params[:step].to_s}", f: f
   = render "workbaskets/shared/success_message", f: f
+  = render "workbaskets/shared/errors_container", f: f
 
   - if step_pointer.duties_conditions_footnotes?
     = render "workbaskets/shared/custom_errors_block", f: f

--- a/app/views/workbaskets/create_quota/_form.html.slim
+++ b/app/views/workbaskets/create_quota/_form.html.slim
@@ -12,6 +12,7 @@
 
   = render "workbaskets/create_quota/steps/#{params[:step].to_s}", f: f
   = render "workbaskets/shared/success_message", f: f
+  = render "workbaskets/shared/errors_container", f: f
 
   - if step_pointer.configure_quota? || step_pointer.conditions_footnotes?
     = render "workbaskets/shared/custom_errors_block", f: f

--- a/app/views/workbaskets/shared/_errors_container.html.slim
+++ b/app/views/workbaskets/shared/_errors_container.html.slim
@@ -1,4 +1,4 @@
-.js-workbasket-errors-container.alert.alert-danger v-if="hasErrors"
+.js-workbasket-errors-container.alert.alert-danger v-cloak="" v-if="hasErrors"
   h3.workbasket-form-errors-header
     | Progress successfuly saved!
     br


### PR DESCRIPTION
Previously removed in a refactoring, but didn't realize error container was being used by "save progress" button, and a custom block for Continue.

![screen shot 2018-09-08 at 20 40 46](https://user-images.githubusercontent.com/758001/45259644-b907b300-b3a7-11e8-9bc6-5a9727a82d61.png)
