### PR TITLE
Refetching options when selection is cleared

### DIFF
--- a/app/assets/javascripts/vue_components/custom-select.js
+++ b/app/assets/javascripts/vue_components/custom-select.js
@@ -46,6 +46,16 @@ Vue.component('custom-select', {
     value: function (value) {
       this.$emit("change-value");
       this.applyValueInSelect(value);
+
+      if (!value) {
+        if (this.url) {
+          this.handleDateSentitivity({}, this.start_date, this.end_date);
+        } else {
+          $(this.$el).find("select")[0].selectize.clearOptions();
+          $(this.$el).find("select")[0].selectize.addOption(this.options);
+          $(this.$el).find("select")[0].selectize.refreshOptions(false);
+        }
+      }
     },
     options: function (options) {
       $(this.$el).find("select")[0].selectize.clearOptions();


### PR DESCRIPTION
Issue was happening when user searched for an option, selects an option,
then deselects option, and when opening the select again, the user only
sees the results for the previous search.

This commits forces a refresh when a option is deselected.