### PR TITLE
Search measure error fixes

### DIFF
--- a/app/models/measure_component.rb
+++ b/app/models/measure_component.rb
@@ -33,7 +33,7 @@ class MeasureComponent < Sequel::Model
   one_to_one :measure, key: :measure_sid,
                        primary_key: :measure_sid
 
-  delegate :description, :abbreviation, to: :duty_expression, prefix: true
+  delegate :description, :abbreviation, to: :duty_expression, prefix: true, allow_nil: true
   delegate :abbreviation, to: :monetary_unit, prefix: true, allow_nil: true
   delegate :description, to: :monetary_unit, prefix: true, allow_nil: true
 

--- a/app/searches/measures/search_filters/date_universal.rb
+++ b/app/searches/measures/search_filters/date_universal.rb
@@ -40,7 +40,14 @@ module Measures
         is
         is_not
         is_after
+        is_after_or_nil
         is_before
+        is_before_or_nil
+      )
+
+      OPERATORS_ALLOW_NIL = %w(
+        is_after_or_nil
+        is_before_or_nil
       )
 
       attr_accessor :field_name,
@@ -106,10 +113,11 @@ module Measures
 
         def compare_sql(compare_operator)
           res = "#{field_name}::date #{compare_operator} ?"
-          res += " OR #{is_not_specified_clause}" if field_name == "validity_end_date"
+          res += " OR #{is_not_specified_clause}" if field_name == "validity_end_date" && OPERATORS_ALLOW_NIL.include?(operator)
 
           res
         end
+
     end
   end
 end

--- a/app/searches/measures/search_filters/measure_sid.rb
+++ b/app/searches/measures/search_filters/measure_sid.rb
@@ -37,7 +37,7 @@ module Measures
         case operator
         when "is"
 
-          [ is_clause, measure_sid ]
+          [ is_clause, measure_sids ]
         when "starts_with", "contains"
 
           [ equal_clause, equal_value ]
@@ -48,7 +48,7 @@ module Measures
 
         def is_clause
           <<-eos
-            measure_sid::text = ?
+            measure_sid::text in ?
           eos
         end
 
@@ -56,6 +56,10 @@ module Measures
           <<-eos
             measure_sid::text ilike ?
           eos
+        end
+
+        def measure_sids
+          measure_sid.split(',').map(&:strip)
         end
 
         def equal_value

--- a/app/views/measures/measures/search_form_parts/_measure_sid_filter.html.erb
+++ b/app/views/measures/measures/search_form_parts/_measure_sid_filter.html.erb
@@ -3,7 +3,7 @@
     <div class="multiple-choice">
       <input name="search[measure_sid][enabled]" id="toggle-measure-sid" type="checkbox" value="1" v-model="measure_sid.enabled" />
       <label for="toggle-measure-sid">
-        Measure SID
+        Measure SIDs
       </label>
     </div>
   </div>

--- a/spec/unit/searches/measures/measure_sid_filter_spec.rb
+++ b/spec/unit/searches/measures/measure_sid_filter_spec.rb
@@ -33,7 +33,7 @@ describe "Measure search: measure_sid filter" do
   describe "Valid Search" do
     it "should filter by additional_code_id with operator" do
       #
-      # 'is' filter
+      # 'is' filter, single value
       #
 
       res = search_results(
@@ -44,6 +44,20 @@ describe "Measure search: measure_sid filter" do
 
       expect(res.count).to be_eql(1)
       expect(res[0].measure_sid).to be_eql(b_measure_sid)
+
+      #
+      # 'is' filter, SIDs list comma separated
+      #
+
+      res = search_results(
+        enabled: true,
+        operator: 'is',
+        value: "#{a_measure_sid}, #{c_measure_sid}"
+      )
+
+      expect(res.count).to be_eql(2)
+      expect(res[0].measure_sid).to be_eql(c_measure_sid)
+      expect(res[1].measure_sid).to be_eql(a_measure_sid)
 
       #
       # 'starts_with' filter

--- a/spec/unit/searches/measures/valid_to_filter_spec.rb
+++ b/spec/unit/searches/measures/valid_to_filter_spec.rb
@@ -35,13 +35,32 @@ describe "Measure search: valid_to filter" do
         value: 3.days.ago.strftime('%d/%m/%Y')
       )
 
+      expect(res.count).to be_eql(2)
+      expect(res[0].measure_sid).to be_eql(c_measure.measure_sid)
+      expect(res[1].measure_sid).to be_eql(b_measure.measure_sid)
+
+      res = search_results(
+        enabled: true,
+        operator: 'is_before',
+        value: 2.days.ago.strftime('%d/%m/%Y')
+      )
+
+      expect(res.count).to be_eql(1)
+      expect(res[0].measure_sid).to be_eql(a_measure.measure_sid)
+
+      res = search_results(
+        enabled: true,
+        operator: 'is_after_or_nil',
+        value: 3.days.ago.strftime('%d/%m/%Y')
+      )
+
       expect(res.count).to be_eql(3)
       measure_sids = res.map(&:measure_sid)
       expect(measure_sids).not_to include(a_measure.measure_sid)
 
       res = search_results(
         enabled: true,
-        operator: 'is_before',
+        operator: 'is_before_or_nil',
         value: 2.days.ago.strftime('%d/%m/%Y')
       )
 


### PR DESCRIPTION
fix error when duty_expression is not present for measure_component.
fixed explicit end_date in measure search.