### PR TITLE
Fixing spooky dropdown opening

### DIFF
--- a/app/assets/javascripts/vue_components/button-dropdown.js
+++ b/app/assets/javascripts/vue_components/button-dropdown.js
@@ -1,6 +1,6 @@
 var template = [
   "<div class='button-dropdown' :class='{ open: open}'>",
-    "<button v-on:click.prevent='toggle' :disabled='disabled'>",
+    "<button role='button' v-on:click.prevent='toggle' :disabled='disabled'>",
       "<slot name='text'>Default text</slot>",
     "</button>",
     "<slot></slot>",
@@ -28,7 +28,8 @@ Vue.component("button-dropdown", {
     var self = this;
 
     this.handleOutsideClick = function(e) {
-      if (e.target.matches("a") || $(e.target).closest($(el)).length < 1) {
+      var t = $(e.target).closest($(el));
+      if ((e.target.matches("a") && t.length > 0) || t.length < 1) {
         this.close();
       }
     }.bind(this);

--- a/app/views/measures/bulks/edit.html.slim
+++ b/app/views/measures/bulks/edit.html.slim
@@ -26,7 +26,7 @@ script
 - cache [ "measure_form_js_variabless", expires_in: 8.hours ] do
   = render "workbaskets/shared/js_variables", form: ::WorkbasketForms::CreateMeasuresForm.new(Measure.new)
 
-form.bulk-edit-measures
+.bulk-edit-measures
   warning-message v-if="overloaded"
     | The server is overloaded at the moment or there is an error preventing the request to load the current batch of measures. Retrying in 30 seconds&hellip;
   = render "table_top"


### PR DESCRIPTION
Behaviour was actually as per standard.
Pressing Enter on the keyboard while on an input should trigger form submission.

Bulk edit screen was unnecessarily a form element, thus causing this issue.