### PR TITLE
UI changes to quota flow

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,6 +6,7 @@
 //= require ./vendors/numeral.min
 //= require ./vendors/URI.min
 //= require ./vendors/dexie
+//= require parsley
 //= require vue
 //= require vue-resource
 //= require ./vendors/vue-virtual-scroller.min

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -6,7 +6,6 @@
 //= require ./vendors/numeral.min
 //= require ./vendors/URI.min
 //= require ./vendors/dexie
-//= require parsley
 //= require vue
 //= require vue-resource
 //= require ./vendors/vue-virtual-scroller.min

--- a/app/assets/javascripts/components/measure_form.js
+++ b/app/assets/javascripts/components/measure_form.js
@@ -98,7 +98,7 @@ $(document).ready(function() {
             }
           } else {
             // country
-            if (window.geographical_areas_json[window.all_settings.geographical_area_id].length === 0) {
+            if (window.all_settings.geographical_area_id instanceof Array || window.geographical_areas_json[window.all_settings.geographical_area_id].length === 0) {
               data.origins.country.selected = true;
               data.origins.country.geographical_area_id = window.all_settings.geographical_area_id;
             } else {

--- a/app/assets/javascripts/components/quota-form.js
+++ b/app/assets/javascripts/components/quota-form.js
@@ -193,6 +193,11 @@ $(document).ready(function() {
             return section;
           });
         }
+
+        if (window.all_settings.sub_quotas) {
+          data.sub_quotas.enabled = true;
+          data.sub_quotas.definitions = window.all_settings.sub_quotas;
+        }
       } else {
         data.measure = default_quota;
       }
@@ -628,7 +633,8 @@ $(document).ready(function() {
       },
       createQuotaConditionsFootnotesStepPayload: function() {
         var payload = {
-          footnotes: this.measure.footnotes
+          footnotes: this.measure.footnotes,
+          sub_quotas: this.sub_quotas.enabled ? this.sub_quotas.definitions : []
         };
 
         try {

--- a/app/assets/javascripts/components/quota-form.js
+++ b/app/assets/javascripts/components/quota-form.js
@@ -145,10 +145,6 @@ $(document).ready(function() {
               section.criticality_each_period = section.criticality_each_period === "true";
               section.duties_each_period = section.duties_each_period === "true";
               section.periods = [];
-              section.parent_quota = {
-                associate: false,
-                order_number: ""
-              };
 
               section.duty_expressions = objectToArray(section.duty_expressions).map(function(e) {
                 delete e.$order;
@@ -189,6 +185,10 @@ $(document).ready(function() {
 
                 return balance;
               });
+            }
+
+            if (section.parent_quota.associate) {
+              section.parent_quota.balances = objectToArray(section.parent_quota.balances);
             }
 
             return section;

--- a/app/assets/javascripts/components/quota-form.js
+++ b/app/assets/javascripts/components/quota-form.js
@@ -120,6 +120,7 @@ $(document).ready(function() {
 
         if (window.all_settings.quota_periods) {
           data.quota_sections = objectToArray(window.all_settings.quota_periods).map(function(section) {
+
             if (section.type == "custom") {
               section.repeat = section.repeat === "true";
               section.opening_balances = [];
@@ -636,8 +637,6 @@ $(document).ready(function() {
           footnotes: this.measure.footnotes,
           sub_quotas: this.sub_quotas.enabled ? this.sub_quotas.definitions : []
         };
-
-        console.log(payload)
 
         try {
           payload.conditions = this.measure.conditions.map(function(condition) {

--- a/app/assets/javascripts/components/quota-form.js
+++ b/app/assets/javascripts/components/quota-form.js
@@ -1,0 +1,809 @@
+//= require ./conditions-parser
+
+$(document).ready(function() {
+
+  var form = document.querySelector(".quota-form");
+
+  if (!form) {
+    return;
+  }
+
+  var app = new Vue({
+    el: form,
+    data: function() {
+      var self = this;
+
+      var data = {
+        goods_nomenclature_code: "",
+        additional_code_preview: "",
+        additional_code: null,
+        goods_nomenclature_code_description: "",
+        additional_code_preview_description: "",
+        additional_code_description: "",
+        statuses: [
+          { value: "open", label: "Open" },
+          { value: "exhausted", label: "Exhausted" },
+          { value: "critical", label: "Critical" },
+          { value: "unblocked", label: "Unblocked" },
+          { value: "unsuspended", label: "Unsuspended" },
+          { value: "reopened", label: "Reopened" }
+        ],
+        origins: {
+          country: {
+            geographical_area_id: [],
+            exclusions: [],
+            selected: false
+          },
+          group: {
+            geographical_area_id: null,
+            exclusions: [],
+            selected: false
+          },
+          erga_omnes: {
+            geographical_area_id: null,
+            exclusions: [],
+            selected: false
+          }
+        },
+        quota_sections: [],
+        sub_quotas: {
+          enabled: false,
+          definitions: []
+        },
+        errors: []
+      };
+
+      var default_quota = {
+        operation_date: null,
+        regulation_id: null,
+        measure_type_id: null,
+        quota_is_licensed: null,
+        quota_licence: null,
+        quota_ordernumber: null,
+        quota_status: "open",
+        quota_criticality_threshold: null,
+        quota_description: null,
+        geographical_area_id: null,
+        excluded_geographical_areas: [],
+        conditions: [],
+        quota_periods: [],
+        measure_components: [],
+        footnotes: [],
+        workbasket_name: null,
+        reduction_indicator: null,
+        commodity_codes: null,
+        commodity_codes_exclusions: null,
+        additional_codes: null,
+        validity_start_date: null,
+        validity_end_date: null,
+
+        existing_quota: null,
+        quota_sections: []
+      };
+
+      if (window.all_settings) {
+        data.measure = jQuery.extend({}, default_quota, this.unwrapPayload(window.all_settings));
+
+        if (window.all_settings.geographical_area_id) {
+          if (window.all_settings.geographical_area_id == '1011') {
+            data.origins.erga_omnes.selected = true;
+            data.origins.erga_omnes.geographical_area_id = window.all_settings.geographical_area_id;
+
+            if (window.all_settings.excluded_geographical_areas) {
+              window.all_settings.excluded_geographical_areas.forEach(function(e) {
+                data.origins.erga_omnes.exclusions.push({
+                  geographical_area_id: e,
+                  options: window.all_geographical_countries
+                });
+              });
+            }
+          } else {
+            // country
+            if (window.all_settings.geographical_area_id instanceof Array || window.geographical_areas_json[window.all_settings.geographical_area_id].length === 0) {
+              data.origins.country.selected = true;
+              data.origins.country.geographical_area_id = window.all_settings.geographical_area_id;
+            } else {
+              data.origins.group.selected = true;
+              data.origins.group.geographical_area_id = window.all_settings.geographical_area_id;
+
+              if (window.all_settings.excluded_geographical_areas) {
+                window.all_settings.excluded_geographical_areas.forEach(function(e) {
+                  data.origins.group.exclusions.push({
+                    geographical_area_id: e,
+                    options: window.geographical_areas_json[window.all_settings.geographical_area_id]
+                  });
+                });
+              }
+            }
+          }
+        }
+
+        if (window.all_settings.quota_periods) {
+          data.quota_sections = objectToArray(window.all_settings.quota_periods).map(function(section) {
+            if (section.type == "custom") {
+              section.repeat = section.repeat === "true";
+              section.opening_balances = [];
+              section.duty_expressions = [];
+
+              section.periods = objectToArray(section.periods).map(function(period) {
+                period.critical = period.critical === "true";
+
+                period.duty_expressions = objectToArray(period.duty_expressions).map(function(e) {
+                  delete e.$order;
+                  e.duty_expression_id = self.getDutyExpressionId(e);
+
+                  return e;
+                });
+
+                return period;
+              });
+
+            } else {
+              section.critical = section.critical === "true";
+              section.staged = section.staged === "true";
+              section.criticality_each_period = section.criticality_each_period === "true";
+              section.duties_each_period = section.duties_each_period === "true";
+              section.periods = [];
+              section.parent_quota = {
+                associate: false,
+                order_number: ""
+              };
+
+              section.duty_expressions = objectToArray(section.duty_expressions).map(function(e) {
+                delete e.$order;
+                e.duty_expression_id = self.getDutyExpressionId(e);
+
+                return e;
+              });
+
+              section.opening_balances = objectToArray(section.opening_balances).map(function(balance) {
+                if (section.type == "annual") {
+                  balance.critical = balance.critical === "true";
+
+                  balance.duty_expressions = objectToArray(balance.duty_expressions).map(function(e) {
+                    delete e.$order;
+                    e.duty_expression_id = self.getDutyExpressionId(e);
+
+                    return e;
+                  });
+                } else {
+                  var ks = {
+                    bi_annual: ["semester1", "semester2"],
+                    quarterly: ["quarter1", "quarter2", "quarter3", "quarter4"],
+                    monthly: ["month1", "month2", "month3", "month4", "month5", "month6", "month7", "month8", "month9", "month10", "month11", "month12"]
+                  };
+
+                  ks[section.type].forEach(function(k) {
+                    balance[k].critical = balance[k].critical === "true";
+
+
+                    balance[k].duty_expressions = objectToArray(balance[k].duty_expressions).map(function(e) {
+                      delete e.$order;
+                      e.duty_expression_id = self.getDutyExpressionId(e);
+
+                      return e;
+                    });
+                  });
+                }
+
+                return balance;
+              });
+            }
+
+            return section;
+          });
+        }
+      } else {
+        data.measure = default_quota;
+      }
+
+      return data;
+    },
+    mounted: function() {
+      var self = this;
+
+      var saveFunction = function(e) {
+        e.preventDefault();
+        e.stopPropagation();
+
+        submit_button = $(this);
+
+        WorkbasketBaseSaveActions.hideSuccessMessage();
+        WorkbasketBaseSaveActions.toogleSaveSpinner($(this).attr('name'));
+        var http_method = "PUT";
+
+        if (window.current_step == 'main') {
+          var payload = self.createQuotaMainStepPayload();
+        } else if (window.current_step == 'configure_quota') {
+          var payload = self.createQuotaConfigureQuotaStepPayload();
+        } else if (window.current_step == 'conditions_footnotes') {
+          var payload = self.createQuotaConditionsFootnotesStepPayload();
+        }
+
+        var data_ops = {
+          step: window.current_step,
+          mode: submit_button.attr('name'),
+          start_date: window.create_measures_start_date,
+          end_date: window.create_measures_end_date,
+          settings: payload
+        };
+
+        self.errors = [];
+
+        $.ajax({
+          url: window.save_url,
+          type: http_method,
+          data: data_ops,
+          success: function(response) {
+            WorkbasketBaseSaveActions.handleSuccessResponse(response, submit_button.attr('name'));
+          },
+          error: function(response) {
+            WorkbasketBaseValidationErrorsHandler.handleErrorsResponse(response, self);
+          }
+        });
+      };
+
+      $(document).on('click', ".js-create-measures-v1-submit-button, .js-workbasket-base-submit-button", debounce(saveFunction, 100, true));
+
+      if (this.measure.quota_periods.length === 0) {
+        this.addQuotaPeriod(true);
+      }
+
+      if (this.measure.conditions.length === 0) {
+        this.addCondition();
+      }
+
+      if (this.measure.footnotes.length === 0) {
+        this.measure.footnotes.push({
+          footnote_type_id: null,
+          description: null
+        });
+      }
+
+      if (this.measure.measure_components.length === 0) {
+        this.measure.measure_components.push({
+          duty_expression_id: null,
+          duty_amount: null,
+          measurement_unit_code: null,
+          measurement_unit_qualifier_code: null
+        });
+      }
+
+      this.fetchNomenclatureCode("/goods_nomenclatures", 10, "goods_nomenclature_code", "goods_nomenclature_code_description");
+      this.fetchAdditionalCode("/additional_codes/preview", 4, "additional_code_preview", "additional_code_preview_description");
+
+      $(".measure-form").on("geoarea:changed", function(e, id) {
+        self.measure.geographical_area_id = id;
+      });
+
+      $(".measure-form").on("exclusions:changed", function(e, ids) {
+        self.measure.excluded_geographical_areas = ids;
+      });
+    },
+    methods: {
+      parseMeasure: function(raw) {
+        var actual = {
+          measure_id: raw.measure_id,
+          regulation_id: raw.regulation_id,
+          measure_type_series_id: raw.measure_type_series_id,
+          measure_type_id: raw.measure_type_id,
+          quota_ordernumber: raw.quota_ordernumber,
+          quota_status: raw.quota_status,
+          quota_criticality_threshold: raw.quota_criticality_threshold,
+          quota_description: raw.quota_description,
+          geographical_area_id: raw.geographical_area_id,
+          excluded_geographical_areas: raw.excluded_geographical_areas,
+          conditions: [],
+          quota_periods: [],
+          measure_components: [],
+          footnotes: raw.footnotes
+        };
+
+
+        return actual;
+      },
+      addCondition: function() {
+        this.measure.conditions.push({
+          id: null,
+          action_code: null,
+          certificate_type_id: null,
+          certificate_id: null,
+          measure_condition_components: [
+            {
+              duty_expression_id: null,
+              amount: null,
+              measurement_unit_code: null,
+              measurement_unit_qualifier_code: null
+            }
+          ]
+        });
+      },
+      addQuotaPeriod: function(first) {
+        this.measure.quota_periods.push({
+          type: first === true ? null : "custom",
+          monthly: {
+            amount1: null,
+            amount2: null,
+            amount3: null,
+            amount4: null,
+            amount5: null,
+            amount6: null,
+            amount7: null,
+            amount8: null,
+            amount9: null,
+            amount10: null,
+            amount11: null,
+            amount12: null,
+          },
+          quarterly: {
+            amount1: null,
+            amount2: null,
+            amount3: null,
+            amount4: null
+          },
+          bi_annual: {
+            amount1: null,
+            amount2: null
+          },
+          annual: {
+            amount1: null
+          },
+          custom: {
+            amount1: null
+          },
+          start_date: null,
+          end_date: null,
+          measurement_unit_id: null,
+          measurement_unit_qualifier_id: null
+        });
+      },
+      addMeasureComponent: function() {
+        this.measure.measure_components.push({
+          duty_expression_id: null,
+          amount: null,
+          measurement_unit_code: null,
+          measurement_unit_qualifier_code: null
+        });
+      },
+      addFootnote: function() {
+        this.measure.footnotes.push({
+          footnote_type_id: null,
+          description: null
+        });
+      },
+      fetchNomenclatureCode: function(url, length, code, description, type, description_field) {
+        var self = this;
+        if (this[code].trim().length === length) {
+          $.ajax({
+            url: url,
+            data: {
+              q: this[code].trim()
+            },
+            success: function(data) {
+
+              if (type === "json") {
+                if (data.length > 0) {
+                  self[description] = data[0][description_field];
+                  self.measure[code] = self[code].trim();
+                } else {
+                  self[description] = "";
+                  self.measure[code] = null;
+                }
+              } else {
+                self[description] = data;
+                self.measure[code] = self[code].trim();
+              }
+
+            },
+            error: function() {
+              self[description] = "";
+              self.measure[code] = null;
+            }
+          });
+        } else {
+          self[description] = "";
+          self.measure[code] = null;
+        }
+      },
+      fetchAdditionalCode: function(url, length, code, description, type, description_field) {
+        var self = this;
+        if (this[code].trim().length === length) {
+          $.ajax({
+            url: url,
+            data: {
+              code: this[code].trim()
+            },
+            success: function(data) {
+
+              if (type === "json") {
+                if (data.length > 0) {
+                  self[description] = data[0][description_field];
+                  self.measure[code] = self[code].trim();
+                } else {
+                  self[description] = "";
+                  self.measure[code] = null;
+                }
+              } else {
+                self[description] = data;
+                self.measure[code] = self[code].trim();
+              }
+
+            },
+            error: function() {
+              self[description] = "";
+              self.measure[code] = null;
+            }
+          });
+        } else {
+          self[description] = "";
+          self.measure[code] = null;
+        }
+      },
+      unwrapPayload: function(payload) {
+        var self = this;
+
+        var measure = {
+          operation_date: payload.operation_date,
+          validity_start_date: payload.start_date,
+          validity_end_date: payload.end_date,
+          regulation_id: payload.regulation_id,
+          measure_type_id: payload.measure_type_id,
+          workbasket_name: payload.workbasket_name,
+          reduction_indicator: payload.reduction_indicator,
+          additional_codes: payload.additional_codes,
+          commodity_codes: payload.commodity_codes,
+          commodity_codes_exclusions: payload.commodity_codes_exclusions,
+          quota_ordernumber: payload.quota_ordernumber,
+          quota_is_licensed: payload.quota_is_licensed === "true",
+          quota_licence: payload.quota_licence,
+          quota_description: payload.quota_description,
+          footnotes: [],
+          measure_components: [],
+          conditions: []
+        };
+
+        if (payload.footnotes) {
+          for (var k in payload.footnotes) {
+            if (!payload.footnotes.hasOwnProperty(k)) {
+              continue;
+            }
+
+            measure.footnotes.push(clone(payload.footnotes[k]));
+          }
+        }
+
+        if (payload.measure_components) {
+          for (var k in payload.measure_components) {
+            if (!payload.measure_components.hasOwnProperty(k)) {
+              continue;
+            }
+
+              var component = clone(payload.measure_components[k]);
+
+              if (component.duty_expression_id) {
+                component.duty_expression_id = self.getDutyExpressionId(component);
+              }
+
+              measure.measure_components.push(component);
+          };
+        }
+
+        if (payload.conditions) {
+          for (var k in payload.conditions) {
+            if (!payload.conditions.hasOwnProperty(k)) {
+              continue;
+            }
+
+            var condition = clone(payload.conditions[k]);
+            condition.condition_code = ConditionsParser.getConditionCode(condition);
+
+            if (condition.measure_condition_components) {
+              var mcc = [];
+
+              for (var kk in condition.measure_condition_components) {
+                if (!condition.measure_condition_components.hasOwnProperty(kk)) {
+                  continue;
+                }
+
+                var component = clone(condition.measure_condition_components[kk]);
+
+                if (component.duty_expression_id) {
+                  component.duty_expression_id = self.getDutyExpressionId(component);
+                }
+
+                mcc.push(component);
+              }
+
+              condition.measure_condition_components = mcc;
+            }
+
+            measure.conditions.push(condition);
+          }
+        }
+
+        if (window.measure_types_json) {
+          window.measure_types_json.forEach(function(mt) {
+            if (mt.measure_type_id == payload.measure_type_id) {
+              measure.measure_type_series_id = mt.measure_type_series_id;
+            }
+          });
+        }
+
+        return measure;
+      },
+      createQuotaMainStepPayload: function() {
+        var payload = {
+          operation_date: this.measure.operation_date,
+          regulation_id: this.measure.regulation_id,
+          measure_type_id: this.measure.measure_type_id,
+          quota_ordernumber: this.measure.quota_ordernumber,
+          quota_description: this.measure.quota_description,
+          quota_is_licensed: this.measure.quota_is_licensed,
+          quota_licence: this.measure.quota_licence,
+          reduction_indicator: this.measure.reduction_indicator,
+          additional_codes: this.measure.additional_codes,
+          commodity_codes: this.measure.commodity_codes,
+          commodity_codes_exclusions: this.measure.commodity_codes_exclusions
+        };
+
+        if (this.origins.country.selected) {
+          payload.geographical_area_id = this.origins.country.geographical_area_id;
+          payload.excluded_geographical_areas = this.origins.country.exclusions.map(function(e) {
+            return e.geographical_area_id;
+          });
+        } else if (this.origins.group.selected) {
+          payload.geographical_area_id = this.origins.group.geographical_area_id;
+          payload.excluded_geographical_areas = this.origins.group.exclusions.map(function(e) {
+            return e.geographical_area_id;
+          });
+        } else if (this.origins.erga_omnes.selected) {
+          payload.geographical_area_id = this.origins.erga_omnes.geographical_area_id;
+          payload.excluded_geographical_areas = this.origins.erga_omnes.exclusions.map(function(e) {
+            return e.geographical_area_id;
+          });
+        }
+
+        return payload;
+      },
+      createQuotaConfigureQuotaStepPayload: function() {
+        var payload = {
+          quota_periods: this.quota_sections.filter(function(section) {
+            return section.type;
+          }).map(function(_section) {
+            var section = clone(_section);
+
+            section.duty_expressions.forEach(function(e) {
+              e.original_duty_expression_id = e.duty_expression_id.slice(0);
+              e.duty_expression_id = e.duty_expression_id.substring(0,2);
+            });
+
+            if (section.type == "custom") {
+              delete section.opening_balances;
+              delete section.critical;
+              delete section.criticality_threshold;
+              delete section.duties_each_period;
+              delete section.criticality_each_period;
+              delete section.staged;
+              delete section.start_date;
+              delete section.period;
+
+              section.periods.forEach(function(period) {
+                period.duty_expressions.forEach(function(e) {
+                  e.original_duty_expression_id = e.duty_expression_id.slice(0);
+                  e.duty_expression_id = e.duty_expression_id.substring(0,2);
+                });
+              });
+            } else {
+              delete section.periods;
+              delete section.repeat;
+
+              section.opening_balances.forEach(function(balance) {
+                if (section.type == "annual") {
+                  balance.duty_expressions.forEach(function(e) {
+                    e.original_duty_expression_id = e.duty_expression_id.slice(0);
+                    e.duty_expression_id = e.duty_expression_id.substring(0,2);
+                  });
+                } else {
+                  var ks = {
+                    bi_annual: ["semester1", "semester2"],
+                    quarterly: ["quarter1", "quarter2", "quarter3", "quarter4"],
+                    monthly: ["month1", "month2", "month3", "month4", "month5", "month6", "month7", "month8", "month9", "month10", "month11", "month12"]
+                  };
+
+                  ks[section.type].forEach(function(k) {
+                    balance[k].duty_expressions.forEach(function(e) {
+                      e.original_duty_expression_id = e.duty_expression_id.slice(0);
+                      e.duty_expression_id = e.duty_expression_id.substring(0,2);
+                    });
+                  });
+                }
+              });
+            }
+
+            return section;
+          })
+        };
+
+        return payload;
+      },
+      createQuotaConditionsFootnotesStepPayload: function() {
+        var payload = {
+          footnotes: this.measure.footnotes
+        };
+
+        try {
+          payload.conditions = this.measure.conditions.map(function(condition) {
+            var c = clone(condition);
+
+            c.original_measure_condition_code = c.condition_code.slice(0);
+            c.condition_code = c.condition_code.substring(0, 1);
+
+            c.measure_condition_components = c.measure_condition_components.map(function(component) {
+              var c = clone(component);
+              if (c.duty_expression_id) {
+                c.original_duty_expression_id = c.duty_expression_id.slice(0);
+                // to ignore A and B
+                c.duty_expression_id = c.duty_expression_id.substring(0, 2);
+              }
+
+              return c;
+            });
+
+            return c;
+          });
+        } catch (e) {
+          console.error(e);
+        }
+
+        return payload;
+      },
+      removeQuotaPeriod: function(quotaPeriod) {
+        var index = this.measure.quota_periods.indexOf(quotaPeriod);
+
+        if (index === -1) {
+          return;
+        }
+
+        this.measure.quota_periods.splice(index, 1);
+      },
+      removeFootnote: function(footnote) {
+        var index = this.measure.footnotes.indexOf(footnote);
+
+        if (index === -1) {
+          return;
+        }
+
+        this.measure.footnotes.splice(index, 1);
+      },
+      getDutyExpressionId: function(component) {
+        var ids = [
+          "01",
+          "02",
+          "04",
+          "15",
+          "17",
+          "19",
+          "20",
+          "35",
+          "36"
+        ];
+
+        if (component.original_duty_expression_id) {
+          return component.original_duty_expression_id;
+        }
+
+        var id = component.duty_expression ? component.duty_expression.duty_expression_id : component.duty_expression_id;
+
+        if (ids.indexOf(id) === -1) {
+          return id;
+        }
+
+        if (component.monetary_unit || component.monetary_unit_code) {
+          return id + "B";
+        }
+
+        return id + "A";
+      }
+    },
+    computed: {
+      showAddMoreQuotaPeriods: function() {
+        if (this.measure.quota_periods.length <= 0) {
+          return false;
+        }
+
+        return this.measure.quota_periods[0].type === "custom";
+      },
+      showDuties: function() {
+        var series = ["A", "B", "M", "N"];
+
+        return this.measure.measure_type_series_id && series.indexOf(this.measure.measure_type_series_id) === -1;
+      },
+      showQuota: function() {
+        if (!this.measure.measure_type_series_id || !this.measure.measure_type_id ) {
+          return false;
+        }
+
+        if (this.measure.measure_type_series_id == "N") {
+          return true;
+        }
+
+        var ids = ["122", "123", "143", "144", "146", "147", "907"];
+
+        if (this.measure.measure_type_series_id == "C" && ids.indexOf(this.measure.measure_type_id) > -1) {
+          return true;
+        }
+
+        return false;
+      },
+      showStandardImportValue: function() {
+        return this.measure.measure_type_id === "490";
+      },
+      showReferencePrice: function() {
+        return this.measure.measure_type_id === "489";
+      },
+      showUnitPrice: function() {
+        return this.measure.measure_type_id === "488";
+      },
+      atLeastOneCondition: function() {
+        return this.measure.conditions.length > 0;
+      },
+      noCondition: function() {
+        return this.measure.conditions.length === 0;
+      },
+      hasErrors: function() {
+        return this.errors.length > 0;
+      },
+      canRemoveQuota: function() {
+        return this.measure.quota_periods.length > 1;
+      },
+      canRemoveFootnote: function() {
+        return this.measure.footnotes.length > 1;
+      },
+      canRemoveCondition: function() {
+        return this.measure.conditions.length > 1;
+      },
+      canRemoveMeasureComponent: function() {
+        return this.measure.measure_components.length > 1;
+      },
+      creatingNewQuota: function() {
+        return this.measure.existing_quota === "new";
+      },
+      usingExistingQuota: function() {
+        return this.measure.existing_quota === "existing";
+      }
+    },
+    watch: {
+      showAddMoreQuotaPeriods: function() {
+        if (!this.showAddMoreQuotaPeriods) {
+          this.measure.quota_periods.splice(1, 200);
+        }
+      },
+      goods_nomenclature_code: function() {
+        this.fetchNomenclatureCode("/goods_nomenclatures", 10, "goods_nomenclature_code", "goods_nomenclature_code_description");
+      },
+      additional_code_preview: function() {
+        this.fetchAdditionalCode("/additional_codes/preview", 4, "additional_code_preview", "additional_code_preview_description");
+      },
+      "measure.validity_start_date": function() {
+        window.measure_start_date = this.measure.validity_start_date;
+
+        $(".measure-form").trigger("dates:changed", [this.measure.validity_start_date, this.measure.validity_end_date]);
+      },
+      "measure.validity_end_date": function() {
+        window.measure_end_date = this.measure.validity_end_date;
+
+        $(".measure-form").trigger("dates:changed", [this.measure.validity_start_date, this.measure.validity_end_date]);
+      },
+      "measure.additional_code_type_id": function(newVal, oldVal) {
+        if (oldVal && !newVal) {
+          this.measure.additional_code = null;
+        }
+      },
+      "measure.quota_is_licensed": function(newVal)  {
+        if (!newVal) {
+          this.measure.quota_licence = null;
+        }
+      }
+    }
+  });
+});

--- a/app/assets/javascripts/components/quota-form.js
+++ b/app/assets/javascripts/components/quota-form.js
@@ -637,6 +637,8 @@ $(document).ready(function() {
           sub_quotas: this.sub_quotas.enabled ? this.sub_quotas.definitions : []
         };
 
+        console.log(payload)
+
         try {
           payload.conditions = this.measure.conditions.map(function(condition) {
             var c = clone(condition);

--- a/app/assets/javascripts/vue_components/date-select.js
+++ b/app/assets/javascripts/vue_components/date-select.js
@@ -1,6 +1,6 @@
 Vue.component('date-select', {
   template: "#date-select-template",
-  props: ["value", "disabled"],
+  props: ["value", "disabled", "min", "max"],
   data: function() {
     return {
       vproxy: this.value
@@ -9,19 +9,40 @@ Vue.component('date-select', {
   mounted: function() {
     var self = this;
 
-    new Pikaday({
+    this.pikaday = new Pikaday({
       field: $(this.$el)[0],
       format: "DD/MM/YYYY",
       blurFieldOnSelect: true
     });
 
+    this.applyMinMax();
+
     $(this.$el).on("change", function() {
       self.vproxy = $(self.$el).val();
     });
   },
+  methods: {
+    applyMinMax: function() {
+      if (this.min) {
+        var min = moment(this.min, ["DD MMM YYYY", "DD/MM/YYYY"], true);
+        this.pikaday.setMinDate(min.isValid() ? min.toDate() : null);
+      }
+
+      if (this.max) {
+        var max = moment(this.max, ["DD MMM YYYY", "DD/MM/YYYY"], true);
+        this.pikaday.setMaxDate(max.isValid() ? max.toDate() : null);
+      }
+    }
+  },
   watch: {
     vproxy: function() {
       this.$emit("update:value", this.vproxy);
+    },
+    min: function() {
+      this.applyMinMax();
+    },
+    max: function() {
+      this.applyMinMax();
     }
   }
 });

--- a/app/assets/javascripts/vue_components/measure-origin.js
+++ b/app/assets/javascripts/vue_components/measure-origin.js
@@ -70,7 +70,7 @@ Vue.component("measure-origin", {
         }
       }
     },
-    origins: function(val) {
+    alreadySelected: function() {
       if (!this.multiple) {
         return;
       }
@@ -78,6 +78,8 @@ Vue.component("measure-origin", {
       this.origin.geographical_area_id = this.origins.map(function(o) {
         return o.id;
       });
+
+      this.origin.selected = true;
     }
   },
   methods: {
@@ -133,6 +135,10 @@ Vue.component("measure-origin", {
       }, []);
     },
     getExclusionOptions: function(geographicalAreaId){
+      if (this.multiple) {
+        return [];
+      }
+
       var currentExclusions = this.getCurrentExclusionsArray(),
           areas = window.geographical_areas_json[geographicalAreaId];
       return areas.slice().filter(function(area){

--- a/app/assets/javascripts/vue_components/measure-origin.js
+++ b/app/assets/javascripts/vue_components/measure-origin.js
@@ -3,8 +3,21 @@ Vue.component("measure-origin", {
   props: [
     "placeholder",
     "kind",
-    "origin"
+    "origin",
+    "multiple"
   ],
+  data: function() {
+    return {
+      origins: [{
+        type: "country",
+        placeholder: "― select a country or region ―",
+        id: null,
+        options: window.all_geographical_countries,
+        key: 1
+      }],
+      key: 2
+    };
+  },
   mounted: function() {
     var self = this,
         radio = $(this.$el).find("input[type='radio']"),
@@ -33,13 +46,16 @@ Vue.component("measure-origin", {
       }
     },
     showExclusions: function() {
-      return this.kind !== "country" && !!this.origin.geographical_area_id;
+      return this.kind !== "country" && this.origin.selected;
+    },
+    alreadySelected: function() {
+      return this.origins.map(function(o) {
+        return o.id;
+      });
     }
   },
   watch: {
     "origin.geographical_area_id": function(newVal) {
-      this.origin.exclusions.splice(0, 999);
-
       if (newVal) {
         this.origin.selected = true;
         $(this.$el).find("input[type='radio']").prop("checked", true).trigger("change");
@@ -51,11 +67,17 @@ Vue.component("measure-origin", {
       if (newVal) {
         if (this.kind === "erga_omnes") {
           this.origin.geographical_area_id = '1011';
-          this.addExclusion();
         }
-      } else {
-        this.origin.geographical_area_id = null;
       }
+    },
+    origins: function(val) {
+      if (!this.multiple) {
+        return;
+      }
+
+      this.origin.geographical_area_id = this.origins.map(function(o) {
+        return o.id;
+      });
     }
   },
   methods: {
@@ -116,6 +138,27 @@ Vue.component("measure-origin", {
       return areas.slice().filter(function(area){
         return !currentExclusions.includes(area.geographical_area_id);
       });
+    },
+    addCountryOrTerritory: function() {
+      this.origins.push({
+        type: "country",
+        placeholder: "― select a country or region ―",
+        id: null,
+        options: window.all_geographical_countries,
+        key: this.key++
+      });
+    },
+    addGroup: function() {
+      this.origins.push({
+        type: "group",
+        placeholder: "― select a group of countries ―",
+        id: null,
+        options: window.geographical_groups_except_erga_omnes,
+        key: this.key++
+      });
+    },
+    removeSubOrigin: function(index) {
+      this.origins.splice(index, 1);
     }
   }
 });

--- a/app/assets/javascripts/vue_components/measure-origin.js
+++ b/app/assets/javascripts/vue_components/measure-origin.js
@@ -7,7 +7,7 @@ Vue.component("measure-origin", {
     "multiple"
   ],
   data: function() {
-    return {
+    var data = {
       origins: [{
         type: "country",
         placeholder: "― select a country or region ―",
@@ -17,6 +17,35 @@ Vue.component("measure-origin", {
       }],
       key: 2
     };
+
+    if (this.origin.geographical_area_id instanceof Array && this.origin.geographical_area_id.length > 0) {
+      var arr = [];
+      var selected_ids = this.origin.geographical_area_id;
+
+      selected_ids.forEach(function(id) {
+        var isCountry = window.geographical_areas_json[id].length === 0;
+        var exclusions = selected_ids.slice(0).filter(function(e) {
+          return e != id;
+        });
+
+        var options = isCountry ? window.all_geographical_countries : window.geographical_groups_except_erga_omnes;
+        var opts = options.filter(function(o) {
+          return exclusions.indexOf(o.geographical_area_id) === -1;
+        });
+
+        arr.push({
+          type: "country",
+          placeholder: isCountry ? "― select a country or region ―" : "― select a group of countries ―",
+          id: id,
+          key: data.key++,
+          options: opts
+        });
+      });
+
+      data.origins = arr;
+    }
+
+    return data;
   },
   mounted: function() {
     var self = this,

--- a/app/assets/javascripts/vue_components/opening-balances-manager.js
+++ b/app/assets/javascripts/vue_components/opening-balances-manager.js
@@ -46,6 +46,9 @@ Vue.component("opening-balances-manager", {
     },
     showCriticality: function() {
       return !this.omitCriticality && (this.section.criticality_each_period || this.section.duties_each_period);
+    },
+    showDuties: function() {
+      return window.all_settings.quota_is_licensed != "true";
     }
   }
 });

--- a/app/assets/javascripts/vue_components/parent-quota-opening-balances.js
+++ b/app/assets/javascripts/vue_components/parent-quota-opening-balances.js
@@ -1,22 +1,24 @@
 var template = `
 <div class="parent-quota-opening-balances">
-  <div class="bootstrap-row" v-if="single">
-    <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
-      <div class="form-group">
-        <input type="text" class="form-control" v-model="balances[0].balance"/>
+  <div v-if="section.parent_quota.balances && section.parent_quota.balances.length > 0">
+    <div class="bootstrap-row" v-if="single || noPerPeriod">
+      <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
+        <div class="form-group" v-for="(balance, index) in section.parent_quota.balances">
+          <input type="text" class="form-control" v-model="balance.balance"/>
+        </div>
       </div>
     </div>
-  </div>
 
-  <div v-else>
-    <div class="bootstrap-row" v-for="(balance, index) in balances">
-      <div class="col-xs-7 col-sm-4 col-md-3 col-lg-2">
-        Year {{index + 1}}
-      </div>
+    <div v-if="!single && !noPerPeriod">
+      <div class="bootstrap-row parent-quota-balance" v-for="(balance, index) in section.parent_quota.balances">
+        <div class="col-xs-4 col-sm-3 col-md-2 col-lg-1">
+          <label>Year {{index + 1}}</label>
+        </div>
 
-      <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
-        <div class="form-group">
-          <input type="text" class="form-control" v-model="balance.balance"/>
+        <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
+          <div class="form-group">
+            <input type="text" class="form-control" v-model="balance.balance"/>
+          </div>
         </div>
       </div>
     </div>
@@ -26,70 +28,43 @@ var template = `
 
 Vue.component("parent-quota-opening-balances", {
   template: template,
-  props: ["section", "balances"],
-  mounted: function() {
-    if (this.balances.length === 0) {
+  props: ["section", "balances", "update-balances"],
+  data: function() {
+    if (!this.section.parent_quota.balances || this.section.parent_quota.balances.length === 0) {
       this.recalculateBalances();
     }
+
+    return {
+
+    };
   },
   computed: {
     single: function() {
       return this.section.type == "custom" || ["1", "1_repeating"].indexOf(this.section.period) > -1;
     },
     noPerPeriod: function() {
-
-      if (this.section.type == "annual") {
-        return this.single ||
-               (
-                !this.section.staged &&
-                !this.section.criticality_each_period &&
-                !this.section.duties_each_period
-               );
+      if (this.section.type == "custom") {
+        return true;
       }
 
-      return !this.section.staged &&
-             !this.section.criticality_each_period &&
-             !this.section.duties_each_period;
+      if (this.section.type == "annual") {
+        return this.single || !this.section.staged;
+      }
+
+      return !this.section.staged;
     },
     /**
      * Watching this computed property will enable us to recalculate the individual balances here
+     * DO NOT REMOVE
      *
      * @returns Float
      */
     total: function() {
-      var self = this;
-
-      var ks = {
-        bi_annual: ["semester1", "semester2"],
-        quarterly: ["quarter1", "quarter2", "quarter3", "quarter4"],
-        monthly: ["month1", "month2", "month3", "month4", "month5", "month6", "month7", "month8", "month9", "month10", "month11", "month12"]
-      };
-
-      if (this.section.type == "custom") {
-        return this.section.periods.map(function(p) {
-          return parseFloat(p.balance);
-        }).reduce(function(acc, current) {
-          return acc + current;
-        });
-      } else {
-        if (this.section.type == "annual" && this.noPerPeriod) {
-          return parseFloat(this.section.balance.balance);
-        } else if (this.noPerPeriod) {
-          return ks[this.section.type].map(function(k) {
-            return parseFloat(self.section.balance[k].balance);
-          }).reduce(function(acc, current) {
-            return acc + current;
-          });
-        } else {
-          return this.section.opening_balances.map(function(balance) {
-            return ks[self.section.type].map(function(k) {
-              return parseFloat(balance[k].balance);
-            }).reduce(function(acc, current) {
-              return acc + current;
-            });
-          });
-        }
-      }
+      return this.sumBalances().map(function(b) {
+        return b.balance;
+      }).reduce(function(a, b) {
+        return a + b;
+      });
     }
   },
   watch: {
@@ -101,9 +76,29 @@ Vue.component("parent-quota-opening-balances", {
   },
   methods: {
     recalculateBalances: function() {
+      var newBalances = this.sumBalances();
+
+      this.updateBalances(newBalances);
+
+      // I wasted SO much time trying to understand and trying
+      // to fix the UI not updating, so I'm forcing it
+      this.$nextTick(function() {
+        this.$forceUpdate();
+      });
+    },
+    sumBalances: function() {
       var newBalances = [];
 
       var self = this;
+
+      var parse = function(n) {
+        var f = parseFloat(n);
+        if (isNaN(f)) {
+          return 0;
+        }
+
+        return f;
+      }
 
       var ks = {
         bi_annual: ["semester1", "semester2"],
@@ -113,7 +108,7 @@ Vue.component("parent-quota-opening-balances", {
 
       if (this.section.type == "custom") {
         var balance = this.section.periods.map(function(p) {
-          return parseFloat(p.balance);
+          return parse(p.balance);
         }).reduce(function(acc, current) {
           return acc + current;
         });
@@ -123,14 +118,14 @@ Vue.component("parent-quota-opening-balances", {
         });
       } else {
         if (this.section.type == "annual" && this.noPerPeriod) {
-          var balance = parseFloat(self.section.balance.balance);
+          var balance = parse(self.section.balance);
 
           newBalances.push({
             balance: balance
           });
         } else if (this.noPerPeriod) {
           var balance = ks[this.section.type].map(function(k) {
-            return parseFloat(self.section.balance[k].balance);
+            return parse(self.section.balance[k]);
           }).reduce(function(acc, current) {
             return acc + current;
           });
@@ -140,20 +135,28 @@ Vue.component("parent-quota-opening-balances", {
           });
         } else {
           this.section.opening_balances.forEach(function(balance) {
-            var b = ks[self.section.type].map(function(k) {
-              return parseFloat(balance[k].balance);
-            }).reduce(function(acc, current) {
-              return acc + current;
-            });
+            if (self.section.type == "annual") {
+              var b = parse(balance.balance);
 
-            newBalances.push({
-              balance: b
-            });
+              newBalances.push({
+                balance: b
+              });
+            } else {
+              var b = ks[self.section.type].map(function(k) {
+                return parse(balance[k].balance);
+              }).reduce(function(acc, current) {
+                return acc + current;
+              });
+
+              newBalances.push({
+                balance: b
+              });
+            }
           });
         }
       }
 
-      this.balances = newBalances;
+      return newBalances;
     }
   }
 });

--- a/app/assets/javascripts/vue_components/parent-quota-opening-balances.js
+++ b/app/assets/javascripts/vue_components/parent-quota-opening-balances.js
@@ -1,0 +1,159 @@
+var template = `
+<div class="parent-quota-opening-balances">
+  <div class="bootstrap-row" v-if="single">
+    <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
+      <div class="form-group">
+        <input type="text" class="form-control" v-model="balances[0].balance"/>
+      </div>
+    </div>
+  </div>
+
+  <div v-else>
+    <div class="bootstrap-row" v-for="(balance, index) in balances">
+      <div class="col-xs-7 col-sm-4 col-md-3 col-lg-2">
+        Year {{index + 1}}
+      </div>
+
+      <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
+        <div class="form-group">
+          <input type="text" class="form-control" v-model="balance.balance"/>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+Vue.component("parent-quota-opening-balances", {
+  template: template,
+  props: ["section", "balances"],
+  mounted: function() {
+    if (this.balances.length === 0) {
+      this.recalculateBalances();
+    }
+  },
+  computed: {
+    single: function() {
+      return this.section.type == "custom" || ["1", "1_repeating"].indexOf(this.section.period) > -1;
+    },
+    noPerPeriod: function() {
+
+      if (this.section.type == "annual") {
+        return this.single ||
+               (
+                !this.section.staged &&
+                !this.section.criticality_each_period &&
+                !this.section.duties_each_period
+               );
+      }
+
+      return !this.section.staged &&
+             !this.section.criticality_each_period &&
+             !this.section.duties_each_period;
+    },
+    /**
+     * Watching this computed property will enable us to recalculate the individual balances here
+     *
+     * @returns Float
+     */
+    total: function() {
+      var self = this;
+
+      var ks = {
+        bi_annual: ["semester1", "semester2"],
+        quarterly: ["quarter1", "quarter2", "quarter3", "quarter4"],
+        monthly: ["month1", "month2", "month3", "month4", "month5", "month6", "month7", "month8", "month9", "month10", "month11", "month12"]
+      };
+
+      if (this.section.type == "custom") {
+        return this.section.periods.map(function(p) {
+          return parseFloat(p.balance);
+        }).reduce(function(acc, current) {
+          return acc + current;
+        });
+      } else {
+        if (this.section.type == "annual" && this.noPerPeriod) {
+          return parseFloat(this.section.balance.balance);
+        } else if (this.noPerPeriod) {
+          return ks[this.section.type].map(function(k) {
+            return parseFloat(self.section.balance[k].balance);
+          }).reduce(function(acc, current) {
+            return acc + current;
+          });
+        } else {
+          return this.section.opening_balances.map(function(balance) {
+            return ks[self.section.type].map(function(k) {
+              return parseFloat(balance[k].balance);
+            }).reduce(function(acc, current) {
+              return acc + current;
+            });
+          });
+        }
+      }
+    }
+  },
+  watch: {
+    total: function(newVal, oldVal) {
+      if (oldVal && newVal && oldVal != newVal) {
+        this.recalculateBalances();
+      }
+    }
+  },
+  methods: {
+    recalculateBalances: function() {
+      var newBalances = [];
+
+      var self = this;
+
+      var ks = {
+        bi_annual: ["semester1", "semester2"],
+        quarterly: ["quarter1", "quarter2", "quarter3", "quarter4"],
+        monthly: ["month1", "month2", "month3", "month4", "month5", "month6", "month7", "month8", "month9", "month10", "month11", "month12"]
+      };
+
+      if (this.section.type == "custom") {
+        var balance = this.section.periods.map(function(p) {
+          return parseFloat(p.balance);
+        }).reduce(function(acc, current) {
+          return acc + current;
+        });
+
+        newBalances.push({
+          balance: balance
+        });
+      } else {
+        if (this.section.type == "annual" && this.noPerPeriod) {
+          var balance = parseFloat(self.section.balance.balance);
+
+          newBalances.push({
+            balance: balance
+          });
+        } else if (this.noPerPeriod) {
+          var balance = ks[this.section.type].map(function(k) {
+            return parseFloat(self.section.balance[k].balance);
+          }).reduce(function(acc, current) {
+            return acc + current;
+          });
+
+          newBalances.push({
+            balance: balance
+          });
+        } else {
+          this.section.opening_balances.forEach(function(balance) {
+            var b = ks[self.section.type].map(function(k) {
+              return parseFloat(balance[k].balance);
+            }).reduce(function(acc, current) {
+              return acc + current;
+            });
+
+            newBalances.push({
+              balance: b
+            });
+          });
+        }
+      }
+
+      this.balances = newBalances;
+    }
+  }
+});

--- a/app/assets/javascripts/vue_components/quota-section.js
+++ b/app/assets/javascripts/vue_components/quota-section.js
@@ -21,6 +21,19 @@ Vue.component("quota-section", {
   },
   props: ["section", "index"],
   methods: {
+    updateBalances: function(balances) {
+      var self = this;
+
+      if (!this.section.parent_quota.balances) {
+        this.section.parent_quota.balances = [];
+      }
+
+      this.section.parent_quota.balances.splice(0, 999);
+
+      balances.forEach(function(b, i) {
+        Vue.set(self.section.parent_quota.balances, i, b);
+      });
+    },
     emptyDutyExpression: function() {
       return clone({
         duty_expression_id: "01A",
@@ -196,13 +209,23 @@ Vue.component("quota-section", {
       if (newVal && newVal != oldVal) {
         this.resetOpeningBalances();
         this.section.parent_quota.associate = false;
-        this.section.parent_quota.balances = [];
+
+        if (!this.section.parent_quota.balances) {
+          this.section.parent_quota.balances = [];
+        }
+
+        this.section.parent_quota.balances.splice(0, 999);
       }
     },
     "section.period": function() {
       this.resetOpeningBalances();
       this.section.parent_quota.associate = false;
-      this.section.parent_quota.balances = [];
+
+      if (!this.section.parent_quota.balances) {
+        this.section.parent_quota.balances = [];
+      }
+
+      this.section.parent_quota.balances.splice(0, 999);
     }
   }
 });

--- a/app/assets/javascripts/vue_components/quota-section.js
+++ b/app/assets/javascripts/vue_components/quota-section.js
@@ -179,6 +179,9 @@ Vue.component("quota-section", {
     },
     omitCriticality: function() {
       return window.all_settings.quota_is_licensed == "true";
+    },
+    showDuties: function() {
+      return window.all_settings.quota_is_licensed != "true";
     }
   },
   watch: {

--- a/app/assets/javascripts/vue_components/quota-section.js
+++ b/app/assets/javascripts/vue_components/quota-section.js
@@ -195,6 +195,36 @@ Vue.component("quota-section", {
     },
     showDuties: function() {
       return window.all_settings.quota_is_licensed != "true";
+    },
+    maxDate: function() {
+      if (this.section.type != "custom") {
+        return null;
+      }
+
+      try {
+        var date = moment(this.section.periods[0].start_date, ["DD MMM YYYY", "DD/MM/YYYY"], true);
+
+        if (!date.isValid()) {
+          return null;
+        }
+
+        return date.add(1, "year").format("DD/MM/YYYY");
+      } catch (e) {
+        return null;
+      }
+    },
+    canAddMorePeriods: function() {
+      if (this.section.periods.length === 0 || !this.maxDate) {
+        return true;
+      }
+
+      var last = moment(this.section.periods[this.section.periods.length - 1].end_date, "DD/MM/YYYY", true);
+
+      if (!last.isValid()) {
+        return false;
+      }
+
+      return moment(this.maxDate, "DD/MM/YYYY", true).diff(last, "days") >= 1;
     }
   },
   watch: {

--- a/app/assets/javascripts/vue_components/quota-section.js
+++ b/app/assets/javascripts/vue_components/quota-section.js
@@ -195,10 +195,14 @@ Vue.component("quota-section", {
     "section.type": function(newVal, oldVal) {
       if (newVal && newVal != oldVal) {
         this.resetOpeningBalances();
+        this.section.parent_quota.associate = false;
+        this.section.parent_quota.balances = [];
       }
     },
     "section.period": function() {
       this.resetOpeningBalances();
+      this.section.parent_quota.associate = false;
+      this.section.parent_quota.balances = [];
     }
   }
 });

--- a/app/assets/javascripts/vue_components/quota-sections-manager.js
+++ b/app/assets/javascripts/vue_components/quota-sections-manager.js
@@ -58,7 +58,8 @@ Vue.component("quota-sections-manager", {
 
         parent_quota: {
           associate: false,
-          order_number: ""
+          order_number: "",
+          balances: []
         }
       });
     },

--- a/app/assets/javascripts/vue_components/quota-sections-manager.js
+++ b/app/assets/javascripts/vue_components/quota-sections-manager.js
@@ -54,7 +54,12 @@ Vue.component("quota-sections-manager", {
             criticality_threshold: 90, // only to be used IF criticality_each_period is true
             duty_expressions: [] // only will be filled IF duties_each_period is TRUE
           }
-        ]
+        ],
+
+        parent_quota: {
+          associate: false,
+          order_number: ""
+        }
       });
     },
     removeSection: function(index) {

--- a/app/assets/javascripts/vue_components/sub-origin.js
+++ b/app/assets/javascripts/vue_components/sub-origin.js
@@ -1,0 +1,42 @@
+var template = "<div class='sub-origin'><slot :availableOptions='availableOptions'></slot></div>";
+
+Vue.component("sub-origin", {
+  template: template,
+  data: function() {
+    return {
+      availableOptions: []
+    };
+  },
+  props: ["origin", "already_selected"],
+  mounted: function() {
+    var self = this;
+
+    // Do not move this to a computed property
+    // somehow it creates an infinite loop
+    // Fixed by debouncing the function and actively
+    // checking if things ACTUALLY changed
+    this.updateAvailableOptions = debounce(function() {
+      var origin = self.origin;
+      var alreadySelectedFiltered = self.already_selected.filter(function(s) {
+        return s != origin.id;
+      });
+
+      var newOptions = origin.options.filter(function(o) {
+        return alreadySelectedFiltered.indexOf(o.geographical_area_id) === -1;
+      });
+
+      self.availableOptions = newOptions;
+    }, 500, false);
+
+    this.updateAvailableOptions();
+  },
+  watch: {
+    already_selected: function(newVal, oldVal) {
+      if (newVal.toString() == oldVal.toString()) {
+        return;
+      }
+
+      this.updateAvailableOptions();
+    }
+  }
+});

--- a/app/assets/javascripts/vue_components/sub-quota-definitions.js
+++ b/app/assets/javascripts/vue_components/sub-quota-definitions.js
@@ -1,0 +1,81 @@
+var template = `
+<div className="sub-quota-definitions">
+  <div class="bootstrap-row" v-for="(sub_quota, sqi) in definitions">
+    <div class="col-md-3 col-lg-3">
+      <div class="form-group">
+        <label class="form-label" v-if="sqi === 0">
+          Sub quota order number
+        </label>
+
+        <input type="text" class="form-control" v-model="sub_quota.order_number" maxlength="6">
+      </div>
+    </div>
+
+    <div class="col-md-6 col-lg-5">
+      <div class="form-group">
+        <label class="form-label" v-if="sqi === 0">
+          Goods commodity code(s)
+        </label>
+
+        <textarea class="form-control" rows="3" v-model="sub_quota.commodity_codes"></textarea>
+      </div>
+    </div>
+
+    <div class="col-md-2 col-lg-1">
+      <div class="form-group">
+        <label class="form-label" v-if="sqi === 0">
+          Coefficient
+        </label>
+
+        <input type="number" class="form-control" v-model="sub_quota.coefficient" min="0" max="1" step="0.1">
+      </div>
+    </div>
+
+    <div className="col-md-1">
+      <div class="form-group">
+        <label class="form-label" v-if="sqi === 0">&nbsp;</label>
+        <a class="secondary-button" href="#" v-on:click.prevent="clearDefinition(sqi)">Clear</a>
+      </div>
+    </div>
+  </div>
+
+  <p>
+    <a href="#" v-on:click.prevent="addDefinition();">
+      Add another associated sub quota
+    </a>
+  </p>
+</div>
+`;
+
+Vue.component("sub-quota-definitions", {
+  template: template,
+  props: [
+    "definitions"
+  ],
+  data: function() {
+    return {
+      key: 1,
+    };
+  },
+  mounted: function() {
+    if (this.definitions.length === 0) {
+      this.addDefinition();
+    }
+  },
+  methods: {
+    addDefinition: function() {
+      this.definitions.push({
+        key: this.key++,
+        order_number: "",
+        commodity_codes: "",
+        coefficient: ""
+      });
+    },
+    clearDefinition: function(index) {
+      var def = this.definitions[index];
+      def.order_number = "";
+      def.commodity_codes = "";
+      def.coefficient = "";
+    }
+  }
+});

--- a/app/assets/javascripts/vue_components/sub-quota-definitions.js
+++ b/app/assets/javascripts/vue_components/sub-quota-definitions.js
@@ -1,6 +1,6 @@
 var template = `
 <div className="sub-quota-definitions">
-  <div class="bootstrap-row" v-for="(sub_quota, sqi) in definitions">
+  <div class="sub-quota-definition bootstrap-row" v-for="(sub_quota, sqi) in definitions">
     <div class="col-md-3 col-lg-3">
       <div class="form-group">
         <label class="form-label" v-if="sqi === 0">

--- a/app/assets/stylesheets/components/create-measures.scss
+++ b/app/assets/stylesheets/components/create-measures.scss
@@ -1,121 +1,115 @@
-.create-measures-v2 {
-  .form-actions {
-    margin-top: 85px;
+.js-workbasket-check-code-description {
+  cursor: pointer;
+  margin-top: 25px;
+  display: inline-block;
+}
+
+.js-workbasket-check-code-container {
+  overflow: hidden;
+  border-left: 3px solid gray;
+  padding-left: 20px;
+
+  &.additional_code_check {
+    margin-bottom: 25px;
   }
+}
 
-  .js-workbasket-check-code-description {
-    cursor: pointer;
-    margin-top: 25px;
-    display: inline-block;
-  }
+span.create-measures-sub_header {
+  display: inline-block;
+  margin-bottom: 15px;
+}
 
-  .js-workbasket-check-code-container {
-    overflow: hidden;
-    border-left: 3px solid gray;
-    padding-left: 20px;
+.form-group.with_less_bottom_margin {
+  margin-bottom: 10px;
+}
 
-    &.additional_code_check {
-      margin-bottom: 25px;
+.create-measures-message-block {
+  margin-top: 40px;
+  margin-bottom: 40px;
+  overflow: hidden;
+}
+
+.create-measures-details-table {
+  margin-bottom: 60px;
+  overflow: hidden;
+
+  td {
+    font-size: 18px;
+
+    &.heading_column {
+      font-weight: bold;
     }
   }
+}
 
-  span.create-measures-sub_header {
-    display: inline-block;
-    margin-bottom: 15px;
-  }
+.create-measures-actions-bar {
+  margin-top: 40px;
+  margin-bottom: 40px;
+  overflow: hidden;
+}
 
-  .form-group.with_less_bottom_margin {
-    margin-bottom: 10px;
-  }
+.submit_group_for_cross_check_block, .save_progress_block, .exit_block {
+  margin-right: 25px;
+  float: left;
+}
 
-  .create-measures-message-block {
-    margin-top: 40px;
-    margin-bottom: 40px;
-    overflow: hidden;
-  }
+.exit_block {
+  padding-top: 10px;
+  margin-left: 5px;
+}
 
-  .create-measures-details-table {
-    margin-bottom: 60px;
-    overflow: hidden;
+.spinner_block {
+  padding-top: 1px;
+  margin-top: -3px;
 
-    td {
-      font-size: 18px;
-
-      &.heading_column {
-        font-weight: bold;
-      }
-    }
-  }
-
-  .create-measures-actions-bar {
-    margin-top: 40px;
-    margin-bottom: 40px;
-    overflow: hidden;
-  }
-
-  .submit_group_for_cross_check_block, .save_progress_block, .exit_block {
-    margin-right: 25px;
+  img {
     float: left;
   }
 
-  .exit_block {
-    padding-top: 10px;
-    margin-left: 5px;
+  span.saving_message {
+    margin-top: 10px;
+    display: inline-block;
+  }
+}
+
+.js-workbasket-base-submit-button.hidden {
+  display: none;
+}
+
+a.disabled, input[type='submit'].disabled {
+  opacity: 0.5;
+  pointer-events: none;
+  cursor: default;
+}
+
+.workbasket-error-block {
+  &.with_left_margin {
+    margin-left: 20px;
   }
 
-  .spinner_block {
-    padding-top: 1px;
-    margin-top: -3px;
-
-    img {
-      float: left;
-    }
-
-    span.saving_message {
-      margin-top: 10px;
-      display: inline-block;
-    }
+  a.js-show_hide_affected_codes {
+    margin-left: 10px;
   }
 
-  .js-workbasket-base-submit-button.hidden {
-    display: none;
+  span.js-affected_codes_list {
+    padding-left: 20px;
+    color:#0b0c0c;
   }
+}
 
-  a.disabled, input[type='submit'].disabled {
-    opacity: 0.5;
-    pointer-events: none;
-    cursor: default;
-  }
+.js-workbasket-base-success-message-container {
+  color: #3c763d;
+  background-color: #dff0d8;
+  border-color: #d6e9c6;
+}
 
-  .workbasket-error-block {
-    &.with_left_margin {
-      margin-left: 20px;
-    }
+h3.create-measures-custom-errors-header {
+  font-weight: bold;
+  font-size: 20px;
+  margin-top: 15px;
+  margin-bottom: 15px;
+}
 
-    a.js-show_hide_affected_codes {
-      margin-left: 10px;
-    }
-
-    span.js-affected_codes_list {
-      padding-left: 20px;
-      color:#0b0c0c;
-    }
-  }
-
-  .js-workbasket-base-success-message-container {
-    color: #3c763d;
-    background-color: #dff0d8;
-    border-color: #d6e9c6;
-  }
-
-  h3.create-measures-custom-errors-header {
-    font-weight: bold;
-    font-size: 20px;
-    margin-top: 15px;
-    margin-bottom: 15px;
-  }
-
-  .js-workbasket-errors-container.hidden {
-    display: none;
-  }
+.js-workbasket-errors-container.hidden {
+  display: none;
 }

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -331,3 +331,11 @@ fieldset + fieldset {
 .single-digit-field {
   width: 50px !important;
 }
+
+.form-group > .form-label {
+  font-weight: 700;
+
+  [class*="col-"] & {
+    font-weight: 400;
+  }
+}

--- a/app/assets/stylesheets/components/forms.scss
+++ b/app/assets/stylesheets/components/forms.scss
@@ -215,15 +215,13 @@ label abbr {
   }
 }
 
-.measure-form {
-  .form-actions {
-    margin-top: 3em;
-  }
+.form-actions {
+  margin-top: 3em;
+}
 
-  .js-workbasket-errors-container, .js-workbasket-base-success-message-container {
-    position: relative;
-    top: 2em;
-  }
+.js-workbasket-errors-container, .js-workbasket-base-success-message-container {
+  position: relative;
+  top: 2em;
 }
 
 .add-another-wrapper {

--- a/app/assets/stylesheets/components/measure-origin.scss
+++ b/app/assets/stylesheets/components/measure-origin.scss
@@ -15,6 +15,10 @@
     padding-bottom: 0;
   }
 
+  p {
+    margin-top: 0;
+  }
+
   .origin-select {
     position: relative;
     top: 0;
@@ -27,5 +31,15 @@
 
   & + .measure-origin {
     margin-top: 12px;
+  }
+}
+
+.sub-origin {
+  position: relative;
+
+  .secondary-button {
+    position: absolute;
+    left: 100%;
+    top: 0;
   }
 }

--- a/app/assets/stylesheets/components/opening-balance.scss
+++ b/app/assets/stylesheets/components/opening-balance.scss
@@ -52,3 +52,7 @@
     margin-top: 50px;
   }
 }
+
+.opening-balances {
+  margin-bottom: 20px !important;
+}

--- a/app/assets/stylesheets/components/parent-quota.scss
+++ b/app/assets/stylesheets/components/parent-quota.scss
@@ -1,0 +1,8 @@
+.parent-quota-balance {
+  margin-top: 15px !important;
+
+  label {
+    position: relative;
+    top: 5px;
+  }
+}

--- a/app/assets/stylesheets/components/sub-quota-definition.scss
+++ b/app/assets/stylesheets/components/sub-quota-definition.scss
@@ -1,0 +1,9 @@
+.sub-quota-definition + .sub-quota-definition{
+  margin-top: 20px;
+}
+
+.sub-quota-definition {
+  textarea {
+    resize: none;
+  }
+}

--- a/app/value_objects/workbasket_value_objects/create_quota/step_pointer.rb
+++ b/app/value_objects/workbasket_value_objects/create_quota/step_pointer.rb
@@ -48,6 +48,7 @@ module WorkbasketValueObjects
         %w(
           conditions
           footnotes
+          sub_quotas
         )
       end
 

--- a/app/views/shared/vue_templates/_measure_origin.html.slim
+++ b/app/views/shared/vue_templates/_measure_origin.html.slim
@@ -2,9 +2,22 @@ script type="text/x-template" id="measure-origin-template"
   .measure-origin
     .multiple-choice
       input type='radio' :id="radioID" class="radio-inline-group" name="geographical_area_type" :checked="origin.selected"
-      label v-if="notErgaOmnes"
+      label v-if="notErgaOmnes && !multiple"
         = content_tag "custom-select", "", { ":options" => "optionsForSelect", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", ":placeholder": "placeholder", "v-model" => "origin.geographical_area_id", class: "origin-select", "code-class-name" => "prefix--region", ":on-change" => "geographicalAreaChanged" }
-      label :for="radioID" v-else=""
+      label v-if="notErgaOmnes && multiple"
+        p v-for="(o, idx) in origins"
+          = content_tag "sub-origin", { ":origin" => "o", ":already_selected" => "alreadySelected", ":key" => "o.key"} do
+            template slot-scope="slotProps"
+              = content_tag "custom-select", "", { ":options" => "slotProps.availableOptions", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", ":placeholder": "o.placeholder", "v-model" => "o.id", class: "origin-select", "code-class-name" => "prefix--region", ":on-change" => "geographicalAreaChanged" }
+              a.secondary-button href="#" v-on:click.prevent="removeSubOrigin(idx)" v-if="origins.length > 1"
+                | Remove
+        p
+          a href="#" v-on:click.prevent="addCountryOrTerritory"
+            | Add another country
+          | &nbsp;|&nbsp;
+          a href="#" v-on:click.prevent="addGroup"
+            | Add another group
+      label :for="radioID" v-if="!notErgaOmnes"
         | Erga Omnes (all origins)
 
     .panel.panel-border-narrow v-if="showExclusions"

--- a/app/views/shared/vue_templates/_measure_origin.html.slim
+++ b/app/views/shared/vue_templates/_measure_origin.html.slim
@@ -9,9 +9,9 @@ script type="text/x-template" id="measure-origin-template"
           = content_tag "sub-origin", { ":origin" => "o", ":already_selected" => "alreadySelected", ":key" => "o.key"} do
             template slot-scope="slotProps"
               = content_tag "custom-select", "", { ":options" => "slotProps.availableOptions", "label-field" => "description", "code-field" => "geographical_area_id", "value-field" => "geographical_area_id", ":placeholder": "o.placeholder", "v-model" => "o.id", class: "origin-select", "code-class-name" => "prefix--region", ":on-change" => "geographicalAreaChanged" }
-              a.secondary-button href="#" v-on:click.prevent="removeSubOrigin(idx)" v-if="origins.length > 1"
+              a.secondary-button href="#" v-on:click.prevent="removeSubOrigin(idx)" v-if="origins.length > 1 && origin.selected"
                 | Remove
-        p
+        p v-if="origin.selected"
           a href="#" v-on:click.prevent="addCountryOrTerritory"
             | Add another country
           | &nbsp;|&nbsp;

--- a/app/views/shared/vue_templates/_opening_balances_manager.html.erb
+++ b/app/views/shared/vue_templates/_opening_balances_manager.html.erb
@@ -191,7 +191,7 @@
         </div>
       </div>
 
-      <div class="form-group">
+      <div class="form-group" v-if="showDuties">
         <label for="" class="form-label">
           What duty should be charged in-quota
         </label>
@@ -399,7 +399,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.duty_expressions" classes="measure-component" type="measure_component" :index="index" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -458,7 +458,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.semester1.duty_expressions" classes="measure-component" type="measure_component" :index="index" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -496,7 +496,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.semester2.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -593,7 +593,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.quarter2.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -631,7 +631,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.quarter3.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -669,7 +669,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.quarter4.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -729,7 +729,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month1.duty_expressions" classes="measure-component" type="measure_component" :index="index" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -767,7 +767,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month2.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -805,7 +805,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month3.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -843,7 +843,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month4.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -881,7 +881,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month5.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -919,7 +919,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month6.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -957,7 +957,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month7.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -995,7 +995,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month8.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -1033,7 +1033,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month9.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -1071,7 +1071,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month10.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -1109,7 +1109,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month11.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -1147,7 +1147,7 @@
               </div>
             </div>
 
-            <div class="col-flow" v-if="section.duties_each_period">
+            <div class="col-flow" v-if="showDuties && section.duties_each_period">
               <components-coordinator :components="balance.month12.duty_expressions" classes="measure-component" type="measure_component" :index="1" :hide-help="true"></components-coordinator>
             </div>
           </div>
@@ -1180,7 +1180,7 @@
         </div>
       </div>
 
-      <div class="form-group" v-if="!section.duties_each_period">
+      <div class="form-group" v-if="showDuties && !section.duties_each_period">
         <label for="" class="form-label">
           What duty should be charged in-quota?
         </label>

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -155,21 +155,37 @@
           <label for="toggle-type">
             Yes - associate this quota section with a parent quota
           </label>
+        </div>
 
-          <div class="panel panel-border-narrow" v-if="section.parent_quota.associate">
-            <div class="form-group">
-              <label class="form-label">Parent quota order number</label>
-              <div class="bootstrap-row">
-                <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
-                  <input type="text" maxlength="6" class="form-control" v-model="section.parent_quota.order_number">
-                </div>
+        <div class="panel panel-border-narrow" v-if="section.parent_quota.associate">
+          <div class="form-group">
+            <label class="form-label">Parent quota order number</label>
+            <div class="bootstrap-row">
+              <div class="col-xs-5 col-sm-3 col-md-2 col-lg-1">
+                <input type="text" maxlength="6" class="form-control" v-model="section.parent_quota.order_number">
               </div>
             </div>
+          </div>
+
+          <div class="form-group">
+            <label class="form-label">
+              Parent quota opening balance(s)
+
+              <span class="form-hint">
+                This defaults to the total of the opening balances entered above, for this section. You can optionally change the value here. The balance here will be measured in the same units as the quota specified here.
+              </span>
+            </label>
+
+            <parent-quota-opening-balances :balances="section.parent_quota.balances" :section="section"></parent-quota-opening-balances>
           </div>
         </div>
       </div>
 
-      <slot></slot>
+      <br>
+
+      <p>
+        <slot></slot>
+      </p>
     </div>
   </div>
 </script>

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -141,6 +141,34 @@
         </p>
       </div>
 
+      <div class="form-group">
+        <label class="form-label">
+          Do you want to associate this quota section with a parent quota?
+
+          <span class="form-hint">
+            An associated parent quota will have its own balance, which is deprecated simultaneously with the current period's balance when drawings are made.
+          </span>
+        </label>
+
+        <div class="multiple-choice">
+          <input id="" type="checkbox" v-model="section.parent_quota.associate">
+          <label for="toggle-type">
+            Yes - associate this quota section with a parent quota
+          </label>
+
+          <div class="panel panel-border-narrow" v-if="section.parent_quota.associate">
+            <div class="form-group">
+              <label class="form-label">Parent quota order number</label>
+              <div class="bootstrap-row">
+                <div class="col-xs-6 col-sm-4 col-md-3 col-lg-2">
+                  <input type="text" maxlength="6" class="form-control" v-model="section.parent_quota.order_number">
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
       <slot></slot>
     </div>
   </div>

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -13,7 +13,7 @@
     </div>
 
     <div class="panel panel-border-narrow" v-if="section.type">
-      <div v-if="section.type != 'custom'">
+      <fieldset v-if="section.type != 'custom'">
         <div class="form-group">
           <label class="form-label">
             What is the start date of this section?
@@ -83,9 +83,9 @@
         </div>
 
         <opening-balances-manager :section="section" v-if="section.measurement_unit_code"></opening-balances-manager>
-      </div>
+      </fieldset>
 
-      <div v-else>
+      <fieldset v-else>
         <div class="form-group">
           <label for="" class="form-label">
             Repeat this section every year?
@@ -139,47 +139,50 @@
         <p>
           <a href="#" v-on:click.prevent="addPeriod">Add another custom period this year</a>
         </p>
-      </div>
+      </fieldset>
+      <br>
+      <br>
+      <fieldset>
+        <div class="form-group">
+          <label class="form-label">
+            Do you want to associate this quota section with a parent quota?
 
-      <div class="form-group">
-        <label class="form-label">
-          Do you want to associate this quota section with a parent quota?
-
-          <span class="form-hint">
-            An associated parent quota will have its own balance, which is deprecated simultaneously with the current period's balance when drawings are made.
-          </span>
-        </label>
-
-        <div class="multiple-choice">
-          <input id="" type="checkbox" v-model="section.parent_quota.associate">
-          <label for="toggle-type">
-            Yes - associate this quota section with a parent quota
+            <span class="form-hint">
+              An associated parent quota will have its own balance, which is deprecated simultaneously with the current period's balance when drawings are made.
+            </span>
           </label>
-        </div>
 
-        <div class="panel panel-border-narrow" v-if="section.parent_quota.associate">
-          <div class="form-group">
-            <label class="form-label">Parent quota order number</label>
-            <div class="bootstrap-row">
-              <div class="col-xs-5 col-sm-3 col-md-2 col-lg-1">
-                <input type="text" maxlength="6" class="form-control" v-model="section.parent_quota.order_number">
+          <div class="multiple-choice">
+            <input id="" type="checkbox" v-model="section.parent_quota.associate">
+            <label for="toggle-type">
+              Yes - associate this quota section with a parent quota
+            </label>
+          </div>
+
+          <div class="panel panel-border-narrow" v-if="section.parent_quota.associate">
+            <div class="form-group">
+              <label class="form-label">Parent quota order number</label>
+              <div class="bootstrap-row">
+                <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
+                  <input type="text" maxlength="6" class="form-control" v-model="section.parent_quota.order_number">
+                </div>
               </div>
             </div>
-          </div>
 
-          <div class="form-group">
-            <label class="form-label">
-              Parent quota opening balance(s)
+            <div class="form-group">
+              <label class="form-label">
+                Parent quota opening balance(s)
 
-              <span class="form-hint">
-                This defaults to the total of the opening balances entered above, for this section. You can optionally change the value here. The balance here will be measured in the same units as the quota specified here.
-              </span>
-            </label>
+                <span class="form-hint">
+                  This defaults to the total of the opening balances entered above, for this section. You can optionally change the value here. The balance here will be measured in the same units as the quota specified here.
+                </span>
+              </label>
 
-            <parent-quota-opening-balances :balances="section.parent_quota.balances" :section="section"></parent-quota-opening-balances>
+              <parent-quota-opening-balances :section="section" :update-balances="updateBalances"></parent-quota-opening-balances>
+            </div>
           </div>
         </div>
-      </div>
+      </fieldset>
 
       <br>
 

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -56,7 +56,7 @@
           </div>
         </div>
 
-        <div class="form-group">
+        <div class="form-group" v-if="showDuties">
           <label for="" class="form-label">
             Do you want to specify different duties for each period in this section?
           </label>

--- a/app/views/shared/vue_templates/_quota_section.html.erb
+++ b/app/views/shared/vue_templates/_quota_section.html.erb
@@ -103,7 +103,7 @@
               What is the start date of this period?
             </label>
 
-            <date-select :value.sync="period.start_date"></date-select>
+            <date-select :value.sync="period.start_date" :min="idx == 0 ? null : section.periods[idx - 1].end_date" :max="maxDate"></date-select>
           </div>
 
           <div class="form-group">
@@ -111,7 +111,7 @@
               What is the end date of this period?
             </label>
 
-            <date-select :value.sync="period.end_date"></date-select>
+            <date-select :value.sync="period.end_date" :min="period.start_date" :max="maxDate"></date-select>
           </div>
 
           <div class="form-group">
@@ -136,7 +136,7 @@
           </p>
         </div>
 
-        <p>
+        <p v-if="canAddMorePeriods">
           <a href="#" v-on:click.prevent="addPeriod">Add another custom period this year</a>
         </p>
       </fieldset>

--- a/app/views/workbaskets/create_measures/steps/_main.html.slim
+++ b/app/views/workbaskets/create_measures/steps/_main.html.slim
@@ -6,5 +6,5 @@
 = render "workbaskets/shared/steps/main/goods_commodity_codes", f: f
 = render "workbaskets/shared/steps/main/additional_codes", f: f
 = render "workbaskets/shared/steps/main/reduction_indicator", f: f
-= render "workbaskets/shared/steps/main/geographical_area", f: f
+= render "workbaskets/shared/steps/main/geographical_area", f: f, multiple_countries: false
 

--- a/app/views/workbaskets/create_quota/_form.html.slim
+++ b/app/views/workbaskets/create_quota/_form.html.slim
@@ -3,7 +3,7 @@
 
 = simple_form_for form, url: create_quotum_url(id: workbasket.id),
                         html: { \
-                          class: "measure-form create-measures-v2",
+                          class: "quota-form",
                           method: :put, data: { \
                             measure: form.measure.to_json,
                             measure_condition_attributes: form.measure.measure_conditions.to_json \

--- a/app/views/workbaskets/create_quota/steps/_conditions_footnotes.html.slim
+++ b/app/views/workbaskets/create_quota/steps/_conditions_footnotes.html.slim
@@ -1,3 +1,5 @@
 = render "workbaskets/shared/steps/duties_conditions_footnotes/conditions", f: f, record_type: 'quota'
 br
 = render "workbaskets/shared/steps/duties_conditions_footnotes/footnotes", f: f
+br
+= render "workbaskets/create_quota/steps/duties_conditions_footnotes/sub_quotas", f: f

--- a/app/views/workbaskets/create_quota/steps/_main.html.slim
+++ b/app/views/workbaskets/create_quota/steps/_main.html.slim
@@ -7,5 +7,5 @@
 = render "workbaskets/shared/steps/main/goods_commodity_codes", f: f
 = render "workbaskets/shared/steps/main/additional_codes", f: f
 = render "workbaskets/shared/steps/main/reduction_indicator", f: f
-= render "workbaskets/shared/steps/main/geographical_area", f: f
+= render "workbaskets/shared/steps/main/geographical_area", f: f, multiple_countries: true
 

--- a/app/views/workbaskets/create_quota/steps/duties_conditions_footnotes/_sub_quotas.html.erb
+++ b/app/views/workbaskets/create_quota/steps/duties_conditions_footnotes/_sub_quotas.html.erb
@@ -5,16 +5,16 @@
     <span class="form-hint">
       Use this to set up weight equivalence associations so that a quota can be shared between different commodity variants at different coefficients.
     </span>
-
-    <div class="multiple-choice">
-      <input type="checkbox" id="associate-sub-quotas" v-model="sub_quotas.enabled">
-      <label for="associate-sub-quotas">
-        Yes &ndash; associate this quota with one or more sub quotas
-      </label>
-    </div>
-
-    <div class="panel panel-border-narrow" v-if="sub_quotas.enabled">
-      <sub-quota-definitions :definitions="sub_quotas.definitions"></sub-quota-definitions>
-    </div>
   </label>
+
+  <div class="multiple-choice">
+    <input type="checkbox" id="associate-sub-quotas" v-model="sub_quotas.enabled">
+    <label for="associate-sub-quotas">
+      Yes &ndash; associate this quota with one or more sub quotas
+    </label>
+  </div>
+
+  <div class="panel panel-border-narrow" v-if="sub_quotas.enabled">
+    <sub-quota-definitions :definitions="sub_quotas.definitions"></sub-quota-definitions>
+  </div>
 </div>

--- a/app/views/workbaskets/create_quota/steps/duties_conditions_footnotes/_sub_quotas.html.erb
+++ b/app/views/workbaskets/create_quota/steps/duties_conditions_footnotes/_sub_quotas.html.erb
@@ -1,0 +1,20 @@
+<div class="form-group">
+  <label class="form-label">
+    Do you want to associate this quota with any sub quotas?
+
+    <span class="form-hint">
+      Use this to set up weight equivalence associations so that a quota can be shared between different commodity variants at different coefficients.
+    </span>
+
+    <div class="multiple-choice">
+      <input type="checkbox" id="associate-sub-quotas" v-model="sub_quotas.enabled">
+      <label for="associate-sub-quotas">
+        Yes &ndash; associate this quota with one or more sub quotas
+      </label>
+    </div>
+
+    <div class="panel panel-border-narrow" v-if="sub_quotas.enabled">
+      <sub-quota-definitions :definitions="sub_quotas.definitions"></sub-quota-definitions>
+    </div>
+  </label>
+</div>

--- a/app/views/workbaskets/create_quota/steps/main/_licensed_block.html.slim
+++ b/app/views/workbaskets/create_quota/steps/main/_licensed_block.html.slim
@@ -3,13 +3,12 @@ fieldset
     | Is this a licensed quota?
 
   .form-group
-    label.form-label
-      .find-measures__checkbox-column
-        .multiple-choice
-          input name="quota_is_licensed" type="hidden" v-model="measure.quota_is_licensed" value="1"
-          input#toggle-type name="quota_is_licensed" type="checkbox" v-model="measure.quota_is_licensed" value="1"
-          label for="toggle-type"
-            | Yes - use of this quota requires presentation of a licence
+    .find-measures__checkbox-column
+      .multiple-choice
+        input name="quota_is_licensed" type="hidden" v-model="measure.quota_is_licensed" value="1"
+        input#toggle-type name="quota_is_licensed" type="checkbox" v-model="measure.quota_is_licensed" value="1"
+        label for="toggle-type"
+          | Yes - use of this quota requires presentation of a licence
 
   .form-group.js-workbasket-create-quota-licence-block v-if="measure.quota_is_licensed"
     label.form-label

--- a/app/views/workbaskets/shared/steps/main/_geographical_area.html.slim
+++ b/app/views/workbaskets/shared/steps/main/_geographical_area.html.slim
@@ -14,6 +14,6 @@ fieldset
     |.
 
   .controls.origins-region
-    = content_tag "measure-origin", "", { kind: "erga_omnes", placeholder: "― select a country or region ―", ":origin" => "origins.erga_omnes" }
-    = content_tag "measure-origin", "", { kind: "group", placeholder: "― select a group of countries ―", ":origin" => "origins.group" }
-    = content_tag "measure-origin", "", { kind: "country", placeholder: "― select a country or region ―", ":origin" => "origins.country" }
+    = content_tag "measure-origin", "", { kind: "erga_omnes", placeholder: "― select a country or region ―", ":origin" => "origins.erga_omnes", ":multiple" => false }
+    = content_tag "measure-origin", "", { kind: "group", placeholder: "― select a group of countries ―", ":origin" => "origins.group", ":multiple" => false }
+    = content_tag "measure-origin", "", { kind: "country", placeholder: "― select a country or region ―", ":origin" => "origins.country", ":multiple" => multiple_countries }


### PR DESCRIPTION
This PR achieves the following:

- Updates origins component to accept multiple countries/territories and not repeat them
- Hide all duty related fields from quota periods if Quota is licensed
- Implements for for quota associations:
  - sub quotas
  - parent quotas
- Implements correct conditionals for custom quota periods, limiting them to 1 year

Besides, this PR starts to refactor quota form out of measure form, but the changes would become too big for one PR.

![screen shot 2018-09-19 at 08 47 30](https://user-images.githubusercontent.com/758001/45752896-586d4700-bbed-11e8-9c22-52d9948cdc3a.png)
![screen shot 2018-09-19 at 08 47 56](https://user-images.githubusercontent.com/758001/45752897-586d4700-bbed-11e8-9ec0-cfaa449b4d87.png)
![screen shot 2018-09-19 at 09 07 50](https://user-images.githubusercontent.com/758001/45752898-586d4700-bbed-11e8-892f-140f98f57a6e.png)

![screen shot 2018-09-19 at 09 23 37](https://user-images.githubusercontent.com/758001/45753006-c0bc2880-bbed-11e8-91b9-69ec3a4ec8bd.png)
![screen shot 2018-09-19 at 09 23 48](https://user-images.githubusercontent.com/758001/45753007-c0bc2880-bbed-11e8-8bc7-cadd1e7acad5.png)
