### PR TITLE
Repositioning datepickers when popups open

### DIFF
--- a/app/assets/javascripts/vue_components/date-select.js
+++ b/app/assets/javascripts/vue_components/date-select.js
@@ -20,6 +20,14 @@ Vue.component('date-select', {
     $(this.$el).on("change", function() {
       self.vproxy = $(self.$el).val();
     });
+
+    this.repositionHandler = function() {
+      Vue.nextTick(function() {
+        self.pikaday.adjustPosition();
+      });
+    }
+
+    $(document).on("datepicker:reposition", this.repositionHandler);
   },
   methods: {
     applyMinMax: function() {
@@ -44,5 +52,8 @@ Vue.component('date-select', {
     max: function() {
       this.applyMinMax();
     }
+  },
+  destroyed() {
+    $(document).off("datepicker:reposition", this.repositionHandler);
   }
 });

--- a/app/assets/javascripts/vue_components/popup.js
+++ b/app/assets/javascripts/vue_components/popup.js
@@ -30,6 +30,9 @@ Vue.component("pop-up", {
     var self = this;
 
     MicroModal.init({
+      onShow: function() {
+        $(document).trigger("datepicker:reposition");
+      },
       onClose: function() {
         if (self.onClose) {
           self.onClose();
@@ -39,6 +42,9 @@ Vue.component("pop-up", {
 
     if (this.open) {
       MicroModal.show("modal-" + this.id, {
+        onShow: function() {
+          $(document).trigger("datepicker:reposition");
+        },
         onClose: function() {
           if (self.onClose) {
             self.onClose();


### PR DESCRIPTION
There was an issue when popups open, Vue would render the datepickers
before the popups rendered fully, causing a misalignment.

This PR triggers an event after the popups fully render, so that
datepickers have a chance of repositioning themselves.

![2018-09-19 16 28 19](https://user-images.githubusercontent.com/758001/45776398-224db880-bc29-11e8-9a8c-0c29aee5aedd.gif)
