### PR TITLE
Search with footnotes fixes

### DIFF
--- a/app/assets/javascripts/components/find-measures.js
+++ b/app/assets/javascripts/components/find-measures.js
@@ -470,6 +470,9 @@ $(document).ready(function() {
       }
     },
     methods: {
+      footnotesIdDisabled: function(index) {
+        return this.footnotesValueDisabled || !this.footnotes.value[index].footnote_type_id;
+      },
       addOriginExclusion: function() {
         this.origin_exclusions.value.push({ value: '' });
       },

--- a/app/assets/javascripts/components/find-measures.js
+++ b/app/assets/javascripts/components/find-measures.js
@@ -380,6 +380,13 @@ $(document).ready(function() {
                 });
               }
             }
+
+            if (data.footnotes.value.length === 0) {
+              data.footnotes.value.push({
+                footnote_type_id: null,
+                footnote_id: null
+              });
+            }
           }
         }
       }

--- a/app/views/measures/measures/_search_form.html.erb
+++ b/app/views/measures/measures/_search_form.html.erb
@@ -235,7 +235,7 @@
 
         <input class="form-control tiny-input" v-model="footnote.footnote_id" :disabled="footnotesValueDisabled">
 
-        <input type="hidden" :name="'search[footnotes][value][' + index + '][' + footnote.footnote_type_id + ']'" :value="footnote.footnote_id" :disabled="footnotesValueDisabled" />
+        <input type="hidden" :name="'search[footnotes][value][' + index + '][' + footnote.footnote_type_id || 'null' + ']'" :value="footnote.footnote_id" :disabled="footnotesValueDisabled" />
       </div>
       <a href="#" v-on:click.prevent="addFootnote" v-if="!footnotesValueDisabled">
         Add another footnote

--- a/app/views/measures/measures/_search_form.html.erb
+++ b/app/views/measures/measures/_search_form.html.erb
@@ -233,7 +233,7 @@
           and ID
         </span>
 
-        <input class="form-control tiny-input" v-model="footnote.footnote_id" :disabled="footnotesValueDisabled">
+        <input class="form-control tiny-input" v-model="footnote.footnote_id" :disabled="footnotesIdDisabled(index)">
 
         <input type="hidden" :name="'search[footnotes][value][' + index + '][' + footnote.footnote_type_id || 'null' + ']'" :value="footnote.footnote_id" :disabled="footnotesValueDisabled" />
       </div>


### PR DESCRIPTION
fix the crash if footnote type was select and then deleted.
added an empty footnote line for existing search params.
disable footnote id field in case footnote type is not specified.