### PR TITLE
Remove Rack::Timeout related settings as we have removed this gem.

### DIFF
--- a/config/initializers/rack_timeout.rb
+++ b/config/initializers/rack_timeout.rb
@@ -1,1 +1,0 @@
-Rack::Timeout.unregister_state_change_observer(:logger) if Rails.env.development?


### PR DESCRIPTION
This setting was throwing an error while loading Rails console