### PR TITLE
fixed crash if validity start date is not present.

### DIFF
--- a/lib/trade_tariff_backend/validations/validity_date_span_validation.rb
+++ b/lib/trade_tariff_backend/validations/validity_date_span_validation.rb
@@ -2,11 +2,11 @@ module TradeTariffBackend
   module Validations
     class ValidityDateSpanValidation < GenericValidation
       def valid?(record = nil)
-      return false if record.validity_start_date.blank?
-
       association = validation_options[:of]
 
       raise ArgumentError.new("validates :validity_date_span excepts of: option to be provided") if association.blank?
+
+      return false if record.validity_start_date.blank?
 
       associated_records = [record.send(association)].flatten.compact.select { |record|
         # not new == persisted

--- a/lib/trade_tariff_backend/validations/validity_date_span_validation.rb
+++ b/lib/trade_tariff_backend/validations/validity_date_span_validation.rb
@@ -2,6 +2,8 @@ module TradeTariffBackend
   module Validations
     class ValidityDateSpanValidation < GenericValidation
       def valid?(record = nil)
+      return false if record.validity_start_date.blank?
+
       association = validation_options[:of]
 
       raise ArgumentError.new("validates :validity_date_span excepts of: option to be provided") if association.blank?


### PR DESCRIPTION
added a check if validity start date is not present in ValidityDateSpanValidation.